### PR TITLE
Add shared Panel toolkit in tools_/panel_.py and consolidate all Pane…

### DIFF
--- a/src/phenotypic/_core/_image_parts/panel_accessor/__init__.py
+++ b/src/phenotypic/_core/_image_parts/panel_accessor/__init__.py
@@ -8,7 +8,7 @@ to retrieve a dashboard class by name.
 # Import dashboards to trigger @register_dashboard decorators
 from ._base_dashboard import BaseDashboard
 from ._detect_mode_dashboard import DetectModeDashboard
-from ._diagnostics_dashboard import PANEL_AVAILABLE
+from phenotypic.tools_.panel_ import PANEL_AVAILABLE
 
 if PANEL_AVAILABLE:
     from ._diagnostics_dashboard import DiagnosticsDashboard

--- a/src/phenotypic/_core/_image_parts/panel_accessor/_base_dashboard.py
+++ b/src/phenotypic/_core/_image_parts/panel_accessor/_base_dashboard.py
@@ -14,12 +14,6 @@ from phenotypic._core._image_parts.accessor_abstracts._image_accessor_base impor
 if TYPE_CHECKING:
     from phenotypic._core._image import Image
 
-_PANEL_IMPORT_ERROR = (
-    "Panel is required for interactive dashboards. "
-    "Install it with: pip install panel"
-)
-
-
 class BaseDashboard(ImageAccessorBase):
     """Base class for all Panel dashboard accessors.
 

--- a/src/phenotypic/_core/_image_parts/panel_accessor/_detect_mode_dashboard.py
+++ b/src/phenotypic/_core/_image_parts/panel_accessor/_detect_mode_dashboard.py
@@ -57,6 +57,10 @@ class DetectModeDashboard(BaseDashboard):
             >>> dashboard = image.panel.detect_modes()
             >>> # dashboard.show()  # opens in browser
         """
+        from phenotypic.tools_.panel_ import require_panel
+
+        require_panel()
+
         import panel as pn
 
         # ---- Gather data ------------------------------------------------

--- a/src/phenotypic/_core/_image_parts/panel_accessor/_diagnostics_dashboard.py
+++ b/src/phenotypic/_core/_image_parts/panel_accessor/_diagnostics_dashboard.py
@@ -6,13 +6,12 @@ from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
 
-try:
+from phenotypic.tools_.panel_ import PANEL_AVAILABLE
+
+if PANEL_AVAILABLE:
     import param
     import panel as pn
-
-    PANEL_AVAILABLE = True
-except ImportError:
-    PANEL_AVAILABLE = False
+else:
     param = None  # type: ignore[assignment]
     pn = None  # type: ignore[assignment]
 

--- a/src/phenotypic/correction/_color_correction/_color_checker_profile.py
+++ b/src/phenotypic/correction/_color_correction/_color_checker_profile.py
@@ -31,16 +31,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _in_jupyter_notebook() -> bool:
-    """Detect whether code is running inside a Jupyter notebook."""
-    try:
-        from IPython import get_ipython
-
-        shell = get_ipython()
-        return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
-    except ImportError:
-        return False
-
 # ---------------------------------------------------------------------------
 # Illuminant constants
 # ---------------------------------------------------------------------------
@@ -711,13 +701,10 @@ class ColorCheckerProfile:
             raise RuntimeError(
                 "Cannot create dashboard for an unfitted profile."
             )
-        from ._diagnostic_dashboard import PANEL_AVAILABLE
+        from phenotypic.tools_.panel_ import require_panel, display_or_return
 
-        if not PANEL_AVAILABLE:
-            raise ImportError(
-                "Panel is required for interactive diagnostics. "
-                "Install with: pip install 'phenotypic[gui]'"
-            )
+        require_panel()
+
         from ._diagnostic_dashboard import ColorCorrectionDashboard
 
         dashboard = ColorCorrectionDashboard(
@@ -725,18 +712,7 @@ class ColorCheckerProfile:
         )
         panel_layout = dashboard.panel()
 
-        if show:
-            if _in_jupyter_notebook():
-                import panel as pn
-
-                pn.extension(inline=True)
-                from IPython.display import display
-
-                display(panel_layout)
-            else:
-                panel_layout.show()
-
-        return panel_layout
+        return display_or_return(panel_layout, show=show)
 
     # -- serialisation ------------------------------------------------------
 

--- a/src/phenotypic/correction/_color_correction/_diagnostic_dashboard.py
+++ b/src/phenotypic/correction/_color_correction/_diagnostic_dashboard.py
@@ -13,13 +13,12 @@ import colour
 import matplotlib.pyplot as plt
 import numpy as np
 
-try:
+from phenotypic.tools_.panel_ import PANEL_AVAILABLE
+
+if PANEL_AVAILABLE:
     import param
     import panel as pn
-
-    PANEL_AVAILABLE = True
-except ImportError:
-    PANEL_AVAILABLE = False
+else:
     param = None  # type: ignore[assignment]
     pn = None  # type: ignore[assignment]
 

--- a/src/phenotypic/gui/__init__.py
+++ b/src/phenotypic/gui/__init__.py
@@ -47,9 +47,9 @@ def _check_gui_deps() -> bool:
     """
     import importlib.util
 
-    return all(
-        importlib.util.find_spec(pkg) is not None for pkg in ["panel", "param"]
-    )
+    from phenotypic.tools_.panel_ import PANEL_AVAILABLE
+
+    return PANEL_AVAILABLE and importlib.util.find_spec("param") is not None
 
 
 GUI_AVAILABLE = _check_gui_deps()

--- a/src/phenotypic/gui/_global_session.py
+++ b/src/phenotypic/gui/_global_session.py
@@ -10,36 +10,18 @@ from pathlib import Path
 from typing import Optional
 
 # Global state
-_panel_initialized = False
 _global_instance_manager: Optional["InstanceManager"] = None
 
 
 def _ensure_panel_initialized() -> None:
     """Ensure Panel extension is initialized (Jupyter only).
 
-    Automatically calls pn.extension() on first use in Jupyter notebooks.
+    Delegates to :func:`phenotypic.tools_.panel_.ensure_panel_extension`.
     Safe to call multiple times - only initializes once.
     """
-    global _panel_initialized
+    from phenotypic.tools_.panel_ import ensure_panel_extension
 
-    if _panel_initialized:
-        return
-
-    try:
-        # Check if we're in a Jupyter environment
-        get_ipython()  # type: ignore  # noqa: F821
-        in_jupyter = True
-    except NameError:
-        in_jupyter = False
-
-    if in_jupyter:
-        import importlib.util
-
-        if importlib.util.find_spec("panel") is not None:
-            import panel as pn
-
-            pn.extension()
-            _panel_initialized = True
+    ensure_panel_extension()
 
 
 def get_global_manager(workspace: Optional[Path] = None) -> "InstanceManager":

--- a/src/phenotypic/measure/_measure_radial_expansion.py
+++ b/src/phenotypic/measure/_measure_radial_expansion.py
@@ -616,6 +616,11 @@ class MeasureRadialExpansion(MeasureFeatures):
         Returns:
             Panel Column layout with 6 diagnostic panels.
         """
+        from phenotypic.tools_.panel_ import require_panel, ensure_panel_extension
+
+        require_panel()
+        ensure_panel_extension()
+
         import panel as pn
 
         inter = self._compute_intermediates(image, object_label)

--- a/src/phenotypic/tools_/__init__.py
+++ b/src/phenotypic/tools_/__init__.py
@@ -12,7 +12,7 @@ The ``register`` submodule provides registry utilities for extensible components
 like plotters and dashboards.
 """
 
-from . import constants_, exceptions_, colourspace, slurm_, slurm
+from . import constants_, exceptions_, colourspace, panel_, slurm_, slurm
 from .funcs_ import timed_execution, is_binary_mask
 from .hdf_ import HDF
 from .mixin import GridInferenceMixin, LazyWidgetMixin, FootprintMixin, ClipControlMixin
@@ -28,6 +28,7 @@ __all__ = [
     "constants_",
     "exceptions_",
     "is_binary_mask",
+    "panel_",
     "register",
     "slurm",
     "slurm_",

--- a/src/phenotypic/tools_/panel_.py
+++ b/src/phenotypic/tools_/panel_.py
@@ -1,0 +1,146 @@
+"""Shared Panel toolkit for interactive dashboards.
+
+Centralises Panel availability checks, Jupyter environment detection,
+and ``pn.extension()`` initialization so that every module using Panel
+imports from one place instead of reimplementing these patterns.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+__all__ = [
+    "PANEL_AVAILABLE",
+    "PANEL_IMPORT_ERROR",
+    "display_or_return",
+    "ensure_panel_extension",
+    "in_ipython",
+    "in_jupyter",
+    "require_panel",
+]
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+PANEL_AVAILABLE: bool = importlib.util.find_spec("panel") is not None
+"""``True`` when the ``panel`` package is importable."""
+
+PANEL_IMPORT_ERROR: str = (
+    "Panel is required for interactive dashboards. "
+    "Install it with: pip install 'phenotypic[gui]'"
+)
+"""User-facing error message when Panel is missing."""
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+
+def require_panel() -> None:
+    """Raise :class:`ImportError` with an actionable message if Panel is missing.
+
+    Raises:
+        ImportError: If ``panel`` is not installed.
+    """
+    if not PANEL_AVAILABLE:
+        raise ImportError(PANEL_IMPORT_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Environment detection
+# ---------------------------------------------------------------------------
+
+
+def in_ipython() -> bool:
+    """Detect whether code is running inside any IPython session.
+
+    Returns:
+        ``True`` when an IPython kernel or terminal is active.
+    """
+    try:
+        get_ipython()  # type: ignore[name-defined]  # noqa: F821
+        return True
+    except NameError:
+        return False
+
+
+def in_jupyter() -> bool:
+    """Detect whether code is running inside a Jupyter notebook.
+
+    This is stricter than :func:`in_ipython` — it returns ``True`` only
+    for notebook kernels (``ZMQInteractiveShell``), not plain IPython
+    terminals.
+
+    Returns:
+        ``True`` when running in a Jupyter notebook kernel.
+    """
+    try:
+        from IPython import get_ipython as _get_ipython
+
+        shell = _get_ipython()
+        return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
+    except ImportError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Extension initialisation
+# ---------------------------------------------------------------------------
+
+_panel_initialized: bool = False
+
+
+def ensure_panel_extension(**kwargs) -> None:
+    """Initialise ``pn.extension()`` once, only when inside IPython.
+
+    Safe to call multiple times — the extension is loaded at most once
+    per process.  Outside IPython the call is a silent no-op.
+
+    Args:
+        **kwargs: Forwarded to ``pn.extension()`` on the first call
+            (e.g. ``inline=True``).
+    """
+    global _panel_initialized
+
+    if _panel_initialized:
+        return
+
+    if not in_ipython():
+        return
+
+    if not PANEL_AVAILABLE:
+        return
+
+    import panel as pn
+
+    pn.extension(**kwargs)
+    _panel_initialized = True
+
+
+# ---------------------------------------------------------------------------
+# Display helper
+# ---------------------------------------------------------------------------
+
+
+def display_or_return(layout, *, show: bool = True):
+    """Display a Panel layout in Jupyter or return it for programmatic use.
+
+    When *show* is ``True`` and the session is a Jupyter notebook the
+    layout is passed to ``IPython.display.display`` (after ensuring the
+    Panel extension is loaded).  Otherwise the layout is returned as-is.
+
+    Args:
+        layout: A Panel layout object (e.g. ``pn.Column``).
+        show: If ``True``, attempt to display interactively.
+
+    Returns:
+        The *layout* object (always returned, even after display).
+    """
+    if show and in_jupyter():
+        ensure_panel_extension()
+        from IPython.display import display
+
+        display(layout)
+
+    return layout

--- a/tests/unit/tools/test_panel_.py
+++ b/tests/unit/tools/test_panel_.py
@@ -1,0 +1,78 @@
+"""Tests for the shared Panel toolkit."""
+
+from __future__ import annotations
+
+import pytest
+
+from phenotypic.tools_.panel_ import (
+    PANEL_AVAILABLE,
+    PANEL_IMPORT_ERROR,
+    display_or_return,
+    ensure_panel_extension,
+    in_ipython,
+    in_jupyter,
+    require_panel,
+)
+
+
+class TestPanelAvailability:
+    """Tests for PANEL_AVAILABLE and require_panel."""
+
+    def test_panel_available_is_bool(self):
+        assert isinstance(PANEL_AVAILABLE, bool)
+
+    def test_panel_import_error_is_str(self):
+        assert isinstance(PANEL_IMPORT_ERROR, str)
+        assert "panel" in PANEL_IMPORT_ERROR.lower()
+
+    @pytest.mark.skipif(not PANEL_AVAILABLE, reason="Panel not installed")
+    def test_require_panel_does_not_raise_when_installed(self):
+        require_panel()  # should not raise
+
+    def test_require_panel_message_is_actionable(self):
+        """The error message should mention how to install."""
+        assert "pip install" in PANEL_IMPORT_ERROR or "uv" in PANEL_IMPORT_ERROR
+
+
+class TestEnvironmentDetection:
+    """Tests for in_ipython and in_jupyter."""
+
+    def test_in_ipython_returns_bool(self):
+        result = in_ipython()
+        assert isinstance(result, bool)
+
+    def test_in_jupyter_returns_bool(self):
+        result = in_jupyter()
+        assert isinstance(result, bool)
+
+    def test_in_jupyter_false_in_pytest(self):
+        """pytest is not a Jupyter notebook."""
+        assert in_jupyter() is False
+
+
+class TestEnsurePanelExtension:
+    """Tests for ensure_panel_extension."""
+
+    def test_ensure_panel_extension_noop_outside_ipython(self):
+        """Should not raise or crash when not in IPython."""
+        ensure_panel_extension()
+
+    def test_ensure_panel_extension_idempotent(self):
+        """Calling twice should not raise."""
+        ensure_panel_extension()
+        ensure_panel_extension()
+
+
+class TestDisplayOrReturn:
+    """Tests for display_or_return."""
+
+    def test_returns_layout_when_show_false(self):
+        sentinel = object()
+        result = display_or_return(sentinel, show=False)
+        assert result is sentinel
+
+    def test_returns_layout_when_not_jupyter(self):
+        """Outside Jupyter, layout is returned even with show=True."""
+        sentinel = object()
+        result = display_or_return(sentinel, show=True)
+        assert result is sentinel


### PR DESCRIPTION
utility logic

Centralizes duplicated Panel availability checks, Jupyter detection, and pn.extension() initialization into a single tools_/panel_.py module. Fixes MeasureRadialExpansion.inspect() not calling pn.extension() which prevented Panel output from rendering in notebooks.