### PR TITLE
add LinearSoftplusModel, AsymmetricSpurTrimmer; detector & CLI fixes

### DIFF
--- a/docs/source/explanation/filamentous_fungi_algorithm.md
+++ b/docs/source/explanation/filamentous_fungi_algorithm.md
@@ -1,85 +1,372 @@
 # The Filamentous Fungi Detection Algorithm
 
-Filamentous fungi grow as networks of branching hyphae that are thin,
-variable in intensity, and often fragmented in microscopy images.
-Standard threshold detectors fail because a single intensity cutoff
-cannot capture the full extent of the mycelium.
+Filamentous fungi grow as sprawling networks of thin, branching hyphae
+that radiate from a dense inoculation point. Standard threshold
+detectors fail on this morphology for three reasons:
 
-PhenoTypic's `FilamentousFungiDetector` uses a multi-stage approach
-designed specifically for this morphology.
+- No single intensity cutoff captures both the dense colony centre *and*
+  the thin peripheral hyphae.
+- Hyphae frequently appear fragmented in imaging: gaps in signal break
+  what is biologically one colony into many disconnected pieces.
+- Neighbouring colonies interleave their hyphae and must still be
+  individually labelled.
 
-## Stage 1: Inoculum Detection
+`FilamentousFungiDetector` handles all three in six phases. The class
+exposes ~10 user-facing knobs grouped into three tiers:
 
-The dense central region of each fungal colony (the inoculation point)
-is detected first using a conventional detector. This is the
-high-confidence anchor for each colony.
+1. **Scene parameters** — describe the sample's geometry.
+2. **Tolerance knobs** — describe image quality and species morphology.
+3. **Overrides** — escape hatches for non-standard imaging.
 
-The `inoculum_detector` parameter accepts any `ObjectDetector` or
-`ImagePipeline`. By default, a simple threshold detector is used.
+Plus four *hidden class-level tunables* (`beta`, `gamma`, `gauss_n_iter`,
+`delta`, `pct_n_orient`) that are fixed to robust defaults. Override
+only via subclassing if you really need to.
 
-## Stage 2: Voronoi Partition
+---
 
-Detected inoculum centers are used to compute a Voronoi tessellation of
-the image. This assigns every pixel to its nearest inoculum center by
-Euclidean distance, effectively partitioning the plate into colony
-territories.
+## Pipeline Overview
 
-## Stage 3: Hyphal Detection
+```
+Phase 1: Inoculum Detection      ──▶ dense colony centres
+Phase 2: Branch Detection        ──▶ binary mask of all hyphal pixels
+Phase 3: Centre Filtering +      ──▶ initial colony labels
+         Voronoi Partition          (connectivity not yet enforced)
+Phase 4: Dijkstra Reconnection   ──▶ fragments routed back to centres
+Phase 5: Final Voronoi           ──▶ final colony labels
+```
 
-An overall detector (or custom pipeline) identifies all foreground
-pixels — both dense inoculum regions and thin hyphal branches. This
-detection is intentionally sensitive, accepting false positives that
-will be filtered later.
+Every hyphal pixel ends up labelled with its parent colony, respecting
+both physical connectivity and spatial proximity.
 
-## Stage 4: Dijkstra Reconnection
+---
 
-When `enable_reconnection=True`, the detector uses phase congruency
-and minimum-cost pathfinding to reconnect fragmented hyphal branches.
+## Phase 1: Inoculum Detection
 
-**Phase congruency** provides an illumination-invariant edge response
-that highlights thin filaments even when their absolute intensity is
-low. The phase congruency map serves as the cost surface for pathfinding.
+Identify the dense colony centres first. These are the high-confidence
+anchors around which the rest of the algorithm operates — they determine
+both the Voronoi seeds and the Dijkstra source pixels. It's recommended if your
+image is uniform enough to instead use `ManualGridDetector`, as it provides
+guaranteed detection where you expect. InoculumDetector generally works, but can
+fail depending on noise in your scene
 
-**Dijkstra's algorithm** finds the lowest-cost path between disconnected
-hyphal fragments, weighted by:
+**Parameters:**
 
-- **Anisotropy** (`beta`) — penalizes paths that deviate from the local
-  filament orientation
-- **MAD penalty** (`gamma`) — penalizes paths through high-variation
-  (noisy) regions
-- **Quality threshold** (`quality_k`) — IQR-based cutoff that rejects
-  low-confidence reconnections
+| Param               | Role                                                                                                                                                                                                                        |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `inoculum_detector` | ObjectDetector or ImagePipeline for centres. Defaults to `InoculumDetector` + `GridSectionLargest` for grid plates. Replace with a species-specific centre detector if the default doesn't pick up your inoculation points. |
 
-## Stage 5: Assignment
+---
 
-Reconnected hyphal pixels are assigned to their nearest inoculum center
-via the Voronoi partition, producing the final labeled object map.
+## Phase 2: Branch Detection
+
+A deliberately *sensitive* detector captures every plausible hyphal
+pixel, intentionally overestimating so that nothing real gets missed.
+False positives are filtered in later phases.
+
+Two signals are combined:
+
+1. **Background-subtracted Gaussian response** — `SubtractGaussian` with
+   σ sized to blur out the whole colony, leaving just the residual
+   signal.
+2. **Phase congruency** — an illumination-invariant edge response that
+   highlights thin filaments even when their absolute intensity is low
+   [[1]](#references). Hyphae are line-like; phase congruency is a
+   line-sensitive feature detector.
+
+The two signals are max-merged, then thresholded with a hysteresis
+detector (triangle low, Otsu high) to produce a binary branch mask.
+
+**Parameters:**
+
+| Param                             | Role                                                                                                    | Default |
+|-----------------------------------|---------------------------------------------------------------------------------------------------------|---------|
+| `edge_noise_threshold`            | Phase congruency noise floor. ↑ = stricter (rejects more pixels as noise; preserves fewer thin hyphae). | 6.0     |
+| `ignore_borders`                  | If True, drops branch components touching the image border.                                             | True    |
+| `gauss_sigma` *(override)*        | SubtractGaussian σ. Auto-derived from `max_colony_radius_px × 1.2`.                                     | —       |
+| `pct_min_wavelength` *(override)* | Log-Gabor minimum wavelength. Auto-derived from `min_branch_width_px × 2`.                              | —       |
+
+**Hidden tunables:** `pct_n_orient = 8` (angular resolution for PCT),
+`gauss_n_iter = 2` (background-subtraction iterations).
+
+---
+
+## Phase 3: Centre Filtering & Initial Voronoi Partition
+
+The inoculum centroids seed a Euclidean Voronoi tessellation that
+assigns every branch-mask pixel to its nearest centre.
+
+First, branch components that don't overlap *any* inoculum centre are
+dropped — debris and noise that happened to pass Phase 2 but don't
+correspond to a real colony. Then centroids of the remaining overlapping
+components become Voronoi seeds.
+
+The result is an *initial* colony label map: every mask pixel has a
+colony ID, but pixels within a given colony aren't necessarily
+physically connected yet. That's what Phase 4 fixes.
+
+**Parameters:** none directly — uses the Phase 1 centroids and the
+Phase 2 mask.
+
+---
+
+## Phase 4: Dijkstra Reconnection
+
+This is the algorithm's heavy lifting. "Pseudo-fragment" components
+(assigned to a colony by Voronoi proximity but not physically touching
+the main body) are bridged back via low-cost paths through the phase
+congruency response.
+
+### 4a. Cost surface construction
+
+Each pixel's routing cost combines four features:
+
+1. **Phase congruency energy** — paths prefer high-PCT-energy
+   (signal-rich) pixels.
+2. **Anisotropy** (weighted by `β`) — rewards directional (line-like)
+   regions. Anisotropy appears in the denominator of the cost formula,
+   so high anisotropy lowers cost; isotropic/non-directional pixels
+   therefore appear expensive by comparison.
+3. **Orientation coherence** — rewards contiguous oriented structure.
+4. **Local MAD** (weighted by `γ`) — penalises noisy/textured regions.
+
+Then two post-assembly penalties are added:
+
+- **Gap penalty** (`gap_crossing_penalty`) — penalises paths that cross
+  low-PCT-energy gaps proportional to the gap length.
+- **Border penalty** (`border_margin_px`) — inflates cost within this
+  many pixels of the image border, preventing shortcut paths that hug
+  edges.
+
+**Parameters:**
+
+| Param                                  | Role                                                                       | Default |
+|----------------------------------------|----------------------------------------------------------------------------|---------|
+| `gap_crossing_penalty`                 | Strength of the distance-gap penalty. ↑ = harder to cross low-energy gaps. | 4.0     |
+| `border_margin_px`                     | Width of the border penalty buffer.                                        | 50      |
+| `mad_window` *(override)*              | Local MAD window. Auto-derived from `min_branch_width_px × 2 + 1`.         | —       |
+| `coherence_window_radius` *(override)* | Orientation coherence window. Auto-derived from `min_branch_width_px × 5`. | —       |
+
+**Hidden tunables:** `beta = 2.0` (anisotropy exponent), `gamma = 1.2`
+(MAD penalty weight).
+
+### 4b. Fragment pre-screening
+
+Fragments stranded far from any routable territory are dropped *before*
+Dijkstra runs — no point wasting compute on hopeless cases. A minimum
+filter of radius `frag_reach_px` precomputes the lowest cost within
+that 2D neighbourhood of every pixel. A fragment passes if at least
+one of its boundary pixels sees a filtered value below `tau_screen` —
+a threshold calibrated from known-good colony boundaries (specifically,
+the 99th percentile of their min-cost envelope distribution), not an
+absolute cutoff.
+
+**Parameters:**
+
+| Param           | Role                                                                  | Default |
+|-----------------|-----------------------------------------------------------------------|---------|
+| `frag_reach_px` | Max 2D distance from fragment boundary to the nearest routable pixel. | 10      |
+
+### 4c. Tiled multi-source Dijkstra
+
+For memory efficiency, the image is split into overlapping tiles. Each
+tile runs a multi-source Dijkstra whose wavefront is seeded from the
+*boundary* pixels of every colony body: all colony pixels (interior and
+boundary) are pre-initialised to cost zero, but interior pixels are
+marked visited immediately and never enter the heap, so propagation
+starts cleanly from the boundary outward. The result is shortest-cost
+paths from every pseudo-fragment back to its nearest main colony body.
+
+Tile size must fit several colonies with routing headroom; tile overlap
+must exceed the maximum reconnection distance so fragments near a tile
+boundary can still see their parent.
+
+**Parameters:**
+
+| Param                       | Role                                                                            | Default |
+|-----------------------------|---------------------------------------------------------------------------------|---------|
+| `tile_size` *(override)*    | Tile side length. Auto-derived from `max_colony_radius_px × 4.8`.               | —       |
+| `tile_overlap` *(override)* | Overlap between adjacent tiles. Auto-derived from `max_colony_radius_px × 2.4`. | —       |
+
+**Hidden tunable:** `delta = 1.0` — radial retreat penalty that biases
+Dijkstra against backtracking through already-visited territory.
+
+### 4d. Path quality filtering
+
+Not every Dijkstra path is accepted. A quality-filter cascade compares
+each candidate against a distribution of *known-good* colony-skeleton
+branches (extracted from the main colony bodies). Five metrics per path:
+
+1. **Median raw cost** along the path (is it consistently cheap?).
+2. **Max of windowed median costs** — the cost surface is sampled along
+   the path; a sliding window of length `max_gap_length` computes the
+   median cost within each window; the *maximum* of those per-window
+   medians becomes the metric. A single-pixel cost spike is absorbed by
+   the median, but a sustained bad stretch of length ≥ `max_gap_length`
+   drives the windowed median up and flags the path.
+3. **Band cost variance** — noisiness of the dilated band around the
+   path.
+4. **PCT energy band median** — average signal level along the path.
+5. **Grayscale SNR** — local contrast vs. background.
+
+Thresholds for each metric are set using `reconnection_tolerance` as an
+IQR multiplier on the known-good distribution.
+
+**Parameters:**
+
+| Param                               | Role                                                                                         | Default |
+|-------------------------------------|----------------------------------------------------------------------------------------------|---------|
+| `max_gap_length`                    | Sliding window length for the "bad stretch" detection. Longer ⇒ tolerates longer gaps.       | 30      |
+| `reconnection_tolerance`            | IQR multiplier for acceptance thresholds. ↑ = more permissive.                               | 2.5     |
+| `path_dilation_radius` *(override)* | Path thickness for band sampling. Auto-derived from `max(1, min_branch_width_px // 2)`.      | —       |
+| `snr_margin` *(override)*           | Background-ring offset for SNR filter. Auto-derived from `max(2, min_branch_width_px // 2)`. | —       |
+
+Paths that survive the cascade get painted into the colony label map
+with their assigned colony ID; the fragment pixels plus the dilated
+reconnection path are labelled together.
+
+---
+
+## Phase 5: Final Voronoi Partition
+
+With reconnected fragments now labelled, a final Voronoi partition
+combines the Phase 3 filtered branch mask (components that overlapped
+an inoculum centre) with all painted reconnection paths from Phase 4.
+This ensures every foreground pixel gets a colony label that's
+consistent with physical connectivity after reconnection, and that
+connected components don't end up split across colony labels.
+
+**Parameters:** none directly.
+
+---
+
+## Parameter Tuning Guide
+
+The knobs fall into four tuning tiers. Work top-down: get scene
+parameters right first, then adjust tolerances if results look wrong,
+only touch overrides as a last resort.
+
+### Tier 1: Always tune first (scene parameters)
+
+These describe your sample. Wrong values here cascade into wrong
+derived values for ~8 other parameters.
+
+| Param                  | How to set it                                                                                                                                                                                       |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `max_colony_radius_px` | Measure the largest colony radius you expect in pixels. Too small ⇒ σ fails to blur out colonies, background subtraction breaks; too large ⇒ wasted memory on oversized tiles.                      |
+| `min_branch_width_px`  | Measure the narrowest hyphal width you want to resolve. Too small ⇒ MAD/dilation windows shrink below Nyquist, missing real hyphae; too large ⇒ wavelength and windows merge neighbouring branches. |
+
+### Tier 2: Tune based on image quality and species
+
+These depend on your imaging conditions and organism. Start at defaults,
+adjust if Phase 2 results look wrong (missing real hyphae / too much
+noise) or Phase 4 reconnection behaves poorly.
+
+| Param                    | When to raise                                                            | When to lower                                                   |
+|--------------------------|--------------------------------------------------------------------------|-----------------------------------------------------------------|
+| `edge_noise_threshold`   | Clean, high-contrast images with obvious hyphae                          | Dim or noisy images where real hyphae are being lost in Phase 2 |
+| `reconnection_tolerance` | Legitimate fragments are not getting reconnected (permissiveness needed) | Obvious over-merging of nearby colonies (strictness needed)     |
+| `max_gap_length`         | Species with long sparse hyphal segments                                 | Over-merging colonies across short gaps                         |
+
+### Tier 3: Usually fine at defaults (spatial tolerances)
+
+Sensible defaults cover most scenes. Touch only for specific failures.
+
+| Param                  | Default | Typical reason to change                                                                                                      |
+|------------------------|---------|-------------------------------------------------------------------------------------------------------------------------------|
+| `ignore_borders`       | `True`  | Set `False` if you need to keep colonies at image edges (mosaic/cropped views).                                               |
+| `frag_reach_px`        | `10`    | Raise if legitimate but distant fragments are being dropped before Dijkstra.                                                  |
+| `border_margin_px`     | `50`    | Lower if image edges carry useful signal; raise for noisy edges.                                                              |
+| `gap_crossing_penalty` | `4.0`   | Lower (2.0) if gap-crossing paths are suppressed too aggressively; raise for very clean images where gaps truly mean absence. |
+
+### Tier 4: Overrides (advanced; rarely needed)
+
+If scene knobs capture your geometry well, auto-derivation works. Only
+override when you have non-standard imaging (anisotropic pixels,
+unusual magnification) or you're reproducing a pipeline with exact
+fixed values.
+
+| Override                  | Derived from           | Formula              |
+|---------------------------|------------------------|----------------------|
+| `gauss_sigma`             | `max_colony_radius_px` | `1.2 × R`            |
+| `tile_size`               | `max_colony_radius_px` | `4.8 × R`            |
+| `tile_overlap`            | `max_colony_radius_px` | `2.4 × R`            |
+| `pct_min_wavelength`      | `min_branch_width_px`  | `2 × w`              |
+| `mad_window`              | `min_branch_width_px`  | `2w + 1` (odd)       |
+| `path_dilation_radius`    | `min_branch_width_px`  | `max(1, round(w/2))` |
+| `snr_margin`              | `min_branch_width_px`  | `max(2, round(w/2))` |
+| `coherence_window_radius` | `min_branch_width_px`  | `5 × w`              |
+
+---
+
+## Experimental tuning: what the defaults assume
+
+The defaults are calibrated for:
+
+- Plates imaged at a typical dissecting-microscope resolution.
+- Colony radii roughly 50–300 px.
+- Hyphal widths of 2–6 px.
+- Moderate imaging noise (clean but not studio-quality).
+
+If your setup differs substantially from these — imaging at very high
+magnification, unusual organisms with atypical aspect ratios, or
+phase-contrast optics with ringing artefacts — expect to iterate.
+Specifically:
+
+- **High-resolution imaging** (w > 6): raise `max_gap_length` and
+  `frag_reach_px` proportionally.
+- **Low-contrast / dim hyphae**: lower `edge_noise_threshold`, raise
+  `reconnection_tolerance`.
+- **Very dense plates with interleaved colonies**: lower
+  `reconnection_tolerance`, raise `gap_crossing_penalty`. Accept a few
+  extra fragments in exchange for cleaner separation.
+
+---
 
 ## Preprocessing Requirements
 
 The detector works best with upstream denoising and illumination
 correction:
 
-1. **StableDenoise (BM3D)** — removes noise without destroying thin
-   filaments
-2. **HomomorphicFilter** — corrects uneven illumination across the plate
+1. **`StableDenoise`** (BM3D) — removes Poisson-Gaussian noise without
+   destroying thin filaments.
+2. **`HomomorphicFilter`** — corrects uneven illumination so phase
+   congruency isn't driven by intensity gradients.
 
 The `FilamentousFungiPipeline` prefab chains these automatically.
 
-## Key Parameters
+---
 
-| Parameter | Effect | Default |
-|-----------|--------|---------|
-| `enable_reconnection` | Enable Dijkstra reconnection | True |
-| `quality_k` | Reconnection permissiveness (higher = more) | 2.5 |
-| `beta` | Anisotropy weight in cost function | 2.0 |
-| `gamma` | MAD penalty weight | 1.2 |
-| `tile_size` | Tile size for memory-efficient processing | 1200 |
+## Quick Reference
+
+```python
+from phenotypic.detect import FilamentousFungiDetector
+
+detector = FilamentousFungiDetector(
+        # Scene: describe your sample
+        max_colony_radius_px=250,  # tier 1 — always tune
+        min_branch_width_px=3,  # tier 1 — always tune
+
+        # Tolerances: describe your image quality
+        edge_noise_threshold=6.0,  # tier 2 — tune if Phase 2 looks wrong
+        reconnection_tolerance=2.5,  # tier 2 — tune if Phase 4 over/under-merges
+        max_gap_length=30,  # tier 2 — species-dependent
+
+        # Spatial tolerances (usually fine)
+        ignore_borders=True,  # tier 3
+        frag_reach_px=10,  # tier 3
+        border_margin_px=50,  # tier 3
+        gap_crossing_penalty=4.0,  # tier 3
+)
+```
+
+---
 
 ## References
 
+<a id="references"></a>
+
 [1] P. Kovesi, "Image features from phase congruency," *Videre: J.
-Computer Vision Research*, vol. 1, no. 3, pp. 1--26, 1999.
+Computer Vision Research*, vol. 1, no. 3, pp. 1–26, 1999.
 
 [2] A. F. Frangi et al., "Multiscale vessel enhancement filtering," in
-*MICCAI*, 1998, pp. 130--137.
+*MICCAI*, 1998, pp. 130–137.

--- a/src/phenotypic/_cli/_cli_checkpoint_handler.py
+++ b/src/phenotypic/_cli/_cli_checkpoint_handler.py
@@ -68,10 +68,16 @@ def _run_manifest(output_dir: Path, progress_dir: Path) -> None:
 
     from ._dashboard._manifest_builder import build_manifest
 
+    datasets_raw = job_metadata.get("datasets", {}) or {}
+    datasets_totals: dict[str, int] = {
+        name: (info["total"] if isinstance(info, dict) else int(info))
+        for name, info in datasets_raw.items()
+    }
+
     build_manifest(
         output_dir=output_dir,
         progress_dir=progress_dir,
-        datasets=job_metadata.get("datasets", {}),
+        datasets=datasets_totals,
         execution_mode=job_metadata.get("execution_mode", "local"),
         start_time=job_metadata.get("start_time", ""),
         slurm_job_ids=job_metadata.get("chunk_job_ids"),
@@ -97,8 +103,12 @@ def _run_finalize(output_dir: Path, progress_dir: Path) -> None:
         logger.warning("No job_metadata.json -- cannot finalize")
         return
 
-    datasets = job_metadata.get("datasets", {})
-    total_expected = sum(datasets.values())
+    datasets_raw = job_metadata.get("datasets", {}) or {}
+    datasets_totals: dict[str, int] = {
+        name: (info["total"] if isinstance(info, dict) else int(info))
+        for name, info in datasets_raw.items()
+    }
+    total_expected = sum(datasets_totals.values())
 
     # Wait for all images to complete (or fail)
     _wait_for_completion(progress_dir, total_expected, timeout=600)
@@ -111,7 +121,7 @@ def _run_finalize(output_dir: Path, progress_dir: Path) -> None:
 
     aggregate_measurements(
         output_dir=output_dir,
-        dataset_names=list(datasets.keys()),
+        dataset_names=list(datasets_totals.keys()),
         include_dataset_column=job_metadata.get("include_dataset_column", True),
         metadata_csv=metadata_csv,
     )
@@ -122,7 +132,7 @@ def _run_finalize(output_dir: Path, progress_dir: Path) -> None:
     build_manifest(
         output_dir=output_dir,
         progress_dir=progress_dir,
-        datasets=datasets,
+        datasets=datasets_totals,
         execution_mode=job_metadata.get("execution_mode", "local"),
         start_time=job_metadata.get("start_time", ""),
         slurm_job_ids=job_metadata.get("chunk_job_ids"),

--- a/src/phenotypic/analysis/__init__.py
+++ b/src/phenotypic/analysis/__init__.py
@@ -7,11 +7,13 @@ modeling across time courses, and Tukey-style outlier removal for colony metrics
 """
 
 from ._edge_correction import EdgeCorrector
+from ._linear_softplus import LinearSoftplusModel
 from ._log_growth_model import LogGrowthModel
 from ._tukey_outlier import TukeyOutlierRemover
 
 __all__ = [
     "EdgeCorrector",
+    "LinearSoftplusModel",
     "LogGrowthModel",
     "TukeyOutlierRemover",
 ]

--- a/src/phenotypic/analysis/_linear_softplus.py
+++ b/src/phenotypic/analysis/_linear_softplus.py
@@ -1,0 +1,517 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Literal, Tuple
+
+import numpy as np
+import pandas as pd
+
+from phenotypic.analysis.abc_ import ModelFitter
+from phenotypic.tools_.measurement_info_ import (
+    LINEAR_SOFTPLUS_MODEL,
+    MODEL_METRICS,
+)
+
+
+class LinearSoftplusModel(ModelFitter):
+    r"""Linear-with-softplus lag-phase growth fitter.
+
+    The model combines a linear post-lag growth phase with a softplus lag
+    transition and an optional softplus saturation ceiling:
+
+    .. math::
+
+        s(t) = \frac{v}{\alpha}\, \ln\!\bigl(1 + e^{\alpha(t-\lambda)}\bigr) + s_0
+
+    When ``smax`` is provided (or inferred per-group as the observed
+    maximum), a second softplus clamps the curve to the saturation
+    ceiling:
+
+    .. math::
+
+        s(t) = s_{\max}
+               - \frac{1}{\beta}\,\ln\!\bigl(1 + e^{\beta(s_{\max} - s_{\text{unclamped}}(t))}\bigr)
+
+    Attributes:
+        smax (float | None): Fixed carrying capacity. ``None`` falls back
+            to per-group observed maximum.
+        beta (float): Saturation transition sharpness.
+        stderr_label (str | None): Column providing per-timepoint standard
+            errors used as weights in the fit. When ``None``, the fit
+            auto-derives a replicate-SE column during aggregation.
+        inoc_size_label (str | None): Column of per-row inoculum size
+            measurements. When supplied, per-group mean and sample std
+            are computed automatically and used as an informative
+            Gaussian prior on ``s0``; when ``None``, no prior is applied
+            (appropriate for yeast where inoculum size is not imaged).
+        prune_saturated (bool): Whether to drop post-saturation timepoints
+            before fitting.
+        saturation_threshold (float): Fraction of peak ``ds/dt`` below
+            which the curve is considered saturated.
+        saturation_buffer (int): Extra rows past the saturation index kept
+            so the fit still sees some plateau evidence.
+        v_upper (float): Upper bound on ``v`` in the optimizer.
+    """
+
+    _measurement_info_class = LINEAR_SOFTPLUS_MODEL
+
+    def __init__(
+        self,
+        on: str,
+        groupby: List[str],
+        time_label: str = "Metadata_Time",
+        agg_func: Callable | str | list | dict | None = "mean",
+        *,
+        smax: float | None = None,
+        beta: float = 10,
+        stderr_label: str | None = None,
+        inoc_size_label: str | None = None,
+        prune_saturated: bool = True,
+        saturation_threshold: float = 0.05,
+        saturation_buffer: int = 2,
+        v_upper: float = 50.0,
+        num_workers: int = 1,
+        loss: Literal["linear"] = "linear",
+        verbose: bool = False,
+    ):
+        """Initialize the linear-softplus fitter.
+
+        Args:
+            on: Target column (size measurement) to fit.
+            groupby: Columns defining the per-fit grouping structure.
+            time_label: Column name representing time. Defaults to
+                ``"Metadata_Time"``.
+            agg_func: Aggregation function for the ``on`` column when
+                ``stderr_label`` is provided. Ignored when
+                ``stderr_label is None`` because the fitter uses pandas
+                named aggregation to derive mean and SE together.
+                Defaults to ``"mean"``.
+            smax: Fixed carrying capacity for every group. When
+                ``None``, each group uses its own post-pruning observed
+                maximum of ``on``.
+            beta: Saturation transition sharpness.
+            stderr_label: Column providing per-timepoint standard
+                errors used as weights. When ``None``, replicate SE is
+                computed automatically during aggregation.
+            inoc_size_label: Optional column providing per-row inoculum
+                size measurements (typically available for filamentous
+                fungi from the t=0 image, absent for yeast). When
+                supplied, per-group mean and sample standard deviation
+                of the column are computed automatically via
+                ``groupby.transform`` and fed into a single virtual
+                Gaussian residual on ``s0`` (spec §5.3). When ``None``
+                (the default, appropriate for yeast), the inoculum
+                prior is omitted from the residual vector entirely.
+            prune_saturated: Whether to drop post-saturation timepoints
+                before fitting.
+            saturation_threshold: Fraction of peak ``ds/dt`` below which
+                the curve is considered saturated.
+            saturation_buffer: Extra rows past the saturation index
+                retained so the fit still sees plateau evidence.
+            v_upper: Upper bound on ``v``.
+            num_workers: Number of parallel workers for per-group fits.
+            loss: Loss method passed through to
+                :func:`scipy.optimize.least_squares`. Defaults to
+                ``"linear"``.
+            verbose: If ``True``, enables optimizer verbose output.
+        """
+        super().__init__(
+            on=on,
+            groupby=groupby,
+            time_label=time_label,
+            agg_func=agg_func,
+            num_workers=num_workers,
+            loss=loss,
+            verbose=verbose,
+        )
+        self.smax = smax
+        self.beta = beta
+        self.stderr_label = stderr_label
+        self.inoc_size_label = inoc_size_label
+        self.prune_saturated = prune_saturated
+        self.saturation_threshold = saturation_threshold
+        self.saturation_buffer = saturation_buffer
+        self.v_upper = v_upper
+
+    # ------------------------------------------------------------------ #
+    # Model math
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def model_func(
+        t: np.ndarray | float,
+        v: float,
+        s0: float,
+        lam: float,
+        alpha: float,
+        smax: float | None = None,
+        beta: float = 10,
+    ) -> float | np.ndarray:
+        r"""Linear-softplus growth curve with optional saturation ceiling.
+
+        Args:
+            t: Time (scalar or array).
+            v: Post-lag growth rate.
+            s0: Initial size.
+            lam: Lag duration.
+            alpha: Lag transition sharpness.
+            smax: Optional carrying capacity. When ``None``, the curve
+                grows linearly forever past the lag.
+            beta: Saturation transition sharpness.
+
+        Returns:
+            Predicted size at ``t``; scalar when ``t`` is scalar,
+            otherwise an array.
+        """
+        t_arr = np.asarray(t, dtype=float)
+        # `logaddexp` is the numerically stable form of log(1 + exp(x)).
+        softplus_lag = np.logaddexp(0.0, alpha * (t_arr - lam)) / alpha
+        s_unclamped = v * softplus_lag + s0
+
+        if smax is None:
+            return s_unclamped
+
+        softplus_sat = np.logaddexp(0.0, beta * (smax - s_unclamped)) / beta
+        s_clamped = smax - softplus_sat
+        return s_clamped
+
+    # ------------------------------------------------------------------ #
+    # Loss function (instance method so we can reach self.beta)
+    # ------------------------------------------------------------------ #
+    def _loss_func(
+        self,
+        params,
+        t,
+        y,
+        sigma=None,
+        smax: float | None = None,
+        sGMM_mean: float | None = None,
+        sGMM_sigma: float | None = None,
+        **_,
+    ):
+        r"""Weighted residuals with optional inoculum prior.
+
+        Residuals are the measurement-vs-model differences, optionally
+        divided by per-timepoint ``sigma`` (spec §6.3). When
+        ``sGMM_mean`` and ``sGMM_sigma`` are supplied (resolved
+        per-group from the ``inoc_size_label`` column by
+        :meth:`_extra_loss_kwargs`), a single virtual residual
+        ``(s0 - sGMM_mean) / sGMM_sigma`` is appended (spec §5.3) to
+        implement the Bayesian MAP-equivalent Gaussian prior on ``s0``.
+        When no inoculum column is provided, the prior is omitted
+        entirely — the residual vector contains only data residuals.
+
+        Args:
+            params: Optimizer vector ``[v, s0, lam, alpha]``.
+            t: Time points.
+            y: Observed sizes.
+            sigma: Optional per-timepoint standard errors; ``None``
+                yields unweighted residuals.
+            smax: Per-group carrying capacity.
+            sGMM_mean: Per-group inoculum-size mean (optional).
+            sGMM_sigma: Per-group inoculum-size sample std (optional).
+
+        Returns:
+            Flat residual vector consumed by
+            :func:`scipy.optimize.least_squares`.
+        """
+        v, s0, lam, alpha = params
+        y_pred = self.model_func(
+            t=t,
+            v=v,
+            s0=s0,
+            lam=lam,
+            alpha=alpha,
+            smax=smax,
+            beta=self.beta,
+        )
+        residuals = np.asarray(y, dtype=float) - np.asarray(y_pred, dtype=float)
+        if sigma is not None:
+            residuals = residuals / np.asarray(sigma, dtype=float)
+
+        if sGMM_mean is not None and sGMM_sigma is not None:
+            prior_residual = (s0 - sGMM_mean) / sGMM_sigma
+            return np.concatenate([residuals, [prior_residual]])
+        return residuals
+
+    # ------------------------------------------------------------------ #
+    # Saturation pruning
+    # ------------------------------------------------------------------ #
+    def _prepare_group(self, group: pd.DataFrame) -> pd.DataFrame:
+        """Drop post-saturation timepoints via a robust hybrid heuristic.
+
+        The pruning rule requires **both** an amplitude criterion
+        (``y >= 90% * (max - min) + min``) *and* a sustained
+        sub-threshold derivative run (3 consecutive points below
+        ``saturation_threshold * peak_slope``) to agree before trimming.
+        The amplitude gate is structurally immune to lag-phase noise
+        because the lag phase sits near ``s0``, far below the amplitude
+        target. The sustained-run gate rejects transient mid-growth
+        dips. A tail-growth guard short-circuits on curves that never
+        saturate within the observation window.
+        """
+        if not self.prune_saturated or len(group) < 6:
+            return group
+
+        g = group.sort_values(self.time_label).reset_index(drop=True)
+        y = g[self.on].to_numpy(dtype=float)
+        t = g[self.time_label].to_numpy(dtype=float)
+
+        window = min(5, max(3, len(y) // 4))
+        dy_dt = np.gradient(y, t)
+        smoothed = np.convolve(dy_dt, np.ones(window) / window, mode="same")
+        peak_slope = float(smoothed.max())
+
+        # Guard against NaN-propagated smoothed arrays (e.g. all-NaN y)
+        # that would silently fall through both gates below.
+        if not np.isfinite(peak_slope) or peak_slope <= 0:
+            return g
+
+        tail_window = smoothed[-window:]
+        if tail_window.size == 0 or not np.any(np.isfinite(tail_window)):
+            return g
+        tail_slope = float(np.nanmean(tail_window))
+        if tail_slope > self.saturation_threshold * peak_slope:
+            return g
+
+        peak_idx = int(np.argmax(smoothed))
+
+        amp_target = y.min() + 0.90 * (y.max() - y.min())
+        amp_mask = y >= amp_target
+        amp_idx = int(np.argmax(amp_mask)) if amp_mask.any() else len(y)
+
+        threshold = self.saturation_threshold * peak_slope
+        below = smoothed[peak_idx:] < threshold
+        sustained = 3
+        deriv_idx: int | None = None
+        run = 0
+        for i, is_below in enumerate(below):
+            run = run + 1 if is_below else 0
+            if run >= sustained:
+                deriv_idx = peak_idx + i - (sustained - 1)
+                break
+        if deriv_idx is None:
+            return g
+
+        sat_idx = max(amp_idx, deriv_idx)
+        keep_through = min(sat_idx + self.saturation_buffer, len(g) - 1)
+        return g.iloc[: keep_through + 1].copy()
+
+    # ------------------------------------------------------------------ #
+    # Per-group loss kwargs (smax, sigma, inoculum prior)
+    # ------------------------------------------------------------------ #
+    _INOC_MEAN_SUFFIX = "_group_mean"
+    _INOC_SIGMA_SUFFIX = "_group_sigma"
+
+    def _extra_loss_kwargs(self, group: pd.DataFrame) -> Dict[str, Any]:
+        kw: Dict[str, Any] = {"smax": self._smax_for(group)}
+        sigma = self._resolve_sigma(group)
+        if sigma is not None:
+            kw["sigma"] = sigma
+        stats = self._inoc_stats(group)
+        if stats is not None:
+            kw["sGMM_mean"], kw["sGMM_sigma"] = stats
+        return kw
+
+    def _inoc_stats(self, group: pd.DataFrame) -> Tuple[float, float] | None:
+        """Resolve per-group inoculum mean and std, or ``None``.
+
+        Reads the pre-computed per-group aggregate columns injected by
+        :meth:`analyze`. Returns ``None`` whenever the column is not
+        configured, the aggregate columns are missing/invalid, or the
+        sample std is zero/non-finite — all of which would make the
+        Gaussian prior undefined.
+        """
+        if self.inoc_size_label is None:
+            return None
+        mean_col = f"{self.inoc_size_label}{self._INOC_MEAN_SUFFIX}"
+        sigma_col = f"{self.inoc_size_label}{self._INOC_SIGMA_SUFFIX}"
+        if mean_col not in group.columns or sigma_col not in group.columns:
+            return None
+        mean_series = group[mean_col].dropna()
+        sigma_series = group[sigma_col].dropna()
+        if mean_series.empty or sigma_series.empty:
+            return None
+        mean = float(mean_series.iloc[0])
+        sigma = float(sigma_series.iloc[0])
+        if (
+            not np.isfinite(mean)
+            or not np.isfinite(sigma)
+            or sigma <= 0
+        ):
+            return None
+        return mean, sigma
+
+    def _smax_for(self, group: pd.DataFrame) -> float:
+        if self.smax is not None:
+            return float(self.smax)
+        return float(group[self.on].max())
+
+    def _resolve_sigma(self, group: pd.DataFrame) -> np.ndarray | None:
+        """Build a per-timepoint sigma vector, aligned with group rows.
+
+        Priority order:
+          1. User-supplied ``stderr_label`` column.
+          2. Auto-derived replicate-SE column ``f"{on}_stderr"`` emitted
+             by :meth:`_extra_agg_columns` when ``stderr_label is None``.
+          3. No weights (return ``None``).
+        """
+        if self.stderr_label is not None and self.stderr_label in group.columns:
+            raw = group[self.stderr_label].to_numpy(dtype=float)
+        elif f"{self.on}_stderr" in group.columns:
+            raw = group[f"{self.on}_stderr"].to_numpy(dtype=float)
+        else:
+            return None
+
+        # Replace zero/NaN sigmas with a small epsilon so the weighted
+        # residuals stay finite. Scale epsilon to the median positive
+        # sigma so it stays commensurate with the data.
+        positive = raw[(raw > 0) & np.isfinite(raw)]
+        if positive.size > 0:
+            eps = 1e-8 * float(np.nanmedian(np.abs(positive)))
+            if eps <= 0 or not np.isfinite(eps):
+                eps = 1e-8
+        else:
+            eps = 1e-8
+        return np.where((raw > 0) & np.isfinite(raw), raw, eps)
+
+    def _extra_agg_columns(self) -> Dict[str, Any]:
+        """Carry per-timepoint stderr and per-group inoculum stats.
+
+        - ``stderr_label`` or the auto-computed ``f"{on}_stderr"`` goes
+          through with a mean aggregation so the weighted loss can
+          read one SE per timepoint.
+        - When ``inoc_size_label`` is configured, the two per-group
+          aggregate columns injected by :meth:`analyze` are pulled
+          through with ``"first"`` — they are already constant within
+          each group so any reducer gives the same answer.
+        """
+        extras: Dict[str, Any] = {}
+        if self.stderr_label is not None:
+            extras[self.stderr_label] = "mean"
+        else:
+            extras[f"{self.on}_stderr"] = "mean"
+        if self.inoc_size_label is not None:
+            extras[f"{self.inoc_size_label}{self._INOC_MEAN_SUFFIX}"] = "first"
+            extras[f"{self.inoc_size_label}{self._INOC_SIGMA_SUFFIX}"] = "first"
+        return extras
+
+    def analyze(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Fit the model to every group of ``data``.
+
+        Pre-computes two broadcasted helper columns on the raw data
+        before delegating to the base-class aggregation pipeline:
+
+        - When ``stderr_label`` is ``None``, a replicate-SEM column
+          derived via ``groupby.transform("sem")`` so the weighted
+          loss can downweight noisy timepoints automatically.
+        - When ``inoc_size_label`` is set, per-group mean and sample
+          std of the inoculum-size column via ``groupby.transform``
+          — these feed the optional Gaussian prior on ``s0``
+          (:meth:`_inoc_stats`).
+
+        Each helper is constant within its group, so the base-class
+        dict-style aggregation carries it through as a flat column
+        without MultiIndex juggling.
+        """
+        needs_copy = (
+            self.stderr_label is None or self.inoc_size_label is not None
+        )
+        if needs_copy:
+            data = data.copy(deep=True)
+
+        if self.stderr_label is None:
+            se_col = f"{self.on}_stderr"
+            data[se_col] = data.groupby(
+                self.groupby + [self.time_label]
+            )[self.on].transform("sem")
+
+        if self.inoc_size_label is not None:
+            mean_col = f"{self.inoc_size_label}{self._INOC_MEAN_SUFFIX}"
+            sigma_col = f"{self.inoc_size_label}{self._INOC_SIGMA_SUFFIX}"
+            grouped = data.groupby(self.groupby)[self.inoc_size_label]
+            data[mean_col] = grouped.transform("mean")
+            data[sigma_col] = grouped.transform("std")
+
+        return super().analyze(data)
+
+    # ------------------------------------------------------------------ #
+    # Required fit hooks
+    # ------------------------------------------------------------------ #
+    def _initial_guess(self, group: pd.DataFrame) -> list[float]:
+        """Heuristic initial guess for ``[v, s0, lam, alpha]``."""
+        g = group.sort_values(self.time_label)
+        y = g[self.on].to_numpy(dtype=float)
+        t = g[self.time_label].to_numpy(dtype=float)
+
+        stats = self._inoc_stats(group)
+        if stats is not None:
+            s0_init = stats[0]
+        else:
+            s0_init = float(np.median(y[: max(2, len(y) // 4)]))
+
+        cut = max(2, int(0.4 * len(y)))
+        if len(y) - cut >= 2 and np.ptp(t[cut:]) > 0:
+            slope = float(np.polyfit(t[cut:], y[cut:], 1)[0])
+        else:
+            slope = 1.0
+        v_init = float(np.clip(slope, 1e-4, self.v_upper))
+
+        y_range = max(y.max() - s0_init, 1e-6)
+        crossing_mask = y > s0_init + 0.1 * y_range
+        if crossing_mask.any():
+            lam_init = float(t[np.argmax(crossing_mask)])
+        else:
+            lam_init = float(t[0])
+
+        alpha_init = 10.0
+        return [v_init, s0_init, lam_init, alpha_init]
+
+    def _bounds(self, group: pd.DataFrame) -> Tuple[List[float], List[float]]:
+        """Parameter bounds ``(lower, upper)`` for ``[v, s0, lam, alpha]``."""
+        t_max = float(group[self.time_label].max())
+        if t_max <= 0:
+            t_max = 1.0
+
+        stats = self._inoc_stats(group)
+        if stats is not None:
+            s0_upper = float(max(3.0 * stats[0], 1e-6))
+        else:
+            s0_upper = float(group[self.on].max()) or 1.0
+            if s0_upper <= 0:
+                s0_upper = 1.0
+
+        lower = [0.0, 0.0, 0.0, 2.0]
+        upper = [self.v_upper, s0_upper, t_max, 50.0]
+        return lower, upper
+
+    def _unpack_params(
+        self, x: np.ndarray, group: pd.DataFrame
+    ) -> Dict[Any, float]:
+        v, s0, lam, alpha = (float(x[i]) for i in range(4))
+        return {
+            LINEAR_SOFTPLUS_MODEL.v: v,
+            LINEAR_SOFTPLUS_MODEL.s0: s0,
+            LINEAR_SOFTPLUS_MODEL.lam: lam,
+            LINEAR_SOFTPLUS_MODEL.alpha: alpha,
+            LINEAR_SOFTPLUS_MODEL.smax: self._smax_for(group),
+            LINEAR_SOFTPLUS_MODEL.beta: float(self.beta),
+        }
+
+    def _predict_kwargs(self, row) -> Dict[str, float]:
+        return {
+            "v": row[LINEAR_SOFTPLUS_MODEL.v],
+            "s0": row[LINEAR_SOFTPLUS_MODEL.s0],
+            "lam": row[LINEAR_SOFTPLUS_MODEL.lam],
+            "alpha": row[LINEAR_SOFTPLUS_MODEL.alpha],
+            "smax": row[LINEAR_SOFTPLUS_MODEL.smax],
+            "beta": row[LINEAR_SOFTPLUS_MODEL.beta],
+        }
+
+    def _hover_fields(self) -> List[Tuple[str, Any, str]]:
+        return [
+            ("v", LINEAR_SOFTPLUS_MODEL.v, ".4f"),
+            ("s0", LINEAR_SOFTPLUS_MODEL.s0, ".3f"),
+            ("lambda", LINEAR_SOFTPLUS_MODEL.lam, ".3f"),
+            ("alpha", LINEAR_SOFTPLUS_MODEL.alpha, ".2f"),
+            ("smax", LINEAR_SOFTPLUS_MODEL.smax, ".3f"),
+            ("RMSE", MODEL_METRICS.RMSE, ".4f"),
+        ]

--- a/src/phenotypic/analysis/_log_growth_model.py
+++ b/src/phenotypic/analysis/_log_growth_model.py
@@ -1,33 +1,14 @@
-import itertools
-from typing import Any, Callable, Dict, List, Literal, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Literal, Tuple
 
-import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import scipy.optimize as optimize
-from joblib import delayed, Parallel
-from sklearn.metrics import (
-    mean_absolute_error,
-    mean_squared_error,
-    root_mean_squared_error,
-)
 
 from phenotypic.analysis.abc_ import ModelFitter
-from phenotypic.tools_.measurement_info_ import LOG_GROWTH_MODEL
-
-if TYPE_CHECKING:
-    import plotly.graph_objects as go
+from phenotypic.tools_.measurement_info_ import LOG_GROWTH_MODEL, MODEL_METRICS
 
 
 class LogGrowthModel(ModelFitter):
-    r"""
-    Represents a log growth model fitter.
-
-    This class defines methods and attributes to configure and fit logarithmic
-    growth models to grouped data. It provides functionality for analyzing and
-    visualizing the fitted models as well as exposing the results for further
-    processing.
+    r"""Logistic-growth model fitter with regularized least-squares objective.
 
     Logistic Kinetics Model:
 
@@ -75,10 +56,6 @@ class LogGrowthModel(ModelFitter):
         lam (float): The penalty factor applied to growth rates.
         beta (float): The maximum penalty factor applied to the carrying
             capacity.
-        loss (Literal["linear"]): The loss calculation method used for fitting.
-        verbose (bool): A flag to enable or disable detailed logging.
-        time_label (str): The column name representing the time dimension
-            in the input data.
         Kmax_label (str | None): The column name for the maximum carrying capacity
             values, if provided.
     """
@@ -91,613 +68,74 @@ class LogGrowthModel(ModelFitter):
             groupby: List[str],
             time_label: str = "Metadata_Time",
             agg_func: Callable | str | list | dict | None = "mean",
-            lam=1.2,
-            beta=2,
+            lam: float = 1.2,
+            beta: float = 2,
             Kmax_label: str | None = None,
             loss: Literal["linear"] = "linear",
             verbose: bool = False,
             n_jobs: int = 1,
     ):
-        """
-        This class initializes parameters for a data processing or modeling procedure.
-        It takes configuration arguments for handling data grouping, time management,
-        aggregation, penalties, loss calculation, and verbosity.
+        """Initialize the log-growth fitter.
 
         Args:
-            on (str): The target variable or column to process.
-            groupby (List[str]): The columns that define the grouping structure.
-            time_label (str): Column name that represents time in the data. Defaults to
-                'Metadata_Time'.
-            agg_func (Callable | str | list | dict | None): Aggregation function(s) to
-                apply to grouped data. Parameter is fed to
-
-                    `pandas.DataFrame.groupby.agg()`. Defaults to 'mean'.
-            lam: The regularization factor applied to growth rates. Defaults to 1.2.
-            beta: The penalty factor applied to the relative difference
-                between carrying capacity and the last value. Defaults to 2.
-            Kmax_label (str | None): Column name that provides maximum K value for
-                processing. Defaults to None.
-            loss (Literal["linear"]): Loss calculation method to apply. Defaults to
-                "linear".
-            verbose (bool): If True, enables detailed logging for process execution.
-                Defaults to False.
-            n_jobs (int): Number of parallel jobs to execute. Defaults to 1.
+            on: Target column (population-size measurement) to fit.
+            groupby: Columns defining the per-fit grouping structure.
+            time_label: Column name representing time. Defaults to
+                ``"Metadata_Time"``.
+            agg_func: Aggregation function fed to ``DataFrame.groupby.agg()``.
+                Defaults to ``"mean"``.
+            lam: Regularization factor applied to the maximum specific
+                growth rate and initial population size. Defaults to 1.2.
+            beta: Penalty factor applied to the relative difference
+                between ``K`` and the largest observed measurement.
+                Defaults to 2.
+            Kmax_label: Optional column providing a per-group upper bound
+                on ``K``. When omitted, the observed maximum of ``on`` is
+                used.
+            loss: Loss method passed through to
+                :func:`scipy.optimize.least_squares`. Defaults to
+                ``"linear"``.
+            verbose: If ``True``, enables the optimizer's verbose output.
+            n_jobs: Number of parallel workers for per-group fits.
         """
-        super().__init__(on=on, groupby=groupby, agg_func=agg_func, num_workers=n_jobs)
+        super().__init__(
+            on=on,
+            groupby=groupby,
+            time_label=time_label,
+            agg_func=agg_func,
+            num_workers=n_jobs,
+            loss=loss,
+            verbose=verbose,
+        )
         self.lam = lam
         self.beta = beta
-        self.loss = loss
-        self.verbose = verbose
-
-        self.time_label = time_label
         self.Kmax_label = Kmax_label
 
-    def analyze(self, data: pd.DataFrame) -> pd.DataFrame:
-        data: pd.DataFrame = data.copy(deep=True)
-        data.loc[:, self.time_label] = self._ensure_float_array(
-                data.loc[:, self.time_label]
-        )
-        self._latest_measurements = data
-
-        apply2group_kwargs = dict(
-                groupby_names=self.groupby,
-                model=self.__class__.model_func,
-                time_label=self.time_label,
-                size_label=self.on,
-                Kmax_label=self.Kmax_label,
-                lam=self.lam,
-                beta=self.beta,
-                loss=self.loss,
-                verbose=self.verbose,
-        )
-
-        # aggregate so that only one sample per timepoint
-        agg_dict = {self.on: self.agg_func}
-        if self.Kmax_label is not None:
-            agg_dict[self.Kmax_label] = (
-                "max"  # Use max for Kmax as it's a carrying capacity
-            )
-
-        agg_data = data.groupby(
-                by=self.groupby + [self.time_label], as_index=False
-        ).agg(agg_dict)
-
-        # Create groups
-        grouped = agg_data.groupby(by=self.groupby, as_index=True)
-        if self.n_jobs == 1:
-            model_res = []
-            for key, group in grouped:
-                model_res.append(
-                        self.__class__._apply2group_func(key, group,
-                                                         **apply2group_kwargs)
-                )
-        else:
-            model_res = Parallel(n_jobs=self.n_jobs)(
-                    delayed(self.__class__._apply2group_func)(
-                            key, group, **apply2group_kwargs
-                    )
-                    for key, group in grouped
-            )
-        self._latest_model_scores = pd.concat(model_res, axis=0).reset_index(drop=False)
-
-        self._latest_model_scores.insert(
-                loc=len(self._latest_model_scores.columns),
-                column=LOG_GROWTH_MODEL.LAM,
-                value=self.lam,
-        )
-
-        self._latest_model_scores.insert(
-                loc=len(self._latest_model_scores.columns),
-                column=LOG_GROWTH_MODEL.BETA,
-                value=self.beta,
-        )
-        return self._latest_model_scores
-
-    def show(self,
-             tmax: int | float | None = None,
-             criteria: Dict[str, Union[Any, List[Any]]] | None = None,
-             figsize=(6, 4),
-             cmap: str | None = "tab20",
-             legend=True,
-             ax: plt.Axes = None,
-             **kwargs,
-             ) -> Tuple[plt.Figure, plt.Axes]:
-        """
-        Visualizes model predictions alongside measurements, allowing optional
-        filtering by specified criteria and plotting configuration.
-
-        Args:
-            tmax (int | float | None, optional): The maximum time value for plotting. If
-                set to None, the maximum time value will be determined from the data
-                automatically.
-            criteria (Dict[str, Union[Any, List[Any]]] | None, optional): A dictionary
-                specifying filtering criteria for data selection. When provided, only
-                data matching the criteria will be used for plotting.
-            figsize (tuple, optional): A tuple specifying the size of the figure.
-                Defaults to (6, 4).
-            cmap (str | None, optional): A string representing either a matplotlib colormap name
-                or a single color (e.g., 'red', '#FF0000'). If a matplotlib colormap is provided,
-                colors will be cycled through it. If a single color is provided, all lines will
-                use that color. Defaults to 'tab20'.
-            legend (bool, optional): A boolean that controls whether a legend is
-                displayed on the plot. Defaults to True.
-            ax (plt.Axes, optional): A matplotlib Axes object on which to plot. If not
-                provided, a new figure and axes object will be created.
-            **kwargs: Additional matplotlib parameters to customize the plot. Common options include:
-                - dpi: Figure resolution (default 100)
-                - facecolor: Figure background color
-                - edgecolor: Figure edge color
-                - line_width: Line width for prediction lines
-                - marker_size: Size of data point markers
-                - elinewidth: Error bar line width
-                - capsize: Error bar cap size
-                - title: Custom figure title
-                - xlabel: Custom x-axis label
-                - ylabel: Custom y-axis label
-                - legend_loc: Legend location (default 'best')
-                - legend_fontsize: Font size for legend
-
-        Returns:
-            Tuple[plt.Figure, plt.Axes]: A tuple containing the matplotlib Figure and
-                Axes objects used for plotting.
-
-        Raises:
-            KeyError: If the group keys for model results and measurements do not
-                align, or if specified columns are missing from the input data.
-        """
-        # Extract figure-level kwargs
-        fig_kwargs = {
-            k: v for k, v in kwargs.items() if k in ("dpi", "facecolor", "edgecolor")
-        }
-        line_width = kwargs.get("line_width", None)
-        marker_size = kwargs.get("marker_size", None)
-        elinewidth = kwargs.get("elinewidth", 1)
-        capsize = kwargs.get("capsize", 2)
-        legend_loc = kwargs.get("legend_loc", "best")
-        legend_fontsize = kwargs.get("legend_fontsize", None)
-
-        if ax is None:
-            fig, ax = plt.subplots(figsize=figsize, **fig_kwargs)
-        else:
-            fig = ax.get_figure()
-
-        # apply filtering of data table
-        if criteria is not None:
-            filtered_model_scores = self._filter_by(
-                    df=self._latest_model_scores, criteria=criteria, copy=True
-            )
-            filtered_measurements = self._filter_by(
-                    df=self._latest_measurements, criteria=criteria, copy=True
-            )
-        else:
-            filtered_model_scores = self._latest_model_scores.copy()
-            filtered_measurements = self._latest_measurements.copy()
-
-        if filtered_measurements.empty:
-            import warnings
-
-            warnings.warn("No data found matching the criteria. Returning empty plot.")
-            return fig, ax
-
-        model_groups = {
-            model_keys: model_groups
-            for model_keys, model_groups in filtered_model_scores.groupby(
-                    by=self.groupby
-            )
-        }
-        meas_groups = {
-            meas_keys: meas_groups
-            for meas_keys, meas_groups in filtered_measurements.groupby(by=self.groupby)
-        }
-
-        filtered_measurements.loc[:, self.time_label] = self._ensure_float_array(
-                filtered_measurements.loc[:, self.time_label]
-        )
-
-        timepoints = pd.Series(filtered_measurements.loc[:, self.time_label].unique())
-
-        step = np.abs(np.mean(timepoints.sort_values().diff().dropna()))
-
-        if np.isnan(step) or step <= 0:
-            step = 1.0
-
-        tmax = timepoints.max() if tmax is None else tmax
-
-        t = np.arange(stop=tmax + step, step=step)
-
-        # Handle both colormap and single color
-        if cmap is not None:
-            try:
-                # Try to get as a matplotlib colormap
-                cmap_obj = matplotlib.colormaps[cmap] if isinstance(cmap, str) else cmap
-                color_iter = itertools.cycle(
-                        cmap_obj(
-                                np.linspace(
-                                        start=0, stop=1, num=len(model_groups),
-                                        endpoint=False
-                                )
-                        )
-                )
-            except (ValueError, AttributeError):
-                # If it fails, treat as a single color and create infinite cycle
-                color_iter = itertools.cycle([cmap])
-        else:
-            # Default to None for automatic matplotlib coloring
-            color_iter = itertools.cycle([None] * len(model_groups))
-
-        for model_key, model_group in model_groups.items():
-            curr_meas = meas_groups[model_key]
-            curr_color = next(color_iter)
-            y_pred = self.model_func(
-                    t=t,
-                    r=model_group[LOG_GROWTH_MODEL.R_FIT].iloc[0],
-                    K=model_group[LOG_GROWTH_MODEL.K_FIT].iloc[0],
-                    N0=model_group[LOG_GROWTH_MODEL.N0_FIT].iloc[0],
-            )
-            plot_kwargs = {}
-            if curr_color is not None:
-                plot_kwargs["color"] = curr_color
-            if line_width is not None:
-                plot_kwargs["linewidth"] = line_width
-            ax.plot(t, y_pred, **plot_kwargs)
-
-            curr_time_groups = curr_meas.groupby(by=self.time_label)
-            curr_mean = curr_time_groups[self.on].mean()
-            curr_stddev = curr_time_groups[self.on].std()
-            curr_stderr = curr_stddev / np.sqrt(curr_time_groups[self.on].count())
-
-            # noinspection PyUnresolvedReferences
-            errorbar_kwargs = {
-                "x"         : curr_mean.index.values,
-                "y"         : curr_mean.values,
-                "yerr"      : curr_stderr,
-                "fmt"       : "o",
-                "elinewidth": elinewidth,
-                "capsize"   : capsize,
-                "label"     : kwargs.get("label", f"{model_key[0]}"),
-            }
-            if curr_color is not None:
-                errorbar_kwargs["color"] = curr_color
-                errorbar_kwargs["ecolor"] = curr_color
-            if marker_size is not None:
-                errorbar_kwargs["markersize"] = marker_size
-            ax.errorbar(**errorbar_kwargs)
-        if legend:
-            # Create legend and check if it fits within the axes
-            legend_kwargs = {"loc": legend_loc}
-            if legend_fontsize is not None:
-                legend_kwargs["fontsize"] = legend_fontsize
-            legend_obj = ax.legend(**legend_kwargs)
-
-            # Draw to ensure bounding boxes are available
-            fig.canvas.draw()
-
-            # Get bounding boxes in display coordinates
-            legend_bbox = legend_obj.get_window_extent()
-            axes_bbox = ax.get_window_extent()
-
-            # Check if legend is larger than axes (with small tolerance)
-            if (
-                    legend_bbox.width > axes_bbox.width * 0.95
-                    or legend_bbox.height > axes_bbox.height * 0.95
-            ):
-                legend_obj.remove()
-
-        ax.set_title("mean±SE")
-        return fig, ax
-
-    def dash(
-            self,
-            tmax: int | float | None = None,
-            criteria: Dict[str, Union[Any, List[Any]]] | None = None,
-            figsize=(6, 4),
-            cmap: str | None = "tab20",
-            legend: bool = True,
-            **kwargs,
-    ) -> "go.Figure":
-        """Interactive Plotly visualization of model predictions and measurements.
-
-        Produces the same plot as ``show()`` but as an interactive Plotly figure
-        with hover information displaying fitted model parameters.
-
-        Args:
-            tmax (int | float | None): Maximum time value for the prediction
-                curve. If None, determined from the data automatically.
-            criteria (Dict[str, Union[Any, List[Any]]] | None): Filtering
-                criteria for data selection. Only matching data is plotted.
-            figsize (tuple): Figure size as ``(width_inches, height_inches)``.
-                Converted to pixels at 100 dpi. Defaults to (6, 4).
-            cmap (str | None): Matplotlib colormap name for series colors, or a
-                single color string. If None, uses the Okabe-Ito palette.
-                Defaults to ``"tab20"``.
-            legend (bool): Whether to display the legend. Defaults to True.
-            **kwargs: Additional layout options:
-                - title: Custom figure title
-                - xlabel: Custom x-axis label
-                - ylabel: Custom y-axis label
-
-        Returns:
-            plotly.graph_objects.Figure: An interactive Plotly figure.
-
-        Raises:
-            ImportError: If plotly is not installed.
-        """
-        from phenotypic.tools_._plotly_helpers import _require_plotly
-        _require_plotly()
-        import plotly.graph_objects as go
-
-        # --- Filter data ---
-        if criteria is not None:
-            filtered_model_scores = self._filter_by(
-                    df=self._latest_model_scores, criteria=criteria, copy=True
-            )
-            filtered_measurements = self._filter_by(
-                    df=self._latest_measurements, criteria=criteria, copy=True
-            )
-        else:
-            filtered_model_scores = self._latest_model_scores.copy()
-            filtered_measurements = self._latest_measurements.copy()
-
-        if filtered_measurements.empty:
-            import warnings
-            warnings.warn(
-                "No data found matching the criteria. Returning empty figure."
-            )
-            return go.Figure()
-
-        # --- Group data ---
-        model_groups = {
-            model_keys: model_group
-            for model_keys, model_group in filtered_model_scores.groupby(
-                    by=self.groupby
-            )
-        }
-        meas_groups = {
-            meas_keys: meas_group
-            for meas_keys, meas_group in filtered_measurements.groupby(
-                    by=self.groupby
-            )
-        }
-
-        filtered_measurements.loc[:, self.time_label] = self._ensure_float_array(
-                filtered_measurements.loc[:, self.time_label]
-        )
-
-        timepoints = pd.Series(
-            filtered_measurements.loc[:, self.time_label].unique()
-        )
-        step = np.abs(np.mean(timepoints.sort_values().diff().dropna()))
-
-        if np.isnan(step) or step <= 0:
-            step = 1.0
-
-        tmax = timepoints.max() if tmax is None else tmax
-        t = np.arange(stop=tmax + step, step=step)
-
-        # --- Color cycling ---
-        _OKABE_ITO = [
-            "#003660", "#E69F00", "#56B4E9",
-            "#009E73", "#0072B2", "#CC79A7",
-        ]
-
-        if cmap is not None:
-            try:
-                import matplotlib
-                cmap_obj = matplotlib.colormaps[cmap]
-                colors = [
-                    f"rgb({int(c[0] * 255)},{int(c[1] * 255)},{int(c[2] * 255)})"
-                    for c in cmap_obj(
-                        np.linspace(0, 1, max(len(model_groups), 1),
-                                    endpoint=False)
-                    )
-                ]
-                color_iter = itertools.cycle(colors)
-            except (ValueError, KeyError):
-                color_iter = itertools.cycle([cmap])
-        else:
-            color_iter = itertools.cycle(_OKABE_ITO)
-
-        # --- Build traces ---
-        fig = go.Figure()
-
-        for model_key, model_group in model_groups.items():
-            curr_meas = meas_groups[model_key]
-            curr_color = next(color_iter)
-
-            r_val = model_group[LOG_GROWTH_MODEL.R_FIT].iloc[0]
-            K_val = model_group[LOG_GROWTH_MODEL.K_FIT].iloc[0]
-            N0_val = model_group[LOG_GROWTH_MODEL.N0_FIT].iloc[0]
-            mu_max = model_group[LOG_GROWTH_MODEL.GROWTH_RATE].iloc[0]
-            rmse_val = model_group[LOG_GROWTH_MODEL.RMSE].iloc[0]
-
-            y_pred = self.model_func(t=t, r=r_val, K=K_val, N0=N0_val)
-
-            if isinstance(model_key, tuple):
-                label = ", ".join(str(k) for k in model_key)
-            else:
-                label = str(model_key)
-
-            # Model prediction line
-            fig.add_trace(go.Scatter(
-                x=t,
-                y=y_pred,
-                mode="lines",
-                name=label,
-                line=dict(color=curr_color, width=2),
-                legendgroup=label,
-                hovertemplate=(
-                    "<b>%{fullData.name}</b><br>"
-                    "Time: %{x:.1f}<br>"
-                    "Predicted: %{y:.2f}<br>"
-                    "<extra>"
-                    f"r = {r_val:.4f}<br>"
-                    f"K = {K_val:.2f}<br>"
-                    f"N\u2080 = {N0_val:.2f}<br>"
-                    f"\u00b5max = {mu_max:.4f}<br>"
-                    f"RMSE = {rmse_val:.4f}"
-                    "</extra>"
-                ),
-            ))
-
-            # Data points with error bars
-            curr_time_groups = curr_meas.groupby(by=self.time_label)
-            curr_mean = curr_time_groups[self.on].mean()
-            curr_stddev = curr_time_groups[self.on].std()
-            curr_count = curr_time_groups[self.on].count()
-            curr_stderr = curr_stddev / np.sqrt(curr_count)
-
-            time_vals = curr_mean.index.values.astype(float)
-            mean_vals = curr_mean.values
-            stderr_vals = np.nan_to_num(curr_stderr.values, nan=0.0)
-
-            fig.add_trace(go.Scatter(
-                x=time_vals,
-                y=mean_vals,
-                mode="markers",
-                name=label,
-                legendgroup=label,
-                showlegend=False,
-                marker=dict(
-                    color=curr_color,
-                    size=7,
-                    line=dict(color=curr_color, width=1),
-                ),
-                error_y=dict(
-                    type="data",
-                    array=stderr_vals,
-                    visible=True,
-                    color=curr_color,
-                    thickness=1,
-                ),
-                customdata=np.column_stack([
-                    time_vals, mean_vals, stderr_vals,
-                ]),
-                hovertemplate=(
-                    "<b>%{fullData.name}</b><br>"
-                    "Time: %{customdata[0]:.1f}<br>"
-                    "Mean: %{customdata[1]:.2f}<br>"
-                    "SE: %{customdata[2]:.4f}<br>"
-                    "<extra></extra>"
-                ),
-            ))
-
-        # --- Layout ---
-        width_px = figsize[0] * 100
-        height_px = figsize[1] * 100
-
-        fig.update_layout(
-            width=width_px,
-            height=height_px,
-            title=dict(
-                text=kwargs.get("title", "mean\u00b1SE"),
-                font=dict(
-                    family="DM Sans, system-ui, sans-serif",
-                    size=13,
-                    color="#003660",
-                ),
-            ),
-            xaxis=dict(
-                title=dict(
-                    text=kwargs.get("xlabel", self.time_label),
-                    font=dict(
-                        family="DM Mono, Courier New, monospace",
-                        size=9,
-                        color="#2e3a4e",
-                    ),
-                ),
-                tickfont=dict(
-                    family="DM Mono, Courier New, monospace",
-                    size=8,
-                    color="#8892a4",
-                ),
-                gridcolor="#e8ecf2",
-                gridwidth=1,
-                linecolor="#dde3ed",
-                linewidth=1.5,
-                showline=True,
-                zeroline=False,
-            ),
-            yaxis=dict(
-                title=dict(
-                    text=kwargs.get("ylabel", self.on),
-                    font=dict(
-                        family="DM Mono, Courier New, monospace",
-                        size=9,
-                        color="#2e3a4e",
-                    ),
-                ),
-                tickfont=dict(
-                    family="DM Mono, Courier New, monospace",
-                    size=8,
-                    color="#8892a4",
-                ),
-                gridcolor="#e8ecf2",
-                gridwidth=1,
-                linecolor="#dde3ed",
-                linewidth=1.5,
-                showline=True,
-                zeroline=False,
-            ),
-            plot_bgcolor="#ffffff",
-            paper_bgcolor="#f5f7fa",
-            showlegend=legend,
-            legend=dict(
-                font=dict(
-                    family="DM Sans, system-ui, sans-serif",
-                    size=11,
-                    color="#2e3a4e",
-                ),
-            ),
-            hovermode="closest",
-        )
-
-        return fig
-
-    def results(self) -> pd.DataFrame:
-        return self._latest_model_scores
-
+    # ------------------------------------------------------------------ #
+    # Model math
+    # ------------------------------------------------------------------ #
     @staticmethod
-    def model_func(t: np.ndarray[float] | float, r: float, K: float, N0: float):
-        """
-        Computes the value of the logistic growth model for a given time point or array
-        of time points and parameters. The logistic model describes growth that
-        initially increases exponentially but levels off as the population reaches
-        a carrying capacity.
+    def model_func(t: np.ndarray | float, r: float, K: float, N0: float):
+        r"""Logistic growth model evaluated at ``t``.
 
-        This static method uses the formula:
-            N(t) = K / (1 + [(K - N0) / N0] * exp(-r * t))
-
-        Where:
-            t: Time (independent variable, can be scalar or array).
-            r: Growth rate.
-            K: Carrying capacity (maximum population size).
-            N0: Initial population size.
+        .. math:: N(t) = K / \left(1 + \frac{K - N_0}{N_0} e^{-rt}\right)
 
         Args:
-            t (np.ndarray[float] | float): Time at which the population is calculated.
-                Can be a single value or an array of values.
-            r (float): Growth rate of the population.
-            K (float): Carrying capacity or the maximum population size.
-            N0 (float): Initial population size at time t=0.
+            t: Time at which the population is evaluated (scalar or array).
+            r: Growth rate.
+            K: Carrying capacity.
+            N0: Initial population size at ``t = 0``.
 
         Returns:
-            float | np.ndarray[float]: The computed population size at the given time
-            or array of times based on the logistic growth model.
+            Population size at ``t``. Scalar when ``t`` is scalar,
+            otherwise an array.
         """
         a = (K - N0) / N0
         return K / (1 + a * np.exp(-r * t))
 
     @staticmethod
-    def _loss_func(params, t, y, lam, beta):
-        r"""
-        Computes a combined loss which includes both the residuals from the predicted
-        values using a logarithmic growth model, a regularization term, and a penalty
-        for deviations in the carrying capacity (K).
-
-        To solve for the parameters, we use the following loss function with the
-        SciPy linear least-squares solver:
-        .. math::
-            \phi=\left(\frac{dN}{dt}\right)^2 + N_0^2
+    def _loss_func(params, t, y, lam, beta):  # type: ignore[override]
+        r"""Regularized residuals for :func:`scipy.optimize.least_squares`.
 
         .. math::
 
@@ -707,171 +145,112 @@ class LogGrowthModel(ModelFitter):
            + \lambda\left(\left(\frac{dN}{dt}\right)^2 + N_0^2\right)
            + \beta \frac{\lvert K - N_{n} \rvert}{N_{n}}
 
-        :math:`\lambda`: regularization term for growth rate and initial population size
-
-        :math:`\beta`: penalty term for deviations in carrying capacity relative to
-            the largest measurement
-
-        The function calculates the residuals (difference between actual and predicted
-        values), a regularization term based on biological parameters, and applies a
-        penalty proportional to the deviation of K from the observed maximum value
-        within the data. A small epsilon is used to ensure numerical stability during
-        penalty calculation.
-
-        Note:
-            This function is used in conjunction with the `scipy.optimize.least_squares`
-            solver to find the parameters
-
         Args:
-            params (List[float]): A list containing the parameters [r, K, N0], where:
-                r: Growth rate.
-                K: Carrying capacity.
-                N0: Initial population size.
-            t (Union[List[float], np.ndarray]): Time points for the observations.
-            y (Union[List[float], np.ndarray, pd.Series]): Observed population size
-                corresponding to the time points t. Can be a list, numpy array, or
-                pandas.Series object.
-            lam (float): Regularization parameter for the specific growth rate and
-                initial population size.
-            beta (float): Scaling parameter for the K-based penalty.
+            params: ``[r, K, N0]`` — candidate parameter vector.
+            t: Time points for the observations.
+            y: Observed population sizes (list, ndarray, or pandas Series).
+            lam: Regularization weight for ``dN/dt`` and ``N0``.
+            beta: Scaling factor for the ``K`` vs. observed-max penalty.
 
         Returns:
-            np.ndarray: A combined loss array consisting of the residuals,
-                regularization sterms, and the K penalty. The array includes:
-                - Residuals: Difference between observed and model-predicted values.
-                - Regularization terms: Regularization applied to dN/dt and N0.
-                - K Penalty: Penalty term applied based on the deviation of K.
+            Flat residual vector consumed by
+            :func:`scipy.optimize.least_squares`.
         """
         r, K, N0 = params
 
-        # cost function (residuals)
-        cost_func = y - LogGrowthModel.model_func(t=t, r=r, K=K, N0=N0)
+        residuals = y - LogGrowthModel.model_func(t=t, r=r, K=K, N0=N0)
 
-        # regularization term
         dN_dt = r * K / 4
         reg_term = np.sqrt(lam) * np.array([dN_dt, N0])
 
-        # K-based penalty
         if hasattr(y, "values"):
             y_array = y.values
         else:
             y_array = np.array(y)
 
-        # Get the value of the last time point
-        # assumes thats the best indicator for carrying capacity
+        # Last-timepoint value as the best proxy for carrying capacity.
         y_max_observed = y_array[np.argmax(t)]
 
-        # Numerical stability epsilon
         epsilon = 1e-8 * np.median(np.abs(y_array[y_array > 0]))
         if epsilon == 0 or np.isnan(epsilon):
             epsilon = 1e-8
 
-        # Relative K penalty
         K_penalty_weight = np.sqrt(beta)
         K_penalty = (
-                K_penalty_weight * np.abs(K - y_max_observed) / (
-                    y_max_observed + epsilon)
+                K_penalty_weight * np.abs(K - y_max_observed)
+                / (y_max_observed + epsilon)
         )
 
-        return np.hstack(
-                [cost_func, reg_term, [K_penalty]]
-        )  # K_penalty is scalar so we need to wrap in a list
+        return np.hstack([residuals, reg_term, [K_penalty]])
 
-    @staticmethod
-    def _apply2group_func(
-            group_key: tuple,
-            group: pd.DataFrame,
-            groupby_names: tuple,
-            model: Callable,
-            time_label: str,
-            size_label: str,
-            Kmax_label: str | None,
-            lam: float,
-            beta: float,
-            loss: Literal["linear"],
-            verbose: bool,
-    ):
-        t_data = group[time_label]
-        size_data = group[size_label]
+    # ------------------------------------------------------------------ #
+    # Fit hooks
+    # ------------------------------------------------------------------ #
+    def _kmax_for(self, group: pd.DataFrame) -> float:
+        if self.Kmax_label is None:
+            return group[self.on].max()
+        k_max = group[self.Kmax_label].max()
+        if pd.isna(k_max):
+            return group[self.on].max() + 1
+        return k_max
 
-        i_min = 0
-        n_samples = len(t_data)
+    def _initial_guess(self, group: pd.DataFrame) -> List[float]:
+        return [1e-5, group[self.on].max(), 0]
+
+    def _bounds(
+            self, group: pd.DataFrame
+    ) -> Tuple[List[float], List[float]]:
+        size_data = group[self.on]
 
         r_min, r_max = 1e-5, np.inf
-
         N0_min, N0_max = 0, size_data.min()
-
-        # Safety check since max bound must be higher than min bound
+        # Ensure upper > lower per least_squares contract.
         if N0_max <= N0_min:
             N0_max = N0_min + 1
 
-        if Kmax_label is None:
-            K_max = size_data.max()
-        else:
-            K_max = group[Kmax_label].max()
+        K_min = 0
+        K_max = self._kmax_for(group)
 
-        if K_max == np.nan:
-            K_max = size_data.max() + 1
+        return [r_min, K_min, N0_min], [r_max, K_max, N0_max]
 
-        K_min = i_min
+    def _unpack_params(
+            self, x: np.ndarray, group: pd.DataFrame
+    ) -> Dict[Any, float]:
+        r, K, N0 = float(x[0]), float(x[1]), float(x[2])
+        return {
+            LOG_GROWTH_MODEL.R_FIT: r,
+            LOG_GROWTH_MODEL.K_FIT: K,
+            LOG_GROWTH_MODEL.N0_FIT: N0,
+            LOG_GROWTH_MODEL.GROWTH_RATE: (r * K) / 4,
+            LOG_GROWTH_MODEL.K_MAX: self._kmax_for(group),
+        }
 
-        try:
-            out = optimize.least_squares(
-                    LogGrowthModel._loss_func,
-                    x0=[1e-5, size_data.max(), 0],
-                    bounds=(
-                        [r_min, K_min, N0_min],
-                        [r_max, K_max, N0_max],
-                    ),
-                    kwargs=dict(
-                            t=t_data,
-                            y=size_data,
-                            lam=lam,
-                            beta=beta,
-                    ),
-                    verbose=verbose,
-                    method="trf",
-                    loss=loss,
-            )
-            x = out.x
-            fitted_values = {
-                LOG_GROWTH_MODEL.R_FIT      : x[0],
-                LOG_GROWTH_MODEL.K_FIT      : x[1],
-                LOG_GROWTH_MODEL.N0_FIT     : x[2],
-                LOG_GROWTH_MODEL.GROWTH_RATE: (x[0] * x[1]) / 4,
-            }
+    def _predict_kwargs(self, row) -> Dict[str, float]:
+        return {
+            "r": row[LOG_GROWTH_MODEL.R_FIT],
+            "K": row[LOG_GROWTH_MODEL.K_FIT],
+            "N0": row[LOG_GROWTH_MODEL.N0_FIT],
+        }
 
-            y_pred = LogGrowthModel.model_func(t=t_data, r=x[0], K=x[1], N0=x[2])
-            model_stats = {
-                LOG_GROWTH_MODEL.K_MAX      : K_max,
-                LOG_GROWTH_MODEL.NUM_SAMPLES: n_samples,
-                LOG_GROWTH_MODEL.LOSS       : out.cost,
-                LOG_GROWTH_MODEL.STATUS     : out.status,
-                LOG_GROWTH_MODEL.MAE        : mean_absolute_error(size_data, y_pred),
-                LOG_GROWTH_MODEL.MSE        : mean_squared_error(size_data, y_pred),
-                LOG_GROWTH_MODEL.RMSE       : root_mean_squared_error(size_data,
-                                                                      y_pred),
-            }
-        except ValueError:
-            fitted_values = {
-                LOG_GROWTH_MODEL.R_FIT      : np.nan,
-                LOG_GROWTH_MODEL.K_FIT      : np.nan,
-                LOG_GROWTH_MODEL.N0_FIT     : np.nan,
-                LOG_GROWTH_MODEL.GROWTH_RATE: np.nan,
-            }
+    def _hyperparam_kwargs(self) -> Dict[str, float]:
+        return {"lam": self.lam, "beta": self.beta}
 
-            model_stats = {
-                LOG_GROWTH_MODEL.K_MAX      : np.nan,
-                LOG_GROWTH_MODEL.NUM_SAMPLES: np.nan,
-                LOG_GROWTH_MODEL.LOSS       : np.nan,
-                LOG_GROWTH_MODEL.STATUS     : np.nan,
-                LOG_GROWTH_MODEL.MAE        : np.nan,
-                LOG_GROWTH_MODEL.MSE        : np.nan,
-                LOG_GROWTH_MODEL.RMSE       : np.nan,
-            }
+    def _post_fit_columns(self) -> Dict[Any, float]:
+        return {
+            LOG_GROWTH_MODEL.LAM: self.lam,
+            LOG_GROWTH_MODEL.BETA: self.beta,
+        }
 
-        return pd.DataFrame(
-                data={**fitted_values, **model_stats},
-                index=pd.MultiIndex.from_tuples(tuples=[group_key],
-                                                names=groupby_names),
-        )
+    def _extra_agg_columns(self) -> Dict[str, Any]:
+        if self.Kmax_label is None:
+            return {}
+        return {self.Kmax_label: "max"}
+
+    def _hover_fields(self) -> List[Tuple[str, Any, str]]:
+        return [
+            ("r", LOG_GROWTH_MODEL.R_FIT, ".4f"),
+            ("K", LOG_GROWTH_MODEL.K_FIT, ".2f"),
+            ("N₀", LOG_GROWTH_MODEL.N0_FIT, ".2f"),
+            ("µmax", LOG_GROWTH_MODEL.GROWTH_RATE, ".4f"),
+            ("RMSE", MODEL_METRICS.RMSE, ".4f"),
+        ]

--- a/src/phenotypic/analysis/abc_/_model_fitter.py
+++ b/src/phenotypic/analysis/abc_/_model_fitter.py
@@ -1,40 +1,704 @@
 from __future__ import annotations
 
 import abc
+import itertools
 from abc import ABC
-from typing import TYPE_CHECKING, Callable, List
+from typing import Any, Callable, Dict, List, Literal, Tuple, TYPE_CHECKING, Union
 
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
+import scipy.optimize as optimize
+from joblib import Parallel, delayed
+from sklearn.metrics import (
+    mean_absolute_error,
+    mean_squared_error,
+    r2_score,
+    root_mean_squared_error,
+)
 
-if TYPE_CHECKING:
-    pass
+from phenotypic.tools_.measurement_info_ import MODEL_METRICS
 
 from ._set_analyzer import SetAnalyzer
 
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
+
 
 class ModelFitter(SetAnalyzer, ABC):
+    """Template base class for grouped least-squares model fitting.
+
+    Subclasses provide the mathematical model (`model_func`), the loss
+    function (`_loss_func`), an initial parameter guess, parameter bounds,
+    and a small set of hooks that let the base class drive ``analyze``,
+    ``show``, ``dash``, and ``results`` without hard-coding parameter
+    names.
+
+    Fit-quality metrics (MAE, MSE, RMSE, R²) and optimizer diagnostics
+    (loss, status, sample count) are emitted under the shared
+    :class:`MODEL_METRICS` category so that every ``ModelFitter`` subclass
+    produces a consistent set of diagnostic columns.
+
+    Attributes:
+        time_label (str): Column name representing the independent
+            variable (typically time).
+        loss (Literal["linear"]): Loss calculation method passed through
+            to :func:`scipy.optimize.least_squares`.
+        verbose (bool): Whether to print detailed optimizer output.
+    """
+
+    _measurement_info_class: type
+
     def __init__(
         self,
         on: str,
         groupby: List[str],
+        time_label: str = "Metadata_Time",
         agg_func: Callable | str | list | dict | None = "mean",
         *,
         num_workers: int = 1,
+        loss: Literal["linear"] = "linear",
+        verbose: bool = False,
     ):
         super().__init__(
             on=on, groupby=groupby, agg_func=agg_func, num_workers=num_workers
         )
         self._latest_model_scores: pd.DataFrame = pd.DataFrame()
+        self.time_label = time_label
+        self.loss = loss
+        self.verbose = verbose
 
+    # ------------------------------------------------------------------ #
+    # Abstract model math — subclasses must implement
+    # ------------------------------------------------------------------ #
     @staticmethod
     @abc.abstractmethod
-    def model_func():
-        """The mathematical model that should be implemented. The first parameter should be the independent variable
-        such as time"""
+    def model_func(*args, **kwargs):
+        """Mathematical model. First positional argument is the independent variable."""
         pass
 
-    @staticmethod
+    def _params_to_model_kwargs(self, params) -> Dict[str, float]:
+        """Map the raw optimizer vector to kwargs for ``model_func``.
+
+        Required only when the subclass relies on the default MSE
+        :meth:`_loss_func`. Subclasses that override ``_loss_func`` with a
+        fully custom residual (e.g. regularized) do not need to implement
+        this hook.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} uses the default MSE loss but does "
+            f"not implement `_params_to_model_kwargs`. Either implement "
+            f"it to map the optimizer vector to `model_func` kwargs, or "
+            f"override `_loss_func` with a fully custom residual."
+        )
+
+    def _loss_func(self, params, t, y, **_):
+        """Default residual vector — plain MSE against the observations.
+
+        ``scipy.optimize.least_squares`` minimizes half the sum of
+        squared residuals, so returning ``y - model_func(t, …)`` here
+        yields the standard MSE fit. Subclasses may override this to add
+        regularization, penalties, or robust loss terms (see
+        :class:`LogGrowthModel` for an example).
+
+        Extra keyword arguments are accepted but ignored so that any
+        hyperparameters supplied by :meth:`_hyperparam_kwargs` can be
+        safely forwarded without needing to match this default
+        signature.
+        """
+        return y - self.model_func(t, **self._params_to_model_kwargs(params))
+
+    # ------------------------------------------------------------------ #
+    # Abstract fit hooks — subclasses must implement
+    # ------------------------------------------------------------------ #
     @abc.abstractmethod
-    def _loss_func():
-        """The loss function that should be implemented for linear least squares fitting"""
+    def _initial_guess(self, group: pd.DataFrame) -> list[float]:
+        """Initial guess ``x0`` for :func:`scipy.optimize.least_squares`."""
         pass
+
+    @abc.abstractmethod
+    def _bounds(
+        self, group: pd.DataFrame
+    ) -> Tuple[List[float], List[float]]:
+        """Return ``(lower, upper)`` bounds for the fitted parameters."""
+        pass
+
+    @abc.abstractmethod
+    def _unpack_params(
+        self, x: np.ndarray, group: pd.DataFrame
+    ) -> Dict[Any, float]:
+        """Map optimizer output to a dict keyed by MeasurementInfo members.
+
+        Must include every fitted/derived parameter column produced by this
+        model (e.g. ``r``, ``K``, ``N0``, ``µmax`` for log-growth). May also
+        include per-group bounds that should be preserved in results
+        (e.g. ``K_max``).
+        """
+        pass
+
+    @abc.abstractmethod
+    def _predict_kwargs(self, row) -> Dict[str, float]:
+        """Build kwargs for ``model_func(t, **kwargs)`` from a results row.
+
+        ``row`` is any mapping keyed by MeasurementInfo members — a dict
+        produced by ``_unpack_params`` at fit time, or a ``pd.Series``
+        drawn from the results DataFrame at plot time.
+        """
+        pass
+
+    # ------------------------------------------------------------------ #
+    # Optional hooks — subclasses may override
+    # ------------------------------------------------------------------ #
+    def _hyperparam_kwargs(self) -> Dict[str, float]:
+        """Extra kwargs forwarded to ``_loss_func`` (e.g. regularization)."""
+        return {}
+
+    def _prepare_group(self, group: pd.DataFrame) -> pd.DataFrame:
+        """Preprocess one group before ``t``/``y`` extraction.
+
+        Default returns the group unchanged. Subclasses override to
+        filter rows (e.g. saturation pruning) or synthesize helper
+        columns needed by the loss function.
+        """
+        return group
+
+    def _extra_loss_kwargs(self, group: pd.DataFrame) -> Dict[str, Any]:
+        """Per-group kwargs forwarded to :meth:`_loss_func`.
+
+        Default is an empty dict. Subclasses override to inject
+        per-group arrays (e.g. weight vectors, per-group bounds)
+        that ``_hyperparam_kwargs`` cannot express because it is
+        group-agnostic. Merged *after* ``_hyperparam_kwargs`` so
+        per-group entries win on collision.
+        """
+        return {}
+
+    def _post_fit_columns(self) -> Dict[Any, float]:
+        """Scalar metadata columns appended to the results DataFrame.
+
+        Useful for recording hyperparameters (e.g. ``lam``, ``beta``) that
+        are constant across every fitted group.
+        """
+        return {}
+
+    def _extra_agg_columns(self) -> Dict[str, Any]:
+        """Additional ``{column: agg_func}`` entries for per-timepoint aggregation."""
+        return {}
+
+    def _hover_fields(self) -> List[Tuple[str, Any, str]]:
+        """``(label, column_key, format_spec)`` entries for the Plotly hover tooltip."""
+        return []
+
+    # ------------------------------------------------------------------ #
+    # Shared metrics / NaN templates
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _compute_metrics(y_true, y_pred) -> Dict[Any, float]:
+        """Compute the generic fit-quality metrics shared by all subclasses."""
+        return {
+            MODEL_METRICS.MAE: mean_absolute_error(y_true, y_pred),
+            MODEL_METRICS.MSE: mean_squared_error(y_true, y_pred),
+            MODEL_METRICS.RMSE: root_mean_squared_error(y_true, y_pred),
+            MODEL_METRICS.R2: r2_score(y_true, y_pred),
+        }
+
+    def _nan_fit_columns(self) -> Dict[Any, float]:
+        """NaN-filled row used when ``least_squares`` raises ``ValueError``.
+
+        Covers every MeasurementInfo member declared on the subclass plus
+        the full :class:`MODEL_METRICS` set (metrics + diagnostics). Any
+        column supplied by ``_post_fit_columns`` is excluded so the
+        constant hyperparameter value is preserved rather than overwritten
+        with NaN.
+        """
+        mi = self._measurement_info_class
+        post_keys = set(self._post_fit_columns().keys())
+        model_cols = {
+            member: np.nan
+            for member in mi.__members__.values()
+            if member not in post_keys
+        }
+        metric_cols = {
+            member: np.nan for member in MODEL_METRICS.__members__.values()
+        }
+        return {**model_cols, **metric_cols}
+
+    # ------------------------------------------------------------------ #
+    # Per-group fit — replaces the old `_apply2group_func` boilerplate
+    # ------------------------------------------------------------------ #
+    def _apply2group_func(self, group_key, group: pd.DataFrame) -> pd.DataFrame:
+        """Fit one group and return a single-row DataFrame of results."""
+        group = self._prepare_group(group)
+        t_data = group[self.time_label]
+        y_data = group[self.on]
+
+        loss_kwargs: Dict[str, Any] = {
+            **self._hyperparam_kwargs(),
+            **self._extra_loss_kwargs(group),
+        }
+
+        try:
+            out = optimize.least_squares(
+                self._loss_func,
+                x0=self._initial_guess(group),
+                bounds=self._bounds(group),
+                kwargs=dict(t=t_data, y=y_data, **loss_kwargs),
+                verbose=int(self.verbose),
+                method="trf",
+                loss=self.loss,
+            )
+            fitted = self._unpack_params(out.x, group)
+            y_pred = self.model_func(t=t_data, **self._predict_kwargs(fitted))
+            row: Dict[Any, float] = {
+                **fitted,
+                **self._compute_metrics(y_data, y_pred),
+                MODEL_METRICS.LOSS: out.cost,
+                MODEL_METRICS.STATUS: out.status,
+                MODEL_METRICS.NUM_SAMPLES: len(t_data),
+            }
+        except ValueError:
+            row = self._nan_fit_columns()
+
+        return pd.DataFrame(
+            data=row,
+            index=pd.MultiIndex.from_tuples(
+                tuples=[group_key], names=self.groupby
+            ),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Orchestration
+    # ------------------------------------------------------------------ #
+    def analyze(self, data: pd.DataFrame) -> pd.DataFrame:
+        """Fit the model to every group of ``data`` and return the results.
+
+        Standard template: copy, float-coerce the time column, aggregate
+        to one sample per timepoint, dispatch per-group fits (serial or
+        parallel via :class:`joblib.Parallel`), concatenate, and append
+        constant hyperparameter columns from ``_post_fit_columns``.
+        """
+        data = data.copy(deep=True)
+        data.loc[:, self.time_label] = self._ensure_float_array(
+            data.loc[:, self.time_label]
+        )
+        self._latest_measurements = data
+
+        agg_dict: Dict[str, Any] = {self.on: self.agg_func}
+        agg_dict.update(self._extra_agg_columns())
+
+        agg_data = data.groupby(
+            by=self.groupby + [self.time_label], as_index=False
+        ).agg(agg_dict)
+
+        grouped = agg_data.groupby(by=self.groupby, as_index=True)
+        if self.n_jobs == 1:
+            model_res = [
+                self._apply2group_func(key, group) for key, group in grouped
+            ]
+        else:
+            model_res = Parallel(n_jobs=self.n_jobs)(
+                delayed(self._apply2group_func)(key, group)
+                for key, group in grouped
+            )
+
+        results = pd.concat(model_res, axis=0).reset_index(drop=False)
+
+        for col_key, val in self._post_fit_columns().items():
+            results.insert(loc=len(results.columns), column=col_key, value=val)
+
+        self._latest_model_scores = results
+        return self._latest_model_scores
+
+    def results(self) -> pd.DataFrame:
+        """Return the most recent fit results produced by :meth:`analyze`."""
+        return self._latest_model_scores
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers for plotting
+    # ------------------------------------------------------------------ #
+    def _filter_for_plot(
+        self, criteria: Dict[str, Union[Any, List[Any]]] | None
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        """Apply `criteria` (if any) to both the model-scores and measurements frames."""
+        if criteria is not None:
+            model_scores = self._filter_by(
+                df=self._latest_model_scores, criteria=criteria, copy=True
+            )
+            measurements = self._filter_by(
+                df=self._latest_measurements, criteria=criteria, copy=True
+            )
+        else:
+            model_scores = self._latest_model_scores.copy()
+            measurements = self._latest_measurements.copy()
+        return model_scores, measurements
+
+    def _time_axis(
+        self, timepoints: pd.Series, tmax: int | float | None
+    ) -> Tuple[np.ndarray, float]:
+        """Derive a uniform time axis for plotting prediction curves."""
+        step = np.abs(np.mean(timepoints.sort_values().diff().dropna()))
+        if np.isnan(step) or step <= 0:
+            step = 1.0
+        upper = timepoints.max() if tmax is None else tmax
+        return np.arange(stop=upper + step, step=step), step
+
+    def _format_hover(self, row) -> str:
+        """Join `_hover_fields` into a Plotly ``<extra>`` payload."""
+        parts = []
+        for label, col_key, fmt in self._hover_fields():
+            val = row[col_key]
+            parts.append(f"{label} = {format(val, fmt)}")
+        return "<br>".join(parts)
+
+    # ------------------------------------------------------------------ #
+    # Matplotlib visualization
+    # ------------------------------------------------------------------ #
+    def show(
+        self,
+        tmax: int | float | None = None,
+        criteria: Dict[str, Union[Any, List[Any]]] | None = None,
+        figsize=(6, 4),
+        cmap: str | None = "tab20",
+        legend: bool = True,
+        ax: plt.Axes | None = None,
+        **kwargs,
+    ) -> Tuple[plt.Figure, plt.Axes]:
+        """Plot model predictions alongside measurements with optional filtering.
+
+        Args:
+            tmax: Upper bound of the prediction curve. If ``None``, uses
+                the maximum observed time.
+            criteria: Column/value filter applied to both fitted results
+                and raw measurements before plotting.
+            figsize: Matplotlib figure size. Used only when ``ax`` is None.
+            cmap: Matplotlib colormap name, a single color string, or
+                ``None`` for matplotlib's default color cycle.
+            legend: Whether to render a legend (auto-removed if larger
+                than the axes).
+            ax: Existing axes to draw into. A new figure is created when
+                omitted.
+            **kwargs: Styling overrides — ``dpi``, ``facecolor``,
+                ``edgecolor``, ``line_width``, ``marker_size``,
+                ``elinewidth``, ``capsize``, ``legend_loc``,
+                ``legend_fontsize``, ``label``.
+
+        Returns:
+            A ``(Figure, Axes)`` pair.
+        """
+        fig_kwargs = {
+            k: v for k, v in kwargs.items() if k in ("dpi", "facecolor", "edgecolor")
+        }
+        line_width = kwargs.get("line_width", None)
+        marker_size = kwargs.get("marker_size", None)
+        elinewidth = kwargs.get("elinewidth", 1)
+        capsize = kwargs.get("capsize", 2)
+        legend_loc = kwargs.get("legend_loc", "best")
+        legend_fontsize = kwargs.get("legend_fontsize", None)
+
+        if ax is None:
+            fig, ax = plt.subplots(figsize=figsize, **fig_kwargs)
+        else:
+            fig = ax.get_figure()
+
+        model_scores, measurements = self._filter_for_plot(criteria)
+
+        if measurements.empty:
+            import warnings
+
+            warnings.warn("No data found matching the criteria. Returning empty plot.")
+            return fig, ax
+
+        measurements.loc[:, self.time_label] = self._ensure_float_array(
+            measurements.loc[:, self.time_label]
+        )
+
+        model_groups = {
+            keys: grp for keys, grp in model_scores.groupby(by=self.groupby)
+        }
+        meas_groups = {
+            keys: grp for keys, grp in measurements.groupby(by=self.groupby)
+        }
+
+        timepoints = pd.Series(measurements.loc[:, self.time_label].unique())
+        t, _ = self._time_axis(timepoints, tmax)
+
+        if cmap is not None:
+            try:
+                cmap_obj = (
+                    matplotlib.colormaps[cmap] if isinstance(cmap, str) else cmap
+                )
+                color_iter = itertools.cycle(
+                    cmap_obj(
+                        np.linspace(
+                            start=0, stop=1, num=len(model_groups), endpoint=False
+                        )
+                    )
+                )
+            except (ValueError, AttributeError):
+                color_iter = itertools.cycle([cmap])
+        else:
+            color_iter = itertools.cycle([None] * len(model_groups))
+
+        for model_key, model_group in model_groups.items():
+            curr_meas = meas_groups[model_key]
+            curr_color = next(color_iter)
+            row = model_group.iloc[0]
+            y_pred = self.model_func(t=t, **self._predict_kwargs(row))
+
+            plot_kwargs: Dict[str, Any] = {}
+            if curr_color is not None:
+                plot_kwargs["color"] = curr_color
+            if line_width is not None:
+                plot_kwargs["linewidth"] = line_width
+            ax.plot(t, y_pred, **plot_kwargs)
+
+            curr_time_groups = curr_meas.groupby(by=self.time_label)
+            curr_mean = curr_time_groups[self.on].mean()
+            curr_stddev = curr_time_groups[self.on].std()
+            curr_stderr = curr_stddev / np.sqrt(curr_time_groups[self.on].count())
+
+            # noinspection PyUnresolvedReferences
+            errorbar_kwargs: Dict[str, Any] = {
+                "x": curr_mean.index.values,
+                "y": curr_mean.values,
+                "yerr": curr_stderr,
+                "fmt": "o",
+                "elinewidth": elinewidth,
+                "capsize": capsize,
+                "label": kwargs.get("label", f"{model_key[0]}"),
+            }
+            if curr_color is not None:
+                errorbar_kwargs["color"] = curr_color
+                errorbar_kwargs["ecolor"] = curr_color
+            if marker_size is not None:
+                errorbar_kwargs["markersize"] = marker_size
+            ax.errorbar(**errorbar_kwargs)
+
+        if legend:
+            legend_kwargs: Dict[str, Any] = {"loc": legend_loc}
+            if legend_fontsize is not None:
+                legend_kwargs["fontsize"] = legend_fontsize
+            legend_obj = ax.legend(**legend_kwargs)
+
+            fig.canvas.draw()
+            legend_bbox = legend_obj.get_window_extent()
+            axes_bbox = ax.get_window_extent()
+            if (
+                legend_bbox.width > axes_bbox.width * 0.95
+                or legend_bbox.height > axes_bbox.height * 0.95
+            ):
+                legend_obj.remove()
+
+        ax.set_title("mean±SE")
+        return fig, ax
+
+    # ------------------------------------------------------------------ #
+    # Plotly visualization
+    # ------------------------------------------------------------------ #
+    def dash(
+        self,
+        tmax: int | float | None = None,
+        criteria: Dict[str, Union[Any, List[Any]]] | None = None,
+        figsize=(6, 4),
+        cmap: str | None = "tab20",
+        legend: bool = True,
+        **kwargs,
+    ) -> "go.Figure":
+        """Interactive Plotly version of :meth:`show`.
+
+        Hover tooltips are populated from ``_hover_fields`` so subclasses
+        can expose whichever fitted parameters and metrics are most
+        meaningful for their model.
+
+        Raises:
+            ImportError: If ``plotly`` is not installed.
+        """
+        from phenotypic.tools_._plotly_helpers import _require_plotly
+
+        _require_plotly()
+        import plotly.graph_objects as go
+
+        model_scores, measurements = self._filter_for_plot(criteria)
+
+        if measurements.empty:
+            import warnings
+
+            warnings.warn(
+                "No data found matching the criteria. Returning empty figure."
+            )
+            return go.Figure()
+
+        measurements.loc[:, self.time_label] = self._ensure_float_array(
+            measurements.loc[:, self.time_label]
+        )
+
+        model_groups = {
+            keys: grp for keys, grp in model_scores.groupby(by=self.groupby)
+        }
+        meas_groups = {
+            keys: grp for keys, grp in measurements.groupby(by=self.groupby)
+        }
+
+        timepoints = pd.Series(measurements.loc[:, self.time_label].unique())
+        t, _ = self._time_axis(timepoints, tmax)
+
+        _OKABE_ITO = [
+            "#003660", "#E69F00", "#56B4E9",
+            "#009E73", "#0072B2", "#CC79A7",
+        ]
+        if cmap is not None:
+            try:
+                cmap_obj = matplotlib.colormaps[cmap]
+                colors = [
+                    f"rgb({int(c[0] * 255)},{int(c[1] * 255)},{int(c[2] * 255)})"
+                    for c in cmap_obj(
+                        np.linspace(0, 1, max(len(model_groups), 1), endpoint=False)
+                    )
+                ]
+                color_iter = itertools.cycle(colors)
+            except (ValueError, KeyError):
+                color_iter = itertools.cycle([cmap])
+        else:
+            color_iter = itertools.cycle(_OKABE_ITO)
+
+        fig = go.Figure()
+
+        for model_key, model_group in model_groups.items():
+            curr_meas = meas_groups[model_key]
+            curr_color = next(color_iter)
+            row = model_group.iloc[0]
+
+            y_pred = self.model_func(t=t, **self._predict_kwargs(row))
+
+            if isinstance(model_key, tuple):
+                label = ", ".join(str(k) for k in model_key)
+            else:
+                label = str(model_key)
+
+            hover_extra = self._format_hover(row)
+
+            fig.add_trace(go.Scatter(
+                x=t,
+                y=y_pred,
+                mode="lines",
+                name=label,
+                line=dict(color=curr_color, width=2),
+                legendgroup=label,
+                hovertemplate=(
+                    "<b>%{fullData.name}</b><br>"
+                    "Time: %{x:.1f}<br>"
+                    "Predicted: %{y:.2f}<br>"
+                    f"<extra>{hover_extra}</extra>"
+                ),
+            ))
+
+            curr_time_groups = curr_meas.groupby(by=self.time_label)
+            curr_mean = curr_time_groups[self.on].mean()
+            curr_stddev = curr_time_groups[self.on].std()
+            curr_count = curr_time_groups[self.on].count()
+            curr_stderr = curr_stddev / np.sqrt(curr_count)
+
+            time_vals = curr_mean.index.values.astype(float)
+            mean_vals = curr_mean.values
+            stderr_vals = np.nan_to_num(curr_stderr.values, nan=0.0)
+
+            fig.add_trace(go.Scatter(
+                x=time_vals,
+                y=mean_vals,
+                mode="markers",
+                name=label,
+                legendgroup=label,
+                showlegend=False,
+                marker=dict(
+                    color=curr_color,
+                    size=7,
+                    line=dict(color=curr_color, width=1),
+                ),
+                error_y=dict(
+                    type="data",
+                    array=stderr_vals,
+                    visible=True,
+                    color=curr_color,
+                    thickness=1,
+                ),
+                customdata=np.column_stack([time_vals, mean_vals, stderr_vals]),
+                hovertemplate=(
+                    "<b>%{fullData.name}</b><br>"
+                    "Time: %{customdata[0]:.1f}<br>"
+                    "Mean: %{customdata[1]:.2f}<br>"
+                    "SE: %{customdata[2]:.4f}<br>"
+                    "<extra></extra>"
+                ),
+            ))
+
+        width_px = figsize[0] * 100
+        height_px = figsize[1] * 100
+
+        fig.update_layout(
+            width=width_px,
+            height=height_px,
+            title=dict(
+                text=kwargs.get("title", "mean±SE"),
+                font=dict(
+                    family="DM Sans, system-ui, sans-serif",
+                    size=13,
+                    color="#003660",
+                ),
+            ),
+            xaxis=dict(
+                title=dict(
+                    text=kwargs.get("xlabel", self.time_label),
+                    font=dict(
+                        family="DM Mono, Courier New, monospace",
+                        size=9,
+                        color="#2e3a4e",
+                    ),
+                ),
+                tickfont=dict(
+                    family="DM Mono, Courier New, monospace",
+                    size=8,
+                    color="#8892a4",
+                ),
+                gridcolor="#e8ecf2",
+                gridwidth=1,
+                linecolor="#dde3ed",
+                linewidth=1.5,
+                showline=True,
+                zeroline=False,
+            ),
+            yaxis=dict(
+                title=dict(
+                    text=kwargs.get("ylabel", self.on),
+                    font=dict(
+                        family="DM Mono, Courier New, monospace",
+                        size=9,
+                        color="#2e3a4e",
+                    ),
+                ),
+                tickfont=dict(
+                    family="DM Mono, Courier New, monospace",
+                    size=8,
+                    color="#8892a4",
+                ),
+                gridcolor="#e8ecf2",
+                gridwidth=1,
+                linecolor="#dde3ed",
+                linewidth=1.5,
+                showline=True,
+                zeroline=False,
+            ),
+            plot_bgcolor="#ffffff",
+            paper_bgcolor="#f5f7fa",
+            showlegend=legend,
+            legend=dict(
+                font=dict(
+                    family="DM Sans, system-ui, sans-serif",
+                    size=11,
+                    color="#2e3a4e",
+                ),
+            ),
+            hovermode="closest",
+        )
+
+        return fig

--- a/src/phenotypic/detect/_filamentous_fungi_detector.py
+++ b/src/phenotypic/detect/_filamentous_fungi_detector.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 import numpy as np
 import gc
 
@@ -22,12 +22,9 @@ from phenotypic.enhance import (
     PhaseCongruencyEnhancer,
 )
 
-from phenotypic.detect import (
-    TriangleDetector,
-    HysteresisDetector,
-)
+from phenotypic.detect import HysteresisDetector
 from phenotypic.detect._inoculum_detector import InoculumDetector
-from phenotypic.refine import MaskOpener, MaskCloser, GridSectionLargest
+from phenotypic.refine import GridSectionLargest
 
 from phenotypic.tools_.branch_pathfinding import (
     _apply_distance_gap_penalty_inplace,
@@ -56,11 +53,10 @@ class FilamentousFungiDetector(GridObjectDetector):
 
     Segment filamentous fungi in two stages: (1) detect compact inoculation
     centres with an ``inoculum_detector``, (2) capture the full hyphal
-    structure with an ``overall_detector`` or, when
-    ``enable_reconnection=True``, via phase-congruency-based branch detection
-    and Dijkstra reconnection. Filtered centre centroids seed a Euclidean
-    Voronoi partition that assigns every fungal pixel to its nearest colony,
-    with connectivity-based correction ensuring uniform labelling within
+    structure via phase-congruency-based branch detection and Dijkstra
+    reconnection. Filtered centre centroids seed a Euclidean Voronoi
+    partition that assigns every fungal pixel to its nearest colony, with
+    connectivity-based correction ensuring uniform labelling within
     connected components. For a full comparison see
     :doc:`/explanation/detection_strategies_compared`.
 
@@ -70,61 +66,58 @@ class FilamentousFungiDetector(GridObjectDetector):
             regions at inoculation points. Default uses an internal
             InoculumDetector + GridSectionLargest pipeline.
 
-        overall_detector: ObjectDetector or ImagePipeline that captures
-            complete fungal structures including spreading hyphae. Should
-            produce full-body masks with a lower threshold than the
-            inoculum detector. Ignored when *enable_reconnection* is True.
+        max_colony_radius_px: Largest colony radius (in pixels) the
+            detector should handle. Sizes scene-derived spatial
+            parameters (``gauss_sigma``, ``tile_size``, ``tile_overlap``)
+            for this worst case. Default 250.
+        min_branch_width_px: Narrowest hyphal branch width (in pixels) to
+            detect. Sizes signal-scale parameters
+            (``pct_min_wavelength``, ``mad_window``,
+            ``path_dilation_radius``, ``snr_margin``,
+            ``coherence_window_radius``). Default 3.
 
-        enable_reconnection: When True, replace the legacy
-            *overall_detector* path with dual-mask branch detection
-            (ContrastStretching + Gaussian subtraction + phase congruency)
-            followed by Dijkstra-based reconnection of fragmented hyphal
-            branches.
+        ignore_borders: If True, drops objects touching the image border
+            during hysteresis-threshold branch detection. Default True.
+        edge_noise_threshold: Noise threshold scaling factor for phase
+            congruency edge detection. Higher values are stricter
+            (reject more pixels as noise; preserve fewer thin hyphae).
+            Default 6.0.
+        reconnection_tolerance: IQR multiplier for path quality threshold
+            calibration. Higher values accept more reconnection paths
+            (may bridge genuinely-missing hyphae but risks over-merging).
+            Default 2.5.
+        max_gap_length: Maximum acceptable length (pixels) of a
+            suspicious cost stretch along a reconnection path. Paths
+            with longer bad stretches are rejected. Default 30.
+        border_margin_px: Border penalty buffer width in pixels.
+            Prevents reconnection paths from routing along image
+            borders. Default 50.
+        frag_reach_px: Maximum 2D distance (pixels) from a fragment's
+            boundary to the nearest routable (low-cost) pixel. Fragments
+            more isolated than this are dropped before Dijkstra routing,
+            since no plausible path could connect them. Default 10.
+        gap_crossing_penalty: Distance-gap penalty strength during
+            Dijkstra routing. Higher values make paths route around
+            low-PCT-energy gaps more aggressively. Default 4.0.
 
-        pct_n_orient: Number of orientations for phase congruency
-            computation. Typical range: 4--8. Default 6.
-        pct_min_wavelength: Minimum wavelength for log-Gabor filters.
-            Typical range: 2--6. Default 3.
-        pct_k: Noise threshold scaling factor for phase congruency.
-            Typical range: 1--5. Default 2.0.
-
-        gauss_sigma: Sigma for SubtractGaussian background subtraction.
-            Typical range: 10--100. Default 50.
-        gauss_n_iter: Number of SubtractGaussian iterations. Default 2.
-
-        morph_width: Disk radius for morphological open/close operations
-            on branch masks. Typical range: 1--5. Default 2.
-
-        beta: Exponent on anisotropy in the composite cost formula.
-            Default 2.0.
-        gamma: Weight of MAD penalty in the composite cost numerator.
-            Default 1.2.
-        r_coherence: Radius for orientation coherence computation.
-            Default 5.
-        mad_window: Window size for local MAD computation (must be odd).
-            Default 11.
-
-        r_screen: Screening radius for fragment pre-screening. Default 50.
-        delta: Dijkstra radial penalty factor for retreating steps.
-            Default 1.5.
-        quality_k: IQR multiplier for path quality threshold calibration.
-            Higher values are more permissive. Default 1.5.
-        window_cost: Sliding window size in pixels for the windowed cost
-            metric. Default 20.
-        edge_margin: Border penalty width in pixels. Prevents paths from
-            routing along image edges. Default 20.
-        gap_penalty_alpha: Distance-gap penalty strength. Higher values
-            impose stronger distance gating on PCT energy gaps.
-            Default 2.0.
-        snr_margin: Extra radius beyond *path_dilation_radius* for the
-            SNR background ring in the grayscale SNR filter. Default 3.
-        path_dilation_radius: Disk radius for dilating reconnection paths.
-            Default 3.
-
-        tile_size: Side length of square tiles for tiled Dijkstra
-            processing. Default 1200.
-        tile_overlap: Overlap in pixels between adjacent tiles.
-            Default 100.
+        gauss_sigma: Override for SubtractGaussian sigma. If None
+            (default), derived from ``max_colony_radius_px``.
+        tile_size: Override for tile side length. If None (default),
+            derived from ``max_colony_radius_px``.
+        tile_overlap: Override for tile overlap. If None (default),
+            derived from ``max_colony_radius_px``.
+        pct_min_wavelength: Override for log-Gabor minimum wavelength.
+            If None (default), derived from ``min_branch_width_px``.
+        mad_window: Override for local MAD window size (must be odd).
+            If None (default), derived from ``min_branch_width_px``.
+        path_dilation_radius: Override for dilating reconnection paths.
+            If None (default), derived from ``min_branch_width_px``.
+        snr_margin: Override for SNR background ring radius beyond
+            ``path_dilation_radius``. If None (default), derived from
+            ``min_branch_width_px``.
+        coherence_window_radius: Override for orientation coherence
+            computation radius. If None (default), derived from
+            ``min_branch_width_px``.
 
     Returns:
         Image: Input image with ``objmask`` set to a binary fungal mask
@@ -132,10 +125,10 @@ class FilamentousFungiDetector(GridObjectDetector):
         colony receives a unique integer label via Voronoi assignment.
 
     Raises:
-        TypeError: If *inoculum_detector* or *overall_detector* are not
-            ObjectDetector or ImagePipeline instances.
-        ValueError: If no centres are detected, no overall structure is
-            detected, or no centres overlap with the overall structure
+        TypeError: If *inoculum_detector* is not an ObjectDetector or
+            ImagePipeline instance.
+        ValueError: If no centres are detected, no branch structure is
+            detected, or no centres overlap with the branch structure
             after filtering.
 
     Best For:
@@ -174,114 +167,129 @@ class FilamentousFungiDetector(GridObjectDetector):
             ops=[InoculumDetector(), GridSectionLargest()]
     )
 
+    # Scene-derivation multipliers (private; override in subclass to tune).
+    # Raw param = multiplier * scene knob (rounded to int where required).
+    _GAUSS_SIGMA_PER_R: float = 1.2
+    _TILE_SIZE_PER_R: float = 4.8
+    _TILE_OVERLAP_PER_R: float = 2.4
+    _WAVELENGTH_PER_W: float = 2.0
+    _MAD_WINDOW_PER_W: float = 2.0
+    _PATH_DILATION_PER_W: float = 0.5
+    _SNR_MARGIN_PER_W: float = 0.5
+    _COHERENCE_RADIUS_PER_W: float = 5.0
+
+    # Algorithm internals (hidden from __init__; override in subclass to tune).
+    beta: float = 2.0          # anisotropy exponent in composite cost
+    gamma: float = 1.2         # MAD penalty weight in composite cost numerator
+    gauss_n_iter: int = 2      # SubtractGaussian iterations
+    delta: float = 1.0         # Dijkstra radial retreat penalty
+    pct_n_orient: int = 8      # phase congruency angular resolution
+
     def __init__(
             self,
             inoculum_detector: Union[ObjectDetector, 'ImagePipeline', None] = None,
-            overall_detector: Union[ObjectDetector, 'ImagePipeline', None] = None,
-            # Reconnection parameters
+            # ── Scene parameters ──
+            max_colony_radius_px: float = 250.0,
+            min_branch_width_px: int = 3,
+            # ── Explicit user knobs ──
             ignore_borders: bool = True,
-            enable_reconnection: bool = True,
-            pct_n_orient: int = 8,
-            pct_min_wavelength: float = 5.0,
-            pct_k: float = 6.0,
-            gauss_sigma: float = 300.0,
-            gauss_n_iter: int = 2,
-            morph_width: int = 5,
-            beta: float = 2.0,
-            gamma: float = 1.2,
-            r_coherence: int = 12,
-            mad_window: int = 7,
-            r_screen: int = 10,
-            delta: float = 1.0,
-            quality_k: float = 2.5,
-            window_cost: int = 30,
-            edge_margin: int = 50,
-            gap_penalty_alpha: float = 4.0,
-            snr_margin: int = 3,
-            path_dilation_radius: int = 2,
-            tile_size: int = 1200,
-            tile_overlap: int = 600,
+            edge_noise_threshold: float = 6.0,
+            reconnection_tolerance: float = 2.5,
+            max_gap_length: int = 30,
+            border_margin_px: int = 50,
+            frag_reach_px: int = 10,
+            gap_crossing_penalty: float = 4.0,
+            *,
+            # ── Scene-derivation overrides (None → auto-derived) ──
+            gauss_sigma: Optional[float] = None,
+            tile_size: Optional[int] = None,
+            tile_overlap: Optional[int] = None,
+            pct_min_wavelength: Optional[float] = None,
+            mad_window: Optional[int] = None,
+            path_dilation_radius: Optional[int] = None,
+            snr_margin: Optional[int] = None,
+            coherence_window_radius: Optional[int] = None,
     ):
         super().__init__()
 
         # Type validation (allow None for serialization/deserialization)
         from phenotypic import ImagePipeline
 
-        if inoculum_detector is not None and not isinstance(inoculum_detector,
-                                                            (ObjectDetector,
-                                                             ImagePipeline)):
+        if inoculum_detector is not None and not isinstance(
+                inoculum_detector, (ObjectDetector, ImagePipeline)
+        ):
             raise TypeError(
-                    "inoculum_detector must be an ObjectDetector or ImagePipeline instance, "
+                    "inoculum_detector must be an ObjectDetector or "
+                    "ImagePipeline instance, "
                     f"got {type(inoculum_detector).__name__}"
-            )
-        if overall_detector is not None and not isinstance(overall_detector,
-                                                           (ObjectDetector,
-                                                            ImagePipeline)):
-            raise TypeError(
-                    "overall_detector must be an ObjectDetector or ImagePipeline instance, "
-                    f"got {type(overall_detector).__name__}"
             )
 
         self.inoculum_detector = inoculum_detector if inoculum_detector \
             else self.__center_pipe
 
-        if overall_detector is None:
-            overall_detector = ImagePipeline(
-                    ops=[
-                        ContrastStretching(),
-                        SubtractGaussian(
-                                sigma=gauss_sigma, n_iter=gauss_n_iter,
-                        ),
-                        TriangleDetector(),
-                        MaskOpener(
-                                shape="disk", width=morph_width, n_iter=1,
-                        ),
-                        MaskCloser(
-                                shape="disk", width=morph_width, n_iter=2,
-                        ),
-                        MaskOpener(
-                                shape="disk", width=morph_width, n_iter=1,
-                        ),
-                        MaskCloser(
-                                shape="disk", width=morph_width, n_iter=2,
-                        ),
-                    ]
-            )
-        self.overall_detector = overall_detector
+        # ── Scene knobs ──
+        self.max_colony_radius_px = float(max_colony_radius_px)
+        self.min_branch_width_px = int(min_branch_width_px)
 
-        # Reconnection parameters
+        # ── Explicit user knobs ──
         self.ignore_borders = ignore_borders
-        self.enable_reconnection = enable_reconnection
-        self.pct_n_orient = pct_n_orient
-        self.pct_min_wavelength = pct_min_wavelength
-        self.pct_k = pct_k
-        self.gauss_sigma = gauss_sigma
-        self.gauss_n_iter = gauss_n_iter
-        self.morph_width = morph_width
-        self.beta = beta
-        self.gamma = gamma
-        self.r_coherence = r_coherence
-        self.mad_window = mad_window
-        self.r_screen = r_screen
-        self.delta = delta
-        self.quality_k = quality_k
-        self.window_cost = window_cost
-        self.edge_margin = edge_margin
-        self.gap_penalty_alpha = gap_penalty_alpha
-        self.snr_margin = snr_margin
-        self.path_dilation_radius = path_dilation_radius
-        self.tile_size = tile_size
-        self.tile_overlap = tile_overlap
+        self.edge_noise_threshold = edge_noise_threshold
+        self.reconnection_tolerance = reconnection_tolerance
+        self.max_gap_length = max_gap_length
+        self.border_margin_px = border_margin_px
+        self.frag_reach_px = frag_reach_px
+        self.gap_crossing_penalty = gap_crossing_penalty
+
+        # ── Scene-derived params (apply overrides if supplied) ──
+        R = self.max_colony_radius_px
+        w = self.min_branch_width_px
+
+        self.gauss_sigma = (
+            float(gauss_sigma) if gauss_sigma is not None
+            else self._GAUSS_SIGMA_PER_R * R
+        )
+        self.tile_size = (
+            int(tile_size) if tile_size is not None
+            else int(round(self._TILE_SIZE_PER_R * R))
+        )
+        self.tile_overlap = (
+            int(tile_overlap) if tile_overlap is not None
+            else int(round(self._TILE_OVERLAP_PER_R * R))
+        )
+
+        self.pct_min_wavelength = (
+            float(pct_min_wavelength) if pct_min_wavelength is not None
+            else self._WAVELENGTH_PER_W * w
+        )
+        # mad_window must be odd; +1 on an even 2w keeps it odd.
+        _mad_default = int(round(self._MAD_WINDOW_PER_W * w)) + 1
+        if _mad_default % 2 == 0:
+            _mad_default += 1
+        self.mad_window = (
+            int(mad_window) if mad_window is not None else _mad_default
+        )
+        self.path_dilation_radius = (
+            int(path_dilation_radius) if path_dilation_radius is not None
+            else max(1, int(round(self._PATH_DILATION_PER_W * w)))
+        )
+        self.snr_margin = (
+            int(snr_margin) if snr_margin is not None
+            else max(2, int(round(self._SNR_MARGIN_PER_W * w)))
+        )
+        self.coherence_window_radius = (
+            int(coherence_window_radius) if coherence_window_radius is not None
+            else int(round(self._COHERENCE_RADIUS_PER_W * w))
+        )
 
     def _operate(self, image: 'GridImage') -> 'GridImage':
         """Detect and separate filamentous fungi using grid-based Voronoi partition.
 
         Algorithm:
         1. Run inoculum_detector to find fungal centers (full labeled regions)
-        2. Detect branches via dual-mask pipeline (reconnection) or overall_detector (legacy)
+        2. Detect branches via dual-mask pipeline (Gaussian + phase congruency)
         3. Filter centers, create grid markers, Voronoi assign with grid seeds
         4. Identify pseudo-fragments (per-label CCs not overlapping inoculum)
-        5. Dijkstra reconnection of pseudo-fragments (reconnection mode only)
+        5. Dijkstra reconnection of pseudo-fragments
         6. Final Voronoi partition with grid markers
         7. Set objmap with assignment results
         """
@@ -313,67 +321,41 @@ class FilamentousFungiDetector(GridObjectDetector):
         self._log_memory_usage("after center detection")
 
         # ── PHASE 2: BRANCH DETECTION ───────────────────────────────
-        if self.enable_reconnection:
-            # ContrastStretching-enhanced copy for dual-mask detection
-            enhanced_work = image.copy()
-            ContrastStretching().apply(enhanced_work, inplace=True)
-            enhanced_arr = enhanced_work.detect_mat[:]
-            enhanced_gray = enhanced_work.gray[:]  # capture before destructive call
+        # ContrastStretching-enhanced copy for dual-mask detection
+        enhanced_work = image.copy()
+        ContrastStretching().apply(enhanced_work, inplace=True)
+        enhanced_arr = enhanced_work.detect_mat[:]
+        enhanced_gray = enhanced_work.gray[:]  # capture before destructive call
 
-            # Mask A: Gauss branches (destructive: modifies enhanced_work in place)
-            bg_removed_arr = self._subtract_background(enhanced_work)
-            del enhanced_work  # no longer valid after destructive call
+        # Mask A: Gauss branches (destructive: modifies enhanced_work in place)
+        bg_removed_arr = self._subtract_background(enhanced_work)
+        del enhanced_work  # no longer valid after destructive call
 
-            # Mask B: PCT branches
-            pct_result = PhaseCongruencyEnhancer(
-                    n_orient=self.pct_n_orient,
-                    min_wavelength=self.pct_min_wavelength,
-                    k=self.pct_k,
-            )._phasecong3(enhanced_arr)
+        # Mask B: PCT branches
+        pct_result = PhaseCongruencyEnhancer(
+                n_orient=self.pct_n_orient,
+                min_wavelength=self.pct_min_wavelength,
+                k=self.edge_noise_threshold,
+        )._phasecong3(enhanced_arr)
 
-            # Overlap filter: keep Gauss labels with any PCT overlap
-            fragmented_overall_detect_mat = self._combine_bg_removed_with_pct(
-                    bg_removed_arr=bg_removed_arr,
-                    pct_sum=pct_result.pc_sum,
-            )
+        # Overlap filter: keep Gauss labels with any PCT overlap
+        fragmented_overall_detect_mat = self._combine_bg_removed_with_pct(
+                bg_removed_arr=bg_removed_arr,
+                pct_sum=pct_result.pc_sum,
+        )
 
-            _fragmented_detect_img = image.copy()
-            _fragmented_detect_img.detect_mat[:] = fragmented_overall_detect_mat
-            HysteresisDetector(
-                    low="triangle",
-                    high="otsu",
-                    ignore_zeros=False,
-                    ignore_borders=self.ignore_borders
-            ).apply(_fragmented_detect_img, inplace=True)
-            overall_objmask = _fragmented_detect_img.objmask[:]
-            del _fragmented_detect_img
+        _fragmented_detect_img = image.copy()
+        _fragmented_detect_img.detect_mat[:] = fragmented_overall_detect_mat
+        HysteresisDetector(
+                low="triangle",
+                high="otsu",
+                ignore_zeros=False,
+                ignore_borders=self.ignore_borders
+        ).apply(_fragmented_detect_img, inplace=True)
+        overall_objmask = _fragmented_detect_img.objmask[:]
+        del _fragmented_detect_img
 
-            self._log_memory_usage("after dual-mask branch detection")
-        else:
-            # Legacy path
-            if self.overall_detector is None:
-                raise ValueError(
-                        "overall_detector is required but not set. "
-                        "Provide a detector when creating FilamentousFungiDetector."
-                )
-            if isinstance(self.overall_detector, ImagePipeline):
-                overall_result = self.overall_detector.apply(image, inplace=False,
-                                                             reset=False)
-            else:
-                overall_result = self.overall_detector.apply(image, inplace=False)
-
-            overall_objmask = overall_result.objmask[:]
-
-            if overall_result.num_objects == 0:
-                raise ValueError(
-                        "No overall structure detected by overall_detector. Cannot "
-                        "create assignment mask. Try adjusting overall_detector "
-                        "parameters."
-                )
-
-            branch_labels = None
-
-            self._log_memory_usage("after overall detection")
+        self._log_memory_usage("after dual-mask branch detection")
 
         # ── PHASE 3: CENTER FILTERING + GRID VORONOI ─────────────────
 
@@ -385,9 +367,9 @@ class FilamentousFungiDetector(GridObjectDetector):
 
         if overlap_objmap.max() == 0:
             raise ValueError(
-                    "No centers overlap with overall structure after filtering. "
-                    "Check that inoculum_detector and overall_detector are compatible "
-                    "(detecting the same objects)."
+                    "No centers overlap with detected branch structure after "
+                    "filtering. Check that inoculum_detector picks up the same "
+                    "objects captured by the dual-mask branch detection."
             )
 
         self._log_memory_usage("after overlap filtering")
@@ -412,33 +394,32 @@ class FilamentousFungiDetector(GridObjectDetector):
         # ── PHASE 4: DIJKSTRA RECONNECTION ──────────────────────────
         colony_labels = inoculum_structure_map
 
-        if self.enable_reconnection:
-            central_mask, fragment_labels = self._identify_pseudo_fragments(
-                    colony_labels=colony_labels,
-                    center_objmask=inoculum_objmask,
-            )
+        central_mask, fragment_labels = self._identify_pseudo_fragments(
+                colony_labels=colony_labels,
+                center_objmask=inoculum_objmask,
+        )
 
-            unmasked_cost, cost_surface = self._build_cost_surface(
-                    pct_result=pct_result,
-                    enhanced_arr=enhanced_arr,
-                    colony_labels=colony_labels,
-                    central_mask=central_mask,
-            )
+        unmasked_cost, cost_surface = self._build_cost_surface(
+                pct_result=pct_result,
+                enhanced_arr=enhanced_arr,
+                colony_labels=colony_labels,
+                central_mask=central_mask,
+        )
 
-            colony_labels = self._reconnect_fragments_tiled(
-                    colony_labels=colony_labels,
-                    fragment_labels=fragment_labels,
-                    cost_surface=cost_surface,
-                    unmasked_cost=unmasked_cost,
-                    pct_energy=pct_result.pc_sum.astype(np.float32),
-                    grayscale=enhanced_gray,
-            )
+        colony_labels = self._reconnect_fragments_tiled(
+                colony_labels=colony_labels,
+                fragment_labels=fragment_labels,
+                cost_surface=cost_surface,
+                unmasked_cost=unmasked_cost,
+                pct_energy=pct_result.pc_sum.astype(np.float32),
+                grayscale=enhanced_gray,
+        )
 
-            self._log_memory_usage(
-                    "after Dijkstra reconnection",
-                    include_process=True,
-                    include_tracemalloc=True,
-            )
+        self._log_memory_usage(
+                "after Dijkstra reconnection",
+                include_process=True,
+                include_tracemalloc=True,
+        )
 
         # ── PHASE 5: FINAL VORONOI ────────────────────────────────────
         final_mask = (colony_labels > 0) | inoculum_structure_mask
@@ -539,9 +520,9 @@ class FilamentousFungiDetector(GridObjectDetector):
             colony_labels: Labeled colony assignment from watershed.
         """
         _apply_distance_gap_penalty_inplace(
-                cost, pct_energy, colony_labels, self.gap_penalty_alpha,
+                cost, pct_energy, colony_labels, self.gap_crossing_penalty,
         )
-        _apply_border_penalty_inplace(cost, self.edge_margin)
+        _apply_border_penalty_inplace(cost, self.border_margin_px)
 
     def _build_cost_surface(
             self,
@@ -573,7 +554,7 @@ class FilamentousFungiDetector(GridObjectDetector):
 
         # Coherence is a measure of the length of the structures orientation
         coherence = compute_orientation_coherence(
-                pct_result.orientation, self.r_coherence
+                pct_result.orientation, self.coherence_window_radius
         )
 
         # For identifying noisy regions away from inoculum center
@@ -626,16 +607,16 @@ class FilamentousFungiDetector(GridObjectDetector):
         # Prescreen fragments: compute envelope once, share across calibration + screening
         colony_branch_mask = (colony_labels > 0).astype(np.int32)
         min_cost_envelope, _ = _compute_screening_envelope(
-                cost_surface, colony_branch_mask, self.r_screen
+                cost_surface, colony_branch_mask, self.frag_reach_px
         )
         tau_screen, _ = calibrate_screening_threshold(
-                cost_surface, colony_branch_mask, r_screen=self.r_screen,
+                cost_surface, colony_branch_mask, r_screen=self.frag_reach_px,
                 min_cost_envelope=min_cost_envelope,
         )
 
         screen_result = prescreen_fragments(
                 cost_surface, fragment_labels,
-                r_screen=self.r_screen,
+                r_screen=self.frag_reach_px,
                 tau_screen=tau_screen,
                 colony_branch_mask=colony_branch_mask,
                 min_cost_envelope=min_cost_envelope,
@@ -760,7 +741,7 @@ class FilamentousFungiDetector(GridObjectDetector):
         # Quality filter: calibrate from colony skeleton branches
         calibration = extract_calibration_branches(
                 tile_colony, tile_raw,
-                window_cost=self.window_cost,
+                window_cost=self.max_gap_length,
                 dilation_radius=self.path_dilation_radius,
                 pct_energy=tile_pct,
                 grayscale=tile_gray,
@@ -771,11 +752,11 @@ class FilamentousFungiDetector(GridObjectDetector):
         # Only apply quality filters if we have calibration data
         if calibration.median_cost_values.size > 0:
             thresholds = calibrate_thresholds(
-                    calibration, k=self.quality_k
+                    calibration, k=self.reconnection_tolerance
             )
             filter_result = apply_filter_cascade(
                     paths, tile_raw, thresholds,
-                    window_cost=self.window_cost,
+                    window_cost=self.max_gap_length,
                     dilation_radius=self.path_dilation_radius,
                     pct_energy=tile_pct,
                     grayscale=tile_gray,
@@ -907,39 +888,6 @@ class FilamentousFungiDetector(GridObjectDetector):
             r = min(int(round(com[0])), objmap.shape[0] - 1)
             c = min(int(round(com[1])), objmap.shape[1] - 1)
             markers[r, c] = marker_id
-
-        return markers
-
-    @staticmethod
-    def _create_markers_from_grid(image: 'GridImage') -> np.ndarray:
-        """Create Voronoi seed markers from grid section centers.
-
-        .. deprecated::
-            Use :meth:`_create_markers_from_centroids` instead, which
-            anchors seeds to detected inoculum positions rather than
-            geometric grid centers.
-
-        Args:
-            image: GridImage with detected objects (needed by the grid
-                accessor to compute row/column edges).
-
-        Returns:
-            2D int32 marker array with one seed per grid section.
-        """
-        h, w = image.gray[:].shape[:2]
-        row_edges = image.grid.get_row_edges()
-        col_edges = image.grid.get_col_edges()
-
-        markers = np.zeros((h, w), dtype=np.int32)
-
-        label_id = 1
-        for r_idx in range(image.nrows):
-            rr = min(int(round((row_edges[r_idx] + row_edges[r_idx + 1]) / 2)), h - 1)
-            for c_idx in range(image.ncols):
-                cc = min(int(round((col_edges[c_idx] + col_edges[c_idx + 1]) / 2)),
-                         w - 1)
-                markers[rr, cc] = label_id
-                label_id += 1
 
         return markers
 

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -1247,12 +1247,12 @@ def _handle_recompile(
     """
     from rich.console import Console
 
+    from phenotypic._cli._cli_chunk_writer import _run_analysis_plugins
     from phenotypic._cli._cli_output_manager import aggregate_measurements
     from phenotypic._cli._cli_utils import load_job_metadata
     from phenotypic._cli._dashboard import (
         build_manifest,
         generate_dashboard,
-        write_analysis_sidecar,
     )
 
     console = Console()
@@ -1293,11 +1293,22 @@ def _handle_recompile(
 
     console.print("[cyan]Running analysis plugins...")
     try:
-        write_analysis_sidecar(output_dir, metadata_csv=metadata_csv)
-        console.print("[green]Analysis sidecar data written")
+        import polars as pl
+
+        merged_df: Optional[pl.DataFrame] = None
+        if master_path and Path(master_path).exists():
+            try:
+                merged_df = pl.read_csv(master_path)
+            except Exception:
+                logger.warning(
+                    "Failed to read master CSV for analysis plugins",
+                    exc_info=True,
+                )
+        _run_analysis_plugins(output_dir, progress_dir, merged_df)
+        console.print("[green]Analysis plugins complete")
     except Exception:
-        logger.warning("Analysis sidecar write failed", exc_info=True)
-        console.print("[yellow]Analysis sidecar write failed (see logs)")
+        logger.warning("Analysis plugin dispatch failed", exc_info=True)
+        console.print("[yellow]Analysis plugin dispatch failed (see logs)")
 
     console.print("[cyan]Rebuilding manifest...")
     progress_dir.mkdir(parents=True, exist_ok=True)

--- a/src/phenotypic/prefab/_filamentous_fungi_pipeline.py
+++ b/src/phenotypic/prefab/_filamentous_fungi_pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 from phenotypic import ImagePipeline
 from phenotypic.abc_ import PrefabPipeline, ObjectDetector
@@ -30,7 +30,7 @@ class FilamentousFungiPipeline(PrefabPipeline):
            frequency-domain filtering on detect_mat.
         3. ``FilamentousFungiDetector`` -- Two-stage detection (inoculum +
            dual-mask reconnection) with Euclidean Voronoi partition and
-           Dijkstra branch reconnection (enabled by default).
+           Dijkstra branch reconnection.
 
     Measurements:
         - ``MeasureGridSpatial`` -- Grid-level spatial statistics.
@@ -54,34 +54,35 @@ class FilamentousFungiPipeline(PrefabPipeline):
         inoculum_detector: Custom ObjectDetector or ImagePipeline that
             identifies fungal centers/nuclei. When None, builds a default
             pipeline of ``InoculumDetector`` + ``GridSectionLargest``.
-        overall_detector: ObjectDetector or ImagePipeline that captures complete
-            fungal structures including hyphae. Ignored when
-            ``enable_reconnection=True`` (the default).
-        enable_reconnection: When True (default), use dual-mask branch
-            detection and Dijkstra-based reconnection instead of the legacy
-            ``overall_detector`` path.
-        pct_n_orient: Number of orientations for phase congruency computation.
-        pct_min_wavelength: Minimum wavelength for log-Gabor filters.
-        pct_k: Noise threshold scaling factor for phase congruency.
-        gauss_sigma: Sigma for SubtractGaussian background subtraction.
-        gauss_n_iter: Number of SubtractGaussian iterations.
-        morph_width: Disk radius for morphological open/close operations on
-            branch masks.
-        beta: Exponent on anisotropy in the composite cost formula.
-        gamma: Weight of MAD penalty in the composite cost numerator.
-        r_coherence: Radius for orientation coherence computation.
-        mad_window: Window size for local MAD computation (must be odd).
-        r_screen: Screening radius for fragment pre-screening.
-        delta: Dijkstra radial penalty factor for retreating steps.
-        quality_k: IQR multiplier for path quality threshold calibration.
-        window_cost: Sliding window size in pixels for the windowed cost metric.
-        edge_margin: Border penalty width in pixels.
-        gap_penalty_alpha: Distance-gap penalty strength.
-        snr_margin: Extra radius beyond ``path_dilation_radius`` for the SNR
-            background ring.
-        path_dilation_radius: Disk radius for dilating reconnection paths.
-        tile_size: Side length of square tiles for tiled Dijkstra processing.
-        tile_overlap: Overlap in pixels between adjacent tiles.
+        max_colony_radius_px: Largest colony radius (in pixels) the
+            detector should handle. Sizes scene-derived spatial
+            parameters for this worst case. Default 250.
+        min_branch_width_px: Narrowest hyphal branch width (in pixels) to
+            detect. Sizes signal-scale parameters. Default 3.
+        ignore_borders: If True, drops objects touching the image border.
+        edge_noise_threshold: Noise threshold scaling factor for phase
+            congruency edge detection.
+        reconnection_tolerance: IQR multiplier for path quality threshold
+            calibration (higher = more permissive).
+        max_gap_length: Maximum acceptable length (pixels) of a
+            suspicious cost stretch along a reconnection path.
+        border_margin_px: Border penalty buffer width in pixels.
+        frag_reach_px: Maximum 2D distance (pixels) from a fragment's
+            boundary to the nearest routable pixel; fragments more
+            isolated than this are dropped before Dijkstra routing.
+        gap_crossing_penalty: Distance-gap penalty strength during
+            Dijkstra routing.
+        gauss_sigma: Override for SubtractGaussian sigma; None auto-derives.
+        pct_min_wavelength: Override for log-Gabor minimum wavelength;
+            None auto-derives.
+        coherence_window_radius: Override for orientation coherence radius;
+            None auto-derives.
+        mad_window: Override for local MAD window (odd); None auto-derives.
+        snr_margin: Override for SNR ring radius; None auto-derives.
+        path_dilation_radius: Override for path dilation radius;
+            None auto-derives.
+        tile_size: Override for tile side length; None auto-derives.
+        tile_overlap: Override for tile overlap; None auto-derives.
         texture_scale: Scale parameter for Haralick texture features.
         texture_warn: Whether to warn on texture computation errors.
         benchmark: Enable per-step timing and memory benchmarks.
@@ -106,29 +107,26 @@ class FilamentousFungiPipeline(PrefabPipeline):
             inoculum_min_diameter: float = 30.0,
             inoculum_max_diameter: float = 100.0,
             inoculum_detector: Union[ObjectDetector, ImagePipeline, None] = None,
-            overall_detector: Union[ObjectDetector, ImagePipeline, None] = None,
+            # Scene parameters
+            max_colony_radius_px: float = 250.0,
+            min_branch_width_px: int = 3,
+            # Explicit user knobs
             ignore_borders: bool = True,
-            enable_reconnection: bool = True,
-            pct_n_orient: int = 8,
-            pct_min_wavelength: float = 5.0,
-            pct_k: float = 6.0,
-            gauss_sigma: float = 300.0,
-            gauss_n_iter: int = 2,
-            morph_width: int = 5,
-            beta: float = 2.0,
-            gamma: float = 1.2,
-            r_coherence: int = 12,
-            mad_window: int = 7,
-            r_screen: int = 10,
-            delta: float = 1.0,
-            quality_k: float = 2.5,
-            window_cost: int = 30,
-            edge_margin: int = 50,
-            gap_penalty_alpha: float = 4.0,
-            snr_margin: int = 3,
-            path_dilation_radius: int = 2,
-            tile_size: int = 1200,
-            tile_overlap: int = 100,
+            edge_noise_threshold: float = 6.0,
+            reconnection_tolerance: float = 2.5,
+            max_gap_length: int = 30,
+            border_margin_px: int = 50,
+            frag_reach_px: int = 10,
+            gap_crossing_penalty: float = 4.0,
+            # Scene-derivation overrides (None → auto-derived)
+            gauss_sigma: Optional[float] = None,
+            pct_min_wavelength: Optional[float] = None,
+            coherence_window_radius: Optional[int] = None,
+            mad_window: Optional[int] = None,
+            snr_margin: Optional[int] = None,
+            path_dilation_radius: Optional[int] = None,
+            tile_size: Optional[int] = None,
+            tile_overlap: Optional[int] = None,
             texture_scale: int = 5,
             texture_warn: bool = False,
             benchmark: bool = False,
@@ -157,25 +155,19 @@ class FilamentousFungiPipeline(PrefabPipeline):
             ),
             FilamentousFungiDetector(
                     inoculum_detector=inoculum_detector,
-                    overall_detector=overall_detector,
+                    max_colony_radius_px=max_colony_radius_px,
+                    min_branch_width_px=min_branch_width_px,
                     ignore_borders=ignore_borders,
-                    enable_reconnection=enable_reconnection,
-                    pct_n_orient=pct_n_orient,
-                    pct_min_wavelength=pct_min_wavelength,
-                    pct_k=pct_k,
+                    edge_noise_threshold=edge_noise_threshold,
+                    reconnection_tolerance=reconnection_tolerance,
+                    max_gap_length=max_gap_length,
+                    border_margin_px=border_margin_px,
+                    frag_reach_px=frag_reach_px,
+                    gap_crossing_penalty=gap_crossing_penalty,
                     gauss_sigma=gauss_sigma,
-                    gauss_n_iter=gauss_n_iter,
-                    morph_width=morph_width,
-                    beta=beta,
-                    gamma=gamma,
-                    r_coherence=r_coherence,
+                    pct_min_wavelength=pct_min_wavelength,
+                    coherence_window_radius=coherence_window_radius,
                     mad_window=mad_window,
-                    r_screen=r_screen,
-                    delta=delta,
-                    quality_k=quality_k,
-                    window_cost=window_cost,
-                    edge_margin=edge_margin,
-                    gap_penalty_alpha=gap_penalty_alpha,
                     snr_margin=snr_margin,
                     path_dilation_radius=path_dilation_radius,
                     tile_size=tile_size,

--- a/src/phenotypic/refine/__init__.py
+++ b/src/phenotypic/refine/__init__.py
@@ -12,6 +12,7 @@ address fragmented colony detections from uneven illumination or heterogeneous p
 by merging nearby detections based on spatial proximity and size thresholds.
 """
 
+from ._asymmetric_spur_trimmer import AsymmetricSpurTrimmer
 from ._border_object_modifier import BorderObjectRemover
 from ._center_deviation_reducer import CenterDeviationReducer
 from ._circularity_modifier import LowCircularityRemover
@@ -38,6 +39,7 @@ from ._grid_section_largest import GridSectionLargest
 from ._separate_objects import SeparateObjects
 
 __all__ = [
+    "AsymmetricSpurTrimmer",
     "BorderObjectRemover",
     "CenterDeviationReducer",
     "GMMCoreExtractor",

--- a/src/phenotypic/refine/_asymmetric_spur_trimmer.py
+++ b/src/phenotypic/refine/_asymmetric_spur_trimmer.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from skimage.measure._regionprops import RegionProperties
+
+    from phenotypic._core._image import Image
+
+import logging
+
+import numpy as np
+from scipy.ndimage import distance_transform_edt, label as ndi_label
+from skimage.measure import euler_number, regionprops
+
+from ..abc_ import ObjectRefiner
+from ..measure._measure_symmetric_zones import MeasureSymmetricZones
+
+_log = logging.getLogger(__name__)
+
+
+class AsymmetricSpurTrimmer(ObjectRefiner):
+    """Trim spurs and web-like noise beyond each colony's symmetric envelope.
+
+    Reuses the symmetric-radius machinery from :class:`MeasureSymmetricZones`
+    to locate, per colony, the radius past which growth stops being angularly
+    symmetric (``R_sym``). Every mask pixel beyond ``R_sym`` is a candidate for
+    removal. Candidates are segmented into connected components and, when
+    ``beehive_threshold`` is provided, classified by their topology: CCs with
+    many enclosed holes per pixel (reticulated "beehive" noise) are removed,
+    while nearly linear branches (holes per pixel ≈ 0) are preserved.
+
+    Compared to the measurement-time version in :class:`MeasureSymmetricZones`,
+    this refiner is deliberately less harsh:
+
+    * The default ``symmetry_threshold`` is ``3/6`` rather than ``4/6`` so
+      ``R_sym`` lands further from the inoculum core.
+    * Per-CC segmentation localizes the decision — trimming one noisy spur
+      never touches a legitimate branch on the other side of the colony.
+    * A safety cap (``max_trim_fraction``) aborts trimming for any colony
+      where the proposal would remove more than the given fraction of its
+      pixels, protecting uniformly asymmetric morphologies.
+
+    Args:
+        symmetry_threshold: Minimum angular coverage (fraction of
+            ``n_angular_bins`` populated) required for growth to count as
+            symmetric. Lower values push ``R_sym`` outward, shrinking the
+            candidate region. Defaults to ``3/6``.
+        n_angular_bins: Number of uniform angular bins used for the coverage
+            diagnostic that feeds ``R_sym``. Defaults to 6.
+        n_annuli: Target number of equal-area annuli for the radial density
+            profile. Auto-scaled down for small colonies. Defaults to 100.
+        pelt_penalty: Penalty controlling PELT changepoint sensitivity for
+            the inoculum core detection. Defaults to 5.0.
+        smoothing_window: Moving-average window (in annuli) applied to the
+            angular coverage profile before the ``R_sym`` threshold test.
+            Defaults to 3.
+        method: Inoculum-centre estimator. ``"distance"`` uses the peak of
+            the Euclidean distance transform; ``"intensity"`` uses the
+            intensity-weighted centroid. Defaults to ``"distance"``.
+        beehive_threshold: Minimum holes-per-pixel density required to trim
+            a candidate connected component. When ``None`` (default), every
+            CC past ``R_sym`` is trimmed — the "pure R_sym" mode. When a
+            float, CCs with ``(1 - euler_number) / area`` below the threshold
+            are kept as legitimate linear branches.
+        max_trim_fraction: Safety cap on the fraction of a colony's pixels
+            that may be removed in a single application. If the proposal
+            exceeds this fraction, trimming is aborted for that colony.
+            Defaults to 0.25.
+        min_cc_area: Minimum candidate-CC area (pixels) required to make a
+            topological decision. Smaller CCs are kept unchanged because
+            Euler statistics are unreliable on tiny regions. Defaults to 50.
+        min_object_area: Minimum colony area (pixels) below which the
+            refiner skips the colony entirely. Defaults to 100.
+
+    Returns:
+        Image: Input image with ``objmap`` updated; ``objmask`` refreshes
+        automatically via the accessor.
+
+    Best For:
+        * Filamentous-fungi detections where Dijkstra-reconnected bridges
+          occasionally produce thin asymmetric spurs off a symmetric body.
+        * Plates where noise manifests as beehive / reticulated web
+          structures while legitimate hyphae remain linear.
+
+    Consider Also:
+        * :class:`SmallObjectRemover` for spurious noise distinguished by
+          size alone rather than spatial relationship to the colony body.
+        * :class:`LowCircularityRemover` when the whole colony should be
+          judged by shape, not just its outer extent.
+
+    Examples:
+        Pure ``R_sym`` trimming (default — every CC past the symmetric
+        envelope is removed). On the synthetic yeast plate the colonies
+        are already compact/symmetric so the op is a no-op; this example
+        simply shows that wiring the refiner into a detection pipeline
+        does not break it:
+
+        >>> from phenotypic.data import load_synth_yeast_plate
+        >>> from phenotypic.detect import OtsuDetector
+        >>> from phenotypic.refine import AsymmetricSpurTrimmer
+        >>> plate = load_synth_yeast_plate()
+        >>> detected = OtsuDetector().apply(plate)
+        >>> trimmer = AsymmetricSpurTrimmer()
+        >>> refined = trimmer.apply(detected)
+        >>> bool(refined.objmap[:].max() >= 0)
+        True
+
+        Two-stage beehive-gated trim — legitimate linear branches past the
+        envelope are preserved; only topologically web-like regions are
+        removed:
+
+        >>> trimmer = AsymmetricSpurTrimmer(beehive_threshold=0.002)
+        >>> refined = trimmer.apply(detected)
+        >>> bool(refined.objmap[:].max() >= 0)
+        True
+    """
+
+    def __init__(
+            self,
+            symmetry_threshold: float = 3 / 6,
+            n_angular_bins: int = 6,
+            n_annuli: int = 100,
+            pelt_penalty: float = 5.0,
+            smoothing_window: int = 3,
+            method: Literal["distance", "intensity"] = "distance",
+            beehive_threshold: float | None = None,
+            max_trim_fraction: float = 0.25,
+            min_cc_area: int = 50,
+            min_object_area: int = 100,
+    ):
+        super().__init__()
+        if not 0.0 <= symmetry_threshold <= 1.0:
+            raise ValueError(
+                    "symmetry_threshold must be in [0, 1]; "
+                    f"got {symmetry_threshold}."
+            )
+        if method not in ("distance", "intensity"):
+            raise ValueError(
+                    f"method must be 'distance' or 'intensity'; got {method!r}."
+            )
+        if beehive_threshold is not None and beehive_threshold < 0.0:
+            raise ValueError(
+                    "beehive_threshold must be non-negative or None; "
+                    f"got {beehive_threshold}."
+            )
+        if not 0.0 < max_trim_fraction <= 1.0:
+            raise ValueError(
+                    "max_trim_fraction must be in (0, 1]; "
+                    f"got {max_trim_fraction}."
+            )
+
+        self.symmetry_threshold = symmetry_threshold
+        self.n_angular_bins = n_angular_bins
+        self.n_annuli = n_annuli
+        self.pelt_penalty = pelt_penalty
+        self.smoothing_window = smoothing_window
+        self.method = method
+        self.beehive_threshold = beehive_threshold
+        self.max_trim_fraction = max_trim_fraction
+        self.min_cc_area = min_cc_area
+        self.min_object_area = min_object_area
+
+    def _operate(self, image: Image) -> Image:
+        """Trim asymmetric spurs / beehive noise from each colony in the objmap.
+
+        Args:
+            image: Detected image with a populated ``objmap``.
+
+        Returns:
+            Image: Same image with ``objmap`` updated in place.
+        """
+        objmap = image.objmap[:]
+        if objmap.max() == 0:
+            return image
+
+        # Work on a copy we can paint zeros into; write back once at the end.
+        modified = objmap.copy()
+
+        # Intensity-weighted centroid needs a gray source.
+        gray_full = image.gray[:] if self.method == "intensity" else None
+
+        for prop in regionprops(objmap):
+            if prop.area < self.min_object_area:
+                continue
+
+            slc = prop.slice
+            objmap_crop = modified[slc]
+            obj_mask = objmap_crop == prop.label
+
+            to_remove = self._trim_mask_for_object(
+                    obj_mask=obj_mask,
+                    prop=prop,
+                    gray_full=gray_full,
+            )
+            if to_remove is None or not to_remove.any():
+                continue
+
+            objmap_crop[to_remove] = 0
+
+        image.objmap[:] = modified
+        return image
+
+    def _trim_mask_for_object(
+            self,
+            obj_mask: np.ndarray,
+            prop: "RegionProperties",
+            gray_full: np.ndarray | None,
+    ) -> np.ndarray | None:
+        """Compute the boolean "pixels to remove" mask for one colony crop.
+
+        Args:
+            obj_mask: Boolean crop of the object in its bounding box.
+            prop: ``skimage.measure._regionprops.RegionProperties`` instance
+                from iterating ``regionprops(objmap)``; used for ``slice``,
+                ``label``, and ``centroid_weighted``.
+            gray_full: Full-image grayscale used for intensity-weighted
+                centroid (``method="intensity"``). ``None`` in distance mode.
+
+        Returns:
+            A boolean array the same shape as ``obj_mask`` with ``True``
+            at pixels to remove, or ``None`` when the colony is ineligible
+            (no asymmetric region, degenerate geometry, or proposal trips
+            the safety cap).
+        """
+        # 1. Centroid (local bbox coords). Distance-transform peak is a safe
+        # fallback; intensity mode uses it when the intensity is all zero and
+        # regionprops produces a NaN weighted centroid.
+        dt = distance_transform_edt(obj_mask)
+        peak_idx = np.unravel_index(int(np.argmax(dt)), obj_mask.shape)
+        distance_centroid = (float(peak_idx[0]), float(peak_idx[1]))
+
+        if self.method == "distance":
+            centroid_rc = distance_centroid
+        else:
+            assert gray_full is not None
+            slc = prop.slice
+            gray_crop = gray_full[slc]
+            intensity_crop = gray_crop
+            if gray_crop.ndim == 3:
+                intensity_crop = gray_crop[..., 0]
+            local_props = regionprops(
+                    obj_mask.astype(np.int32),
+                    intensity_image=intensity_crop,
+            )
+            if not local_props:
+                return None
+            cw = local_props[0].centroid_weighted
+            if np.isnan(cw[0]) or np.isnan(cw[1]):
+                # Intensity is flat/zero on this crop; fall back to distance peak.
+                centroid_rc = distance_centroid
+            else:
+                centroid_rc = (float(cw[0]), float(cw[1]))
+
+        # 2. Distance map from centroid.
+        dist_map = MeasureSymmetricZones._distance_from_point(
+                obj_mask.shape, centroid_rc
+        )
+
+        mask_distances = dist_map[obj_mask]
+        if mask_distances.size == 0:
+            return None
+        max_pixel_radius = int(mask_distances.max())
+        if max_pixel_radius <= 0:
+            return None
+
+        effective_annuli = max(6, min(self.n_annuli, max_pixel_radius))
+
+        # 3. R_sym pipeline.
+        density_profile, annulus_radii = (
+            MeasureSymmetricZones._compute_radial_density_profile(
+                    obj_mask, dist_map, effective_annuli,
+            )
+        )
+        if annulus_radii.size == 0:
+            return None
+
+        try:
+            core_radius = MeasureSymmetricZones._find_core_radius(
+                    density_profile, annulus_radii, self.pelt_penalty,
+            )
+        except Exception:  # pragma: no cover — ruptures failure is rare
+            _log.debug(
+                    "PELT changepoint detection failed for label %d; "
+                    "treating core as zero.",
+                    prop.label, exc_info=True,
+            )
+            core_radius = 0.0
+
+        _, _, angular_coverage = (
+            MeasureSymmetricZones._compute_sholl_angular_profile(
+                    obj_mask, dist_map, centroid_rc, annulus_radii,
+                    self.n_angular_bins,
+            )
+        )
+        r_sym = MeasureSymmetricZones._find_symmetric_radius(
+                annulus_radii,
+                angular_coverage,
+                core_radius,
+                self.symmetry_threshold,
+                self.smoothing_window,
+        )
+
+        # 4. Asymmetric region.
+        asymmetric_region = obj_mask & (dist_map > r_sym)
+        if not asymmetric_region.any():
+            return None
+
+        # 5. Per-CC decision.
+        cc_map, n_cc = ndi_label(asymmetric_region)
+        if n_cc == 0:
+            return None
+
+        to_remove = np.zeros_like(obj_mask, dtype=bool)
+        for cc_id in range(1, n_cc + 1):
+            cc_mask = cc_map == cc_id
+            cc_area = int(cc_mask.sum())
+            if cc_area < self.min_cc_area:
+                continue
+
+            if self.beehive_threshold is None:
+                to_remove |= cc_mask
+                continue
+
+            holes = max(0, 1 - int(euler_number(cc_mask, connectivity=2)))
+            density = holes / float(cc_area)
+            if density >= self.beehive_threshold:
+                to_remove |= cc_mask
+
+        if not to_remove.any():
+            return None
+
+        # 6. Safety cap.
+        total_area = int(obj_mask.sum())
+        if total_area <= 0:
+            return None
+        trim_fraction = to_remove.sum() / float(total_area)
+        if trim_fraction > self.max_trim_fraction:
+            _log.debug(
+                    "AsymmetricSpurTrimmer aborted label %d: trim fraction "
+                    "%.3f exceeds max_trim_fraction %.3f.",
+                    prop.label, trim_fraction, self.max_trim_fraction,
+            )
+            return None
+
+        return to_remove

--- a/src/phenotypic/tools_/measurement_info_.py
+++ b/src/phenotypic/tools_/measurement_info_.py
@@ -950,6 +950,31 @@ class GRID(MeasurementInfo):
     )
 
 
+class MODEL_METRICS(MeasurementInfo):
+    """Generic fit-quality metrics and diagnostics shared by all ModelFitter subclasses.
+
+    These columns are produced by any model fitter that wraps
+    :func:`scipy.optimize.least_squares`, independent of the specific
+    mathematical model. Subclass-specific fitted parameters live in the
+    subclass's own MeasurementInfo class (e.g., ``LOG_GROWTH_MODEL``).
+    """
+
+    @classmethod
+    def category(cls) -> str:
+        return "ModelMetrics"
+
+    # fit-quality metrics
+    MAE = "MAE", "The mean absolute error"
+    MSE = "MSE", "The mean squared error"
+    RMSE = "RMSE", "The root mean squared error"
+    R2 = "R2", "The coefficient of determination"
+
+    # fit diagnostics
+    NUM_SAMPLES = "NumSamples", "The number of samples used for model fitting"
+    LOSS = "OptimizerLoss", "The loss of model fitting"
+    STATUS = "OptimizerStatus", "The output of the optimizer status"
+
+
 class LOG_GROWTH_MODEL(MeasurementInfo):
     @classmethod
     def category(cls) -> str:
@@ -972,12 +997,24 @@ class LOG_GROWTH_MODEL(MeasurementInfo):
     )
     GROWTH_RATE = "µmax", "The growth rate of the colony calculated as (K*r)/4"
     K_MAX = "Kmax", "The upper bound of the carrying capacity for model fitting"
-    NUM_SAMPLES = "NumSamples", "The number of samples used for model fitting"
-    LOSS = "OptimizerLoss", "The loss of model fitting"
-    STATUS = "OptimizerStatus", "The output of the optimizer status"
-    MAE = "MAE", "The mean absolute error"
-    MSE = "MSE", "The mean squared error"
-    RMSE = "RMSE", "The root mean squared error"
+
+
+class LINEAR_SOFTPLUS_MODEL(MeasurementInfo):
+    @classmethod
+    def category(cls) -> str:
+        return "LinearSoftplusModel"
+
+    v = ("v", "The post-lag phase growth rate.")
+    s0 = ("s0", "The initial size")
+    lam = ("lambda", "The duration of the lag phase")
+    alpha = ("alpha", "lag phase transition sharpness")
+    smax = ("smax", "The carrying capacity if fitted")
+    beta = (
+        "beta",
+        "user-provided saturation transition sharpness. Not fitted since "
+        "this is not always biologically meaningful and adds complexity "
+        "to the fitting.",
+    )
 
 
 class EDGE_CORRECTION(MeasurementInfo):

--- a/tests/unit/analysis/test_linear_softplus_model.py
+++ b/tests/unit/analysis/test_linear_softplus_model.py
@@ -1,0 +1,625 @@
+"""Unit tests for :class:`phenotypic.analysis.LinearSoftplusModel`.
+
+Fixtures mirror the structure of ``test_log_growth_model.py``: synthetic
+two-group time courses built directly from ``model_func`` plus noise so
+ground-truth parameters are known. Assertions are tolerance-based to
+accommodate the least-squares-with-prior optimizer.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from phenotypic.analysis import LinearSoftplusModel
+from phenotypic.tools_.measurement_info_ import (
+    LINEAR_SOFTPLUS_MODEL,
+    MODEL_METRICS,
+)
+
+
+# ---------------------------------------------------------------------- #
+# Synthetic fixtures
+# ---------------------------------------------------------------------- #
+def _build_group(
+    t: np.ndarray,
+    *,
+    v: float,
+    s0: float,
+    lam: float,
+    alpha: float,
+    smax: float | None,
+    beta: float = 10.0,
+    noise_sigma: float = 0.0,
+    n_replicates: int = 3,
+    strain: str = "Strain1",
+    rng: np.random.Generator | None = None,
+) -> pd.DataFrame:
+    """Build a replicated measurement DataFrame for a single strain."""
+    rng = rng or np.random.default_rng(0)
+    y_clean = LinearSoftplusModel.model_func(
+        t=t, v=v, s0=s0, lam=lam, alpha=alpha, smax=smax, beta=beta
+    )
+    rows = []
+    for rep in range(n_replicates):
+        noise = rng.normal(0.0, noise_sigma, size=len(t)) if noise_sigma > 0 else 0.0
+        y = np.asarray(y_clean, dtype=float) + noise
+        for ti, yi in zip(t, y):
+            rows.append(
+                {
+                    "Metadata_Time": float(ti),
+                    "Shape_Area": float(yi),
+                    "Metadata_Dataset": "Test",
+                    "Metadata_Strain": strain,
+                    "Metadata_Replicate": rep,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.fixture(scope="module")
+def clean_fixture():
+    """Two-group noise-free fixture for parameter-recovery tests."""
+    t = np.linspace(0, 20, 30)
+    rng = np.random.default_rng(1)
+    g1 = _build_group(
+        t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+        noise_sigma=0.0, strain="Strain1", rng=rng,
+    )
+    g2 = _build_group(
+        t, v=3.0, s0=2.0, lam=6.0, alpha=10.0, smax=40.0,
+        noise_sigma=0.0, strain="Strain2", rng=rng,
+    )
+    return pd.concat([g1, g2], ignore_index=True)
+
+
+@pytest.fixture(scope="module")
+def noisy_fixture():
+    """Two-group noisy fixture for R² / schema tests."""
+    t = np.linspace(0, 20, 30)
+    rng = np.random.default_rng(2)
+    g1 = _build_group(
+        t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+        noise_sigma=0.5, strain="Strain1", rng=rng,
+    )
+    g2 = _build_group(
+        t, v=3.0, s0=2.0, lam=6.0, alpha=10.0, smax=40.0,
+        noise_sigma=0.5, strain="Strain2", rng=rng,
+    )
+    return pd.concat([g1, g2], ignore_index=True)
+
+
+# ---------------------------------------------------------------------- #
+# Basic behavior
+# ---------------------------------------------------------------------- #
+class TestBasics:
+    def test_initialization(self):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+        )
+        assert m.on == "Shape_Area"
+        assert m.groupby == ["Metadata_Dataset", "Metadata_Strain"]
+        assert m.time_label == "Metadata_Time"
+        assert m.smax is None
+        assert m.beta == 10
+        assert m.stderr_label is None
+        assert m.inoc_size_label is None
+        assert m.prune_saturated is True
+        assert m.saturation_threshold == 0.05
+        assert m.saturation_buffer == 2
+        assert m.v_upper == 50.0
+        assert m.loss == "linear"
+        assert not m.verbose
+
+    def test_model_func_shapes(self):
+        t = np.linspace(0, 10, 20)
+        y_open = LinearSoftplusModel.model_func(
+            t=t, v=2.0, s0=0.5, lam=2.0, alpha=10.0, smax=None
+        )
+        assert y_open.shape == t.shape
+        assert y_open[-1] > y_open[0]
+
+        y_sat = LinearSoftplusModel.model_func(
+            t=t, v=2.0, s0=0.5, lam=2.0, alpha=10.0, smax=5.0, beta=10.0
+        )
+        assert y_sat.shape == t.shape
+        # saturation ceiling should cap the growth
+        assert y_sat[-1] < 5.0 + 1e-6
+
+    def test_schema(self, noisy_fixture):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+        )
+        results = m.analyze(noisy_fixture)
+        assert isinstance(results, pd.DataFrame)
+        assert not results.empty
+
+        expected = [
+            LINEAR_SOFTPLUS_MODEL.v,
+            LINEAR_SOFTPLUS_MODEL.s0,
+            LINEAR_SOFTPLUS_MODEL.lam,
+            LINEAR_SOFTPLUS_MODEL.alpha,
+            LINEAR_SOFTPLUS_MODEL.smax,
+            LINEAR_SOFTPLUS_MODEL.beta,
+            MODEL_METRICS.MAE,
+            MODEL_METRICS.MSE,
+            MODEL_METRICS.RMSE,
+            MODEL_METRICS.R2,
+            MODEL_METRICS.NUM_SAMPLES,
+            MODEL_METRICS.LOSS,
+            MODEL_METRICS.STATUS,
+        ]
+        for col in expected:
+            assert col in results.columns, f"missing column: {col}"
+
+    def test_r2_finite_and_bounded(self, noisy_fixture):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+        )
+        results = m.analyze(noisy_fixture)
+        r2 = results[MODEL_METRICS.R2]
+        assert r2.notna().all()
+        assert np.isfinite(r2).all()
+        assert (r2 <= 1.0 + 1e-6).all()
+        # both groups should fit reasonably well on the noisy fixture
+        assert (r2 > 0.8).all()
+
+
+# ---------------------------------------------------------------------- #
+# Parameter recovery
+# ---------------------------------------------------------------------- #
+class TestParameterRecovery:
+    def test_recovers_ground_truth(self, clean_fixture):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=False,
+        )
+        results = m.analyze(clean_fixture).set_index("Metadata_Strain")
+
+        # Strain1: v=5, s0=1, lam=4, smax=50
+        row1 = results.loc["Strain1"]
+        assert abs(row1[LINEAR_SOFTPLUS_MODEL.v] - 5.0) < 0.3
+        assert abs(row1[LINEAR_SOFTPLUS_MODEL.s0] - 1.0) < 0.5
+        assert abs(row1[LINEAR_SOFTPLUS_MODEL.lam] - 4.0) < 0.5
+
+        # Strain2: v=3, s0=2, lam=6, smax=40
+        row2 = results.loc["Strain2"]
+        assert abs(row2[LINEAR_SOFTPLUS_MODEL.v] - 3.0) < 0.3
+        assert abs(row2[LINEAR_SOFTPLUS_MODEL.s0] - 2.0) < 0.5
+        assert abs(row2[LINEAR_SOFTPLUS_MODEL.lam] - 6.0) < 0.5
+
+
+# ---------------------------------------------------------------------- #
+# Weighting
+# ---------------------------------------------------------------------- #
+class TestWeighting:
+    def test_weighted_vs_unweighted_differ(self):
+        """Feed a fixture where early-time points are deliberately noisy.
+
+        With the `stderr_label` column flagging high SE at early times,
+        the weighted fit should pull ``s0`` closer to the true value
+        than the unweighted fit.
+        """
+        t = np.linspace(0, 20, 25)
+        rng = np.random.default_rng(10)
+        clean = _build_group(
+            t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng,
+        )
+        # Corrupt the first 4 timepoints (early times, replicated) to be noisy.
+        early_times = np.unique(t)[:4]
+        mask = clean["Metadata_Time"].isin(early_times)
+        clean.loc[mask, "Shape_Area"] += rng.normal(0, 5.0, size=mask.sum())
+
+        # Provide a stderr_label: high for noisy early points, low elsewhere.
+        clean["Area_SE"] = np.where(mask, 5.0, 0.1)
+
+        m_weighted = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            stderr_label="Area_SE",
+            prune_saturated=False,
+        )
+        # To make "unweighted" comparable, supply a uniform SE column.
+        clean["Area_SE_uniform"] = 1.0
+        m_unweighted = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            stderr_label="Area_SE_uniform",
+            prune_saturated=False,
+        )
+
+        res_w = m_weighted.analyze(clean)
+        res_u = m_unweighted.analyze(clean)
+
+        s0_w = float(res_w[LINEAR_SOFTPLUS_MODEL.s0].iloc[0])
+        s0_u = float(res_u[LINEAR_SOFTPLUS_MODEL.s0].iloc[0])
+        # Weighted should be closer to ground truth s0=1.0 than unweighted.
+        assert abs(s0_w - 1.0) < abs(s0_u - 1.0) + 1e-9
+        # At minimum the two fits must differ non-trivially.
+        assert abs(s0_w - s0_u) > 1e-3
+
+    def test_stderr_label_column_passed_through(self):
+        """Given a stderr_label, it must be used — not auto-SEM."""
+        t = np.linspace(0, 20, 15)
+        rng = np.random.default_rng(11)
+        df = _build_group(
+            t, v=4.0, s0=1.0, lam=4.0, alpha=10.0, smax=40.0,
+            noise_sigma=0.2, strain="Strain1", rng=rng, n_replicates=2,
+        )
+        df["Area_SE"] = 1.0
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            stderr_label="Area_SE",
+            prune_saturated=False,
+        )
+        res = m.analyze(df)
+        # Smoke check: a fit completed with finite parameters.
+        assert np.isfinite(res[LINEAR_SOFTPLUS_MODEL.v].iloc[0])
+        assert np.isfinite(res[LINEAR_SOFTPLUS_MODEL.s0].iloc[0])
+
+
+# ---------------------------------------------------------------------- #
+# smax fallback
+# ---------------------------------------------------------------------- #
+class TestSmaxFallback:
+    def test_per_group_observed_max(self, clean_fixture):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=False,
+        )
+        results = m.analyze(clean_fixture).set_index("Metadata_Strain")
+        # Strain1 ground truth smax=50 → observed max ≈ 50
+        assert abs(results.loc["Strain1", LINEAR_SOFTPLUS_MODEL.smax] - 50.0) < 1.0
+        # Strain2 ground truth smax=40 → observed max ≈ 40
+        assert abs(results.loc["Strain2", LINEAR_SOFTPLUS_MODEL.smax] - 40.0) < 1.0
+
+    def test_explicit_smax_overrides(self, clean_fixture):
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            smax=100.0,
+            prune_saturated=False,
+        )
+        results = m.analyze(clean_fixture)
+        assert (results[LINEAR_SOFTPLUS_MODEL.smax] == 100.0).all()
+
+
+# ---------------------------------------------------------------------- #
+# Saturation pruning
+# ---------------------------------------------------------------------- #
+class TestSaturationPruning:
+    def test_basic_pruning_drops_plateau_and_preserves_growth(self):
+        """On a 20-growth + 20-plateau fixture, ``_prepare_group`` must
+        drop real rows (catches a silent no-op) and keep the growth
+        phase intact, and the end-to-end fit must still recover ``v``.
+
+        This combines three checks that together pin down the pruning
+        behavior deterministically:
+          1. ``len(pruned) < len(group)`` — a no-op `_prepare_group`
+             (returning the group unchanged) fails here.
+          2. ``len(pruned) >= len(t_growth)`` — an over-aggressive
+             implementation that trims the growth phase fails here.
+          3. The downstream fit recovers ``v`` near ground truth — a
+             broken pruner that e.g. drops the wrong rows would fail.
+        """
+        t_growth = np.linspace(0, 20, 20)
+        t_plateau = np.linspace(20.5, 50, 20)
+        t_all = np.concatenate([t_growth, t_plateau])
+        rng = np.random.default_rng(20)
+        df = _build_group(
+            t_all, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng, n_replicates=1,
+        )
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=True,
+        )
+        group = df.groupby(["Metadata_Dataset", "Metadata_Strain"]).get_group(
+            ("Test", "Strain1")
+        )
+        pruned = m._prepare_group(group)
+
+        # Direct behavioral check — pruning must actually drop rows.
+        assert len(pruned) < len(group), (
+            f"expected pruning to drop plateau rows; "
+            f"got {len(pruned)}/{len(group)}"
+        )
+        # Dynamic-range check — the pruned slice must span the full
+        # growth transition (lag near s0=1 through saturation near
+        # smax=50). An over-aggressive pruner that clipped mid-growth
+        # would fail here.
+        y_pruned = pruned[m.on].to_numpy(dtype=float)
+        assert y_pruned.min() <= 2.0, (
+            f"pruner dropped the lag phase; min y={y_pruned.min():.2f}"
+        )
+        assert y_pruned.max() >= 49.0, (
+            f"pruner dropped the saturation shoulder; max y={y_pruned.max():.2f}"
+        )
+
+        # End-to-end smoke — downstream fit recovers v within tolerance.
+        res = m.analyze(df)
+        v_fit = float(res[LINEAR_SOFTPLUS_MODEL.v].iloc[0])
+        assert abs(v_fit - 5.0) < 0.3, (
+            f"pruned fit did not recover v within tolerance: v_fit={v_fit:.4f}"
+        )
+
+    def test_lag_noise_does_not_trim_lag(self):
+        """Heavy lag-phase noise must NOT trigger early trimming."""
+        t = np.linspace(0, 20, 30)
+        rng = np.random.default_rng(21)
+        df = _build_group(
+            t, v=5.0, s0=1.0, lam=6.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng, n_replicates=1,
+        )
+        # Add large noise only to lag-phase points (t <= 5).
+        lag_mask = df["Metadata_Time"] <= 5.0
+        df.loc[lag_mask, "Shape_Area"] += rng.normal(
+            0, 0.3, size=int(lag_mask.sum())
+        )
+
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=True,
+        )
+        pruned = m._prepare_group(
+            df.groupby(["Metadata_Dataset", "Metadata_Strain"]).get_group(
+                ("Test", "Strain1")
+            )
+        )
+        # All pre-peak (t <= 8) rows should survive.
+        lag_rows_kept = (pruned["Metadata_Time"] <= 5.0).sum()
+        lag_rows_original = int(lag_mask.sum())
+        assert lag_rows_kept == lag_rows_original
+
+    def test_transient_growth_dip_not_pruned(self):
+        """A single noisy low-derivative point mid-growth must NOT trigger."""
+        t = np.linspace(0, 20, 40)
+        rng = np.random.default_rng(22)
+        df = _build_group(
+            t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng, n_replicates=1,
+        )
+        # Inject a transient dip at a mid-growth timepoint.
+        mid_time = 8.0
+        dip_mask = df["Metadata_Time"] == df["Metadata_Time"].iloc[
+            np.argmin(np.abs(df["Metadata_Time"] - mid_time))
+        ]
+        df.loc[dip_mask, "Shape_Area"] *= 0.95  # small dip
+
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=True,
+        )
+        group = df.groupby(["Metadata_Dataset", "Metadata_Strain"]).get_group(
+            ("Test", "Strain1")
+        )
+        pruned = m._prepare_group(group)
+        # Ensure the dip location is still present.
+        assert pruned["Metadata_Time"].max() >= mid_time + 1.0
+
+    def test_non_saturating_curve_is_noop(self):
+        """Curve ending mid-growth must not be pruned."""
+        # Stop well before the curve saturates: t ∈ [0, 6] with smax=50.
+        t = np.linspace(0, 6, 15)
+        rng = np.random.default_rng(23)
+        df = _build_group(
+            t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng, n_replicates=1,
+        )
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=True,
+        )
+        group = df.groupby(["Metadata_Dataset", "Metadata_Strain"]).get_group(
+            ("Test", "Strain1")
+        )
+        pruned = m._prepare_group(group)
+        # Tail-slope guard must short-circuit: nothing pruned.
+        assert len(pruned) == len(group)
+
+
+# ---------------------------------------------------------------------- #
+# Inoculum prior
+# ---------------------------------------------------------------------- #
+class TestInoculumPrior:
+    def test_column_prior_pulls_s0_toward_group_mean(self):
+        """A tight inoc_size column far from the data's implied s0 must
+        bias the fit toward the column's group mean."""
+        t = np.linspace(0, 20, 25)
+        rng = np.random.default_rng(30)
+        df = _build_group(
+            t, v=5.0, s0=3.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.3, strain="Strain1", rng=rng, n_replicates=2,
+        )
+        # Inoculum measurements clustered tightly around 0.5 —
+        # far from the curve's implied s0 ≈ 3.
+        df["Inoc_Size"] = rng.normal(0.5, 0.02, size=len(df))
+
+        m_no_prior = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=False,
+        )
+        m_prior = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            inoc_size_label="Inoc_Size",
+            prune_saturated=False,
+        )
+
+        s0_no = float(m_no_prior.analyze(df)[LINEAR_SOFTPLUS_MODEL.s0].iloc[0])
+        s0_yes = float(m_prior.analyze(df)[LINEAR_SOFTPLUS_MODEL.s0].iloc[0])
+
+        group_mean = float(df["Inoc_Size"].mean())
+        # The prior should pull s0 closer to the column's group mean
+        # than the no-prior fit.
+        assert abs(s0_yes - group_mean) < abs(s0_no - group_mean)
+
+    def test_no_inoc_label_omits_prior_residual(self):
+        """Verify residual length: N without prior kwargs, N+1 with them.
+
+        Locks in the symmetry of ``_loss_func`` — a regression in either
+        direction (always appending, or never appending) would flip one
+        of the two assertions below.
+        """
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            prune_saturated=False,
+        )
+        y = np.asarray([1.0, 2.0, 3.0], dtype=float)
+        t_arr = np.asarray([0.0, 1.0, 2.0], dtype=float)
+        params = [1.0, 0.5, 1.0, 10.0]
+
+        # Negative: no prior kwargs → residual vector matches y shape.
+        res = m._loss_func(params, t_arr, y, smax=5.0)
+        assert res.shape == (3,)
+
+        # Positive: prior kwargs appended → residual vector is length N+1.
+        res_with_prior = m._loss_func(
+            params, t_arr, y, smax=5.0, sGMM_mean=0.5, sGMM_sigma=0.1
+        )
+        assert res_with_prior.shape == (4,)
+
+    def test_inoc_label_with_nan_stats_omits_prior(self):
+        """A zero-variance inoculum column must cause ``_inoc_stats`` to
+        return ``None`` so the virtual residual is silently skipped —
+        not a silent division by zero that corrupts the fit."""
+        t = np.linspace(0, 20, 15)
+        rng = np.random.default_rng(32)
+        df = _build_group(
+            t, v=5.0, s0=1.0, lam=4.0, alpha=10.0, smax=50.0,
+            noise_sigma=0.0, strain="Strain1", rng=rng, n_replicates=1,
+        )
+        df["Inoc_Size"] = 0.5  # zero-variance column
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+            inoc_size_label="Inoc_Size",
+            prune_saturated=False,
+        )
+
+        # Direct check: construct the group the same way analyze() would
+        # (broadcasting per-group mean/std via transform) and assert the
+        # resolver returns None on the zero-variance input.
+        probe = df.copy()
+        grouped = probe.groupby(
+            ["Metadata_Dataset", "Metadata_Strain"]
+        )["Inoc_Size"]
+        probe["Inoc_Size_group_mean"] = grouped.transform("mean")
+        probe["Inoc_Size_group_sigma"] = grouped.transform("std")
+        group = probe.groupby(
+            ["Metadata_Dataset", "Metadata_Strain"]
+        ).get_group(("Test", "Strain1"))
+        assert m._inoc_stats(group) is None
+
+        # Companion check: analyze() completes and doesn't silently
+        # corrupt the fit when the column is degenerate.
+        res = m.analyze(df)
+        assert np.isfinite(res[LINEAR_SOFTPLUS_MODEL.v].iloc[0])
+
+
+# ---------------------------------------------------------------------- #
+# Degenerate input → NaN row
+# ---------------------------------------------------------------------- #
+class TestDegenerateInput:
+    def test_all_zero_data_does_not_crash(self):
+        """All-zero measurements must not raise; analyze returns a row.
+
+        The optimizer converges to some trivial parameter vector here
+        (residuals are degenerate), so we only assert that the pipeline
+        completes and produces a single row — not that the values are
+        NaN.
+        """
+        t = np.linspace(0, 20, 15)
+        rows = []
+        for rep in range(2):
+            for ti in t:
+                rows.append(
+                    {
+                        "Metadata_Time": float(ti),
+                        "Shape_Area": 0.0,
+                        "Metadata_Dataset": "Test",
+                        "Metadata_Strain": "Dead",
+                        "Metadata_Replicate": rep,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+        )
+        res = m.analyze(df)
+        assert len(res) == 1
+        # v must respect the configured upper bound.
+        assert 0.0 <= float(res[LINEAR_SOFTPLUS_MODEL.v].iloc[0]) <= 50.0
+
+    def test_nan_input_triggers_nan_row(self):
+        """NaN measurements propagate into the optimizer, triggering the
+        NaN fit-column path (``_nan_fit_columns``) instead of crashing."""
+        t = np.linspace(0, 20, 15)
+        rows = []
+        for ti in t:
+            rows.append(
+                {
+                    "Metadata_Time": float(ti),
+                    "Shape_Area": float("nan"),
+                    "Metadata_Dataset": "Test",
+                    "Metadata_Strain": "Broken",
+                }
+            )
+        df = pd.DataFrame(rows)
+        m = LinearSoftplusModel(
+            on="Shape_Area",
+            groupby=["Metadata_Dataset", "Metadata_Strain"],
+        )
+        res = m.analyze(df)
+        assert len(res) == 1
+        # Every fitted parameter must be NaN.
+        assert np.isnan(float(res[LINEAR_SOFTPLUS_MODEL.v].iloc[0]))
+        assert np.isnan(float(res[LINEAR_SOFTPLUS_MODEL.s0].iloc[0]))
+        assert np.isnan(float(res[LINEAR_SOFTPLUS_MODEL.lam].iloc[0]))
+        assert np.isnan(float(res[LINEAR_SOFTPLUS_MODEL.alpha].iloc[0]))
+
+
+# ---------------------------------------------------------------------- #
+# LogGrowthModel regression — hooks must be no-ops by default
+# ---------------------------------------------------------------------- #
+def test_log_growth_still_works():
+    """Sanity check: adding hooks to the base class didn't break siblings."""
+    from phenotypic.analysis import LogGrowthModel
+
+    np.random.seed(0)
+    t = np.arange(0, 10, 1)
+    r_true, K_true, N0_true = 0.5, 1000.0, 50.0
+    rows = []
+    for ti in t:
+        y = K_true / (1 + (K_true - N0_true) / N0_true * np.exp(-r_true * ti))
+        for _ in range(3):
+            rows.append(
+                {
+                    "Metadata_Time": float(ti),
+                    "Shape_Area": float(y),
+                    "Metadata_Dataset": "Test",
+                    "Metadata_Strain": "Strain1",
+                }
+            )
+    df = pd.DataFrame(rows)
+    m = LogGrowthModel(
+        on="Shape_Area",
+        groupby=["Metadata_Dataset", "Metadata_Strain"],
+    )
+    res = m.analyze(df)
+    assert not res.empty

--- a/tests/unit/analysis/test_log_growth_model.py
+++ b/tests/unit/analysis/test_log_growth_model.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from pathlib import Path
 
 from phenotypic.analysis._log_growth_model import LogGrowthModel
-from phenotypic.tools_.measurement_info_ import LOG_GROWTH_MODEL
+from phenotypic.tools_.measurement_info_ import LOG_GROWTH_MODEL, MODEL_METRICS
 
 
 class TestLogGrowthModel:
@@ -130,12 +130,13 @@ class TestLogGrowthModel:
             LOG_GROWTH_MODEL.N0_FIT,
             LOG_GROWTH_MODEL.GROWTH_RATE,
             LOG_GROWTH_MODEL.K_MAX,
-            LOG_GROWTH_MODEL.NUM_SAMPLES,
-            LOG_GROWTH_MODEL.LOSS,
-            LOG_GROWTH_MODEL.STATUS,
-            LOG_GROWTH_MODEL.MAE,
-            LOG_GROWTH_MODEL.MSE,
-            LOG_GROWTH_MODEL.RMSE,
+            MODEL_METRICS.NUM_SAMPLES,
+            MODEL_METRICS.LOSS,
+            MODEL_METRICS.STATUS,
+            MODEL_METRICS.MAE,
+            MODEL_METRICS.MSE,
+            MODEL_METRICS.RMSE,
+            MODEL_METRICS.R2,
         ]
 
         for col in expected_columns:
@@ -145,6 +146,12 @@ class TestLogGrowthModel:
         assert not results[LOG_GROWTH_MODEL.R_FIT].isna().all()
         assert not results[LOG_GROWTH_MODEL.K_FIT].isna().all()
         assert not results[LOG_GROWTH_MODEL.N0_FIT].isna().all()
+
+        # R^2 should be finite and at most 1.0 on the synthetic fixture
+        r2_values = results[MODEL_METRICS.R2]
+        assert r2_values.notna().all()
+        assert np.isfinite(r2_values).all()
+        assert (r2_values <= 1.0).all()
 
         # Check that growth rate is calculated correctly (r * K / 4)
         r_values = results[LOG_GROWTH_MODEL.R_FIT]

--- a/tests/unit/cli/test_cli_checkpoint_handler.py
+++ b/tests/unit/cli/test_cli_checkpoint_handler.py
@@ -1,0 +1,163 @@
+"""Unit tests for the SLURM checkpoint handler.
+
+Focused on schema coercion: ``job_metadata["datasets"]`` is written with the
+nested ``{name: {total, images}}`` shape but ``build_manifest`` (and
+downstream code) expect the flat ``{name: int}`` shape.  The handler must
+coerce at the boundary, mirroring :mod:`phenotypic._cli._cli_sentinel`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="SLURM checkpoint handler only runs on POSIX",
+)
+
+from phenotypic._cli._cli_checkpoint_handler import _run_finalize, _run_manifest
+
+
+NESTED_DATASETS = {
+    "ds1": {"total": 3, "images": ["a.tif", "b.tif", "c.tif"]},
+    "ds2": {"total": 2, "images": ["x.tif", "y.tif"]},
+}
+FLAT_DATASETS = {"ds1": 3, "ds2": 2}
+EXPECTED_TOTALS = {"ds1": 3, "ds2": 2}
+
+
+def _write_job_metadata(progress_dir: Path, datasets_field: dict) -> None:
+    """Write a minimal job_metadata.json with the given datasets shape."""
+    progress_dir.mkdir(parents=True, exist_ok=True)
+    (progress_dir / "job_metadata.json").write_text(
+        json.dumps(
+            {
+                "start_time": "2026-04-21T00:00:00.000",
+                "execution_mode": "slurm",
+                "datasets": datasets_field,
+                "chunk_job_ids": {"0": "12345"},
+                "chunk_scripts": [],
+                "image_task_mapping": {},
+                "include_dataset_column": True,
+                "metadata_csv": None,
+                "input_path": "fake",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestRunManifestCoercion:
+    """``_run_manifest`` must pass ``{name: int}`` to ``build_manifest``."""
+
+    @pytest.mark.parametrize(
+        "datasets_field",
+        [NESTED_DATASETS, FLAT_DATASETS],
+        ids=["nested_schema", "legacy_flat_int"],
+    )
+    def test_build_manifest_receives_flat_int_datasets(
+        self, tmp_path: Path, datasets_field: dict
+    ) -> None:
+        output_dir = tmp_path / "out"
+        progress_dir = output_dir / "progress"
+        _write_job_metadata(progress_dir, datasets_field)
+
+        with patch(
+            "phenotypic._cli._dashboard._manifest_builder.build_manifest"
+        ) as mock_build_manifest:
+            _run_manifest(output_dir, progress_dir)
+
+        mock_build_manifest.assert_called_once()
+        kwargs = mock_build_manifest.call_args.kwargs
+        assert kwargs["datasets"] == EXPECTED_TOTALS
+        assert all(isinstance(v, int) for v in kwargs["datasets"].values())
+
+    def test_no_metadata_file_early_exits(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        progress_dir = output_dir / "progress"
+        progress_dir.mkdir(parents=True)
+
+        with patch(
+            "phenotypic._cli._dashboard._manifest_builder.build_manifest"
+        ) as mock_build_manifest:
+            _run_manifest(output_dir, progress_dir)
+
+        mock_build_manifest.assert_not_called()
+
+
+class TestRunFinalizeCoercion:
+    """``_run_finalize`` must coerce before sum(), aggregate, and manifest."""
+
+    @pytest.mark.parametrize(
+        "datasets_field",
+        [NESTED_DATASETS, FLAT_DATASETS],
+        ids=["nested_schema", "legacy_flat_int"],
+    )
+    def test_finalize_coerces_and_propagates_flat_totals(
+        self, tmp_path: Path, datasets_field: dict
+    ) -> None:
+        output_dir = tmp_path / "out"
+        progress_dir = output_dir / "progress"
+        _write_job_metadata(progress_dir, datasets_field)
+
+        with (
+            patch(
+                "phenotypic._cli._cli_checkpoint_handler._wait_for_completion"
+            ) as mock_wait,
+            patch(
+                "phenotypic._cli._cli_output_manager.aggregate_measurements"
+            ) as mock_aggregate,
+            patch(
+                "phenotypic._cli._dashboard._manifest_builder.build_manifest"
+            ) as mock_build_manifest,
+            patch(
+                "phenotypic._cli._cli_chunk_writer._run_analysis_plugins"
+            ) as mock_plugins,
+            patch(
+                "phenotypic._cli._dashboard._generator.generate_dashboard"
+            ) as mock_dashboard,
+        ):
+            _run_finalize(output_dir, progress_dir)
+
+        mock_wait.assert_called_once()
+        wait_total = mock_wait.call_args.args[1]
+        assert wait_total == sum(EXPECTED_TOTALS.values())
+
+        mock_aggregate.assert_called_once()
+        aggregate_kwargs = mock_aggregate.call_args.kwargs
+        assert aggregate_kwargs["dataset_names"] == list(EXPECTED_TOTALS.keys())
+
+        mock_build_manifest.assert_called_once()
+        manifest_kwargs = mock_build_manifest.call_args.kwargs
+        assert manifest_kwargs["datasets"] == EXPECTED_TOTALS
+        assert all(isinstance(v, int) for v in manifest_kwargs["datasets"].values())
+
+        mock_plugins.assert_called_once()
+        mock_dashboard.assert_called_once()
+
+    def test_no_metadata_file_early_exits(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "out"
+        progress_dir = output_dir / "progress"
+        progress_dir.mkdir(parents=True)
+
+        with (
+            patch(
+                "phenotypic._cli._cli_checkpoint_handler._wait_for_completion"
+            ) as mock_wait,
+            patch(
+                "phenotypic._cli._cli_output_manager.aggregate_measurements"
+            ) as mock_aggregate,
+            patch(
+                "phenotypic._cli._dashboard._manifest_builder.build_manifest"
+            ) as mock_build_manifest,
+        ):
+            _run_finalize(output_dir, progress_dir)
+
+        mock_wait.assert_not_called()
+        mock_aggregate.assert_not_called()
+        mock_build_manifest.assert_not_called()

--- a/tests/unit/cli/test_cli_progress_dashboard.py
+++ b/tests/unit/cli/test_cli_progress_dashboard.py
@@ -616,7 +616,7 @@ class TestSentinelScript:
         assert "#SBATCH --partition=gpu" in content
         assert "#SBATCH --account=mylab" in content
         assert "#SBATCH --time=01:00:00" in content  # default max_runtime=1800 → 60-min floor
-        assert "pheno-sentinel" in content
+        assert "pht-sentinel" in content
         assert "phenotypic._cli._cli_sentinel" in content
         # Uses the same Python path as array job scripts, not bare "python"
         assert "-m phenotypic._cli._cli_sentinel" in content

--- a/tests/unit/cli/test_cli_recompile.py
+++ b/tests/unit/cli/test_cli_recompile.py
@@ -1,0 +1,116 @@
+"""Unit tests for the CLI ``--recompile`` path (``_handle_recompile``).
+
+Verifies that recompile mirrors the SLURM finalizer's post-aggregation
+pattern: it reads the freshly-written ``master_measurements.csv`` and
+dispatches analysis plugins via ``_run_analysis_plugins`` (not the
+DuckDB-based ``write_analysis_sidecar``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="CLI recompile path has non-Windows dependencies",
+)
+
+from phenotypic.phenotypicCLI import _handle_recompile
+
+
+def _make_fake_results(tmp_path: Path) -> Path:
+    """Create a minimal output dir with one dataset and a stub parquet."""
+    output_dir = tmp_path / "out"
+    ds_meas_dir = output_dir / "results" / "ds1" / "measurements"
+    ds_meas_dir.mkdir(parents=True)
+    (ds_meas_dir / "img1.parquet").write_text("")  # presence only
+    return output_dir
+
+
+class TestHandleRecompile:
+    """``_handle_recompile`` uses the finalizer analysis-plugin pattern."""
+
+    def test_dispatches_run_analysis_plugins_from_master_csv(
+        self, tmp_path: Path
+    ) -> None:
+        output_dir = _make_fake_results(tmp_path)
+
+        def _fake_aggregate(**_kwargs: object) -> Path:
+            master = output_dir / "master_measurements.csv"
+            master.write_text("col_a\n1\n", encoding="utf-8")
+            return master
+
+        with (
+            patch(
+                "phenotypic._cli._cli_output_manager.aggregate_measurements",
+                side_effect=_fake_aggregate,
+            ),
+            patch(
+                "phenotypic._cli._cli_chunk_writer._run_analysis_plugins"
+            ) as mock_plugins,
+            patch(
+                "phenotypic._cli._dashboard.build_manifest"
+            ) as mock_manifest,
+            patch(
+                "phenotypic._cli._dashboard.generate_dashboard"
+            ) as mock_dashboard,
+            patch(
+                "phenotypic._cli._dashboard._analysis_data.write_analysis_sidecar"
+            ) as mock_sidecar,
+        ):
+            _handle_recompile(
+                output_dir=output_dir,
+                metadata_csv=None,
+                include_dataset_column=True,
+            )
+
+        mock_sidecar.assert_not_called()
+
+        mock_plugins.assert_called_once()
+        args = mock_plugins.call_args.args
+        assert args[0] == output_dir
+        assert args[1] == output_dir / "progress"
+        merged_df = args[2]
+        assert merged_df is not None
+        assert merged_df.height == 1
+        assert "col_a" in merged_df.columns
+
+        mock_manifest.assert_called_once()
+        mock_dashboard.assert_called_once()
+
+    def test_plugin_dispatch_failure_does_not_crash(self, tmp_path: Path) -> None:
+        output_dir = _make_fake_results(tmp_path)
+
+        def _fake_aggregate(**_kwargs: object) -> Path:
+            master = output_dir / "master_measurements.csv"
+            master.write_text("col_a\n1\n", encoding="utf-8")
+            return master
+
+        with (
+            patch(
+                "phenotypic._cli._cli_output_manager.aggregate_measurements",
+                side_effect=_fake_aggregate,
+            ),
+            patch(
+                "phenotypic._cli._cli_chunk_writer._run_analysis_plugins",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "phenotypic._cli._dashboard.build_manifest"
+            ) as mock_manifest,
+            patch(
+                "phenotypic._cli._dashboard.generate_dashboard"
+            ) as mock_dashboard,
+        ):
+            _handle_recompile(
+                output_dir=output_dir,
+                metadata_csv=None,
+                include_dataset_column=True,
+            )
+
+        mock_manifest.assert_called_once()
+        mock_dashboard.assert_called_once()

--- a/tests/unit/cli/test_cli_slurm_array.py
+++ b/tests/unit/cli/test_cli_slurm_array.py
@@ -218,7 +218,7 @@ class TestArrayJobScriptGeneration:
 
         # Check SBATCH directives
         assert "#!/bin/bash" in content
-        assert "#SBATCH --job-name=pheno-test_dataset" in content
+        assert "#SBATCH --job-name=pht-test_dataset" in content
         assert "#SBATCH --array=0-9" in content  # 10 images, 0-indexed
         assert "#SBATCH --partition=short" in content
         assert "#SBATCH --mem=16G" in content
@@ -256,7 +256,7 @@ class TestArrayJobScriptGeneration:
         content = script_path.read_text()
 
         # Should have chunk ID in job name
-        assert "#SBATCH --job-name=pheno-test_dataset-chunk0" in content
+        assert "#SBATCH --job-name=pht-test_dataset-chunk0" in content
         # Should only include first 5 images
         assert "#SBATCH --array=0-4" in content
 
@@ -274,7 +274,7 @@ class TestArrayJobScriptGeneration:
         content = script_path.read_text()
 
         # Should have chunk ID in job name and filename
-        assert "#SBATCH --job-name=pheno-test_dataset-chunk1" in content
+        assert "#SBATCH --job-name=pht-test_dataset-chunk1" in content
         assert "array_job_chunk1.sh" in str(script_path)
         # Should only include last 5 images
         assert "#SBATCH --array=0-4" in content  # Still 0-indexed for chunk

--- a/tests/unit/detect/test_filamentous_fungi_detector.py
+++ b/tests/unit/detect/test_filamentous_fungi_detector.py
@@ -6,19 +6,18 @@ from phenotypic.detect import (
     TriangleDetector,
     FilamentousFungiDetector,
 )
-from phenotypic.enhance import GaussianBlur, CLAHE
+from phenotypic.enhance import GaussianBlur
 
 
 class TestFilamentousFungiDetector:
     """Test suite for FilamentousFungiDetector functionality and edge cases."""
 
     def test_basic_detection(self, synth_plate):
-        """Test basic detection with two detectors produces valid result."""
+        """Test basic detection with default configuration produces valid result."""
         image = synth_plate.copy()
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
         )
         result = detector.apply(image)
 
@@ -32,7 +31,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
         result = detector.apply(image)
 
@@ -54,45 +52,19 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=EmptyCenterDetector(),
-                overall_detector=TriangleDetector(),
         )
 
         # apply() wraps exceptions in RuntimeError per framework's error handling
         with pytest.raises(RuntimeError, match="No centers detected"):
             detector.apply(image)
 
-    # def test_no_overall_detected_raises(self, synth_plate):
-    #     """Test that error is raised when overall_detector finds nothing."""
-    #     image = synth_plate.copy()
-    #
-    #     # Create a custom detector that always returns empty mask
-    #     class EmptyOverallDetector(TriangleDetector):
-    #         def _operate(self, img):
-    #             img.objmask[:] = False
-    #             return img
-    #
-    #     detector = FilamentousFungiDetector(
-    #             inoculum_detector=OtsuDetector(),
-    #             overall_detector=EmptyOverallDetector(),
-    #     )
-    #
-    #     # apply() wraps exceptions in RuntimeError per framework's error handling
-    #     with pytest.raises(RuntimeError, match="No overall structure detected"):
-    #         detector.apply(image)
-
-    def test_center_and_overall_produce_results(self, synth_plate):
-        """Test that both center and overall detectors produce results."""
+    def test_default_inoculum_detector(self, synth_plate):
+        """Test that the default inoculum detector pipeline runs end-to-end."""
         image = synth_plate.copy()
 
-        detector = FilamentousFungiDetector(
-                inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
-        )
-
-        # Should successfully detect both centers and overall structure
+        detector = FilamentousFungiDetector()
         result = detector.apply(image)
 
-        # Verify results have detected objects
         assert result.objmap[:].max() > 0
         assert result.objmask[:].sum() > 0
 
@@ -101,15 +73,6 @@ class TestFilamentousFungiDetector:
         with pytest.raises(TypeError, match="inoculum_detector must be"):
             FilamentousFungiDetector(
                     inoculum_detector="not_a_detector",
-                    overall_detector=TriangleDetector(),
-            )
-
-    def test_invalid_overall_detector_type_raises(self):
-        """Test that TypeError is raised for invalid overall_detector type."""
-        with pytest.raises(TypeError, match="overall_detector must be"):
-            FilamentousFungiDetector(
-                    inoculum_detector=OtsuDetector(),
-                    overall_detector=123,
             )
 
     def test_inplace_false_preserves_original(self, synth_plate):
@@ -119,7 +82,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
         result = detector.apply(image, inplace=False)
 
@@ -136,7 +98,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
         result = detector.apply(image, inplace=True)
 
@@ -157,50 +118,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=center_pipeline,
-                overall_detector=TriangleDetector(),
-        )
-        result = detector.apply(image)
-
-        # Should produce valid results
-        assert result.objmap[:].max() > 0
-        assert result.objmask[:].sum() > 0
-
-    def test_with_imagepipeline_overall_detector(self, synth_plate):
-        """Test that ImagePipeline works as overall_detector."""
-        image = synth_plate.copy()
-
-        # Create pipeline for overall detection with preprocessing
-        overall_pipeline = ImagePipeline([
-            CLAHE(clip_limit=2.0),
-            TriangleDetector()
-        ])
-
-        detector = FilamentousFungiDetector(
-                inoculum_detector=OtsuDetector(),
-                overall_detector=overall_pipeline,
-        )
-        result = detector.apply(image)
-
-        # Should produce valid results
-        assert result.objmap[:].max() > 0
-        assert result.objmask[:].sum() > 0
-
-    def test_with_both_imagepipeline_detectors(self, synth_plate):
-        """Test that ImagePipeline works for both detectors."""
-        image = synth_plate.copy()
-
-        center_pipeline = ImagePipeline([
-            GaussianBlur(sigma=0.5),
-            OtsuDetector()
-        ])
-        overall_pipeline = ImagePipeline([
-            CLAHE(clip_limit=2.0),
-            TriangleDetector()
-        ])
-
-        detector = FilamentousFungiDetector(
-                inoculum_detector=center_pipeline,
-                overall_detector=overall_pipeline,
         )
         result = detector.apply(image)
 
@@ -212,7 +129,6 @@ class TestFilamentousFungiDetector:
         """Test that detector serializes and deserializes correctly."""
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
         )
 
         # Create pipeline
@@ -229,7 +145,6 @@ class TestFilamentousFungiDetector:
         restored_detector = list(restored_pipeline._ops.values())[0]
         assert isinstance(restored_detector, FilamentousFungiDetector)
         assert isinstance(restored_detector.inoculum_detector, OtsuDetector)
-        assert isinstance(restored_detector.overall_detector, TriangleDetector)
 
     def test_serialization_functional_equivalence(self, synth_plate):
         """Test that serialized/deserialized detector produces identical results."""
@@ -238,7 +153,6 @@ class TestFilamentousFungiDetector:
         # Original detector
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
         original_result = detector.apply(image, inplace=False)
 
@@ -264,12 +178,11 @@ class TestFilamentousFungiDetector:
         """Test that detector integrates into full processing pipeline."""
         image = synth_plate.copy()
 
-        # Build pipeline with enhancement, detection, and cleanup
+        # Build pipeline with enhancement and detection
         pipeline = ImagePipeline([
             GaussianBlur(sigma=1.0),
             FilamentousFungiDetector(
                     inoculum_detector=OtsuDetector(),
-                    overall_detector=TriangleDetector(),
             ),
         ])
 
@@ -279,20 +192,13 @@ class TestFilamentousFungiDetector:
         assert result.objmap[:].max() > 0
         assert result.objmask[:].sum() > 0
 
-    def test_different_detector_combinations(self, synth_plate):
-        """Test various detector combinations work correctly."""
+    def test_different_inoculum_detectors(self, synth_plate):
+        """Test that different inoculum detector choices produce valid results."""
         image = synth_plate.copy()
 
-        combinations = [
-            (OtsuDetector(), TriangleDetector()),
-            (OtsuDetector(), OtsuDetector()),
-            (TriangleDetector(), OtsuDetector()),
-        ]
-
-        for center, overall in combinations:
+        for inoculum in (OtsuDetector(), TriangleDetector()):
             detector = FilamentousFungiDetector(
-                    inoculum_detector=center,
-                    overall_detector=overall,
+                    inoculum_detector=inoculum,
             )
             result = detector.apply(image.copy())
 
@@ -306,7 +212,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
         result = detector.apply(image)
 
@@ -328,7 +233,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(),
-                overall_detector=TriangleDetector(),
         )
 
         # Apply multiple times and verify consistent memory usage
@@ -344,7 +248,6 @@ class TestFilamentousFungiDetector:
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
         )
 
         result1 = detector.apply(image.copy())

--- a/tests/unit/refine/test_asymmetric_spur_trimmer.py
+++ b/tests/unit/refine/test_asymmetric_spur_trimmer.py
@@ -1,0 +1,393 @@
+"""Tests for AsymmetricSpurTrimmer."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from skimage.draw import disk, rectangle
+
+from phenotypic import Image, ImagePipeline
+from phenotypic.refine import AsymmetricSpurTrimmer
+
+
+# =====================================================================
+# Fixtures
+# =====================================================================
+
+
+def _make_image(objmap: np.ndarray) -> Image:
+    """Wrap an objmap in an Image with a dummy rgb backing store."""
+    h, w = objmap.shape
+    image = Image(arr=np.zeros((h, w, 3), dtype=np.uint8))
+    image.objmap[:] = objmap.astype(image.objmap[:].dtype)
+    return image
+
+
+def _stamp_disk(objmap: np.ndarray, centre, radius: int, label: int) -> None:
+    rr, cc = disk(centre, radius, shape=objmap.shape)
+    objmap[rr, cc] = label
+
+
+def _stamp_rect(objmap: np.ndarray, start, end, label: int) -> None:
+    rr, cc = rectangle(start=start, end=end, shape=objmap.shape)
+    objmap[rr.astype(int), cc.astype(int)] = label
+
+
+def _stamp_web(
+        objmap: np.ndarray,
+        top_left,
+        shape,
+        cell_size: int,
+        label: int,
+) -> None:
+    """Stamp a reticulated web (many enclosed small holes) into objmap.
+
+    Creates a filled rectangle then knocks out an evenly-spaced grid of
+    square holes so the topological Euler number is very negative.
+    """
+    h, w = shape
+    r0, c0 = top_left
+    objmap[r0:r0 + h, c0:c0 + w] = label
+
+    # Punch out small square holes on a grid, leaving 1-pixel walls.
+    for rr in range(r0 + 1, r0 + h - 1, cell_size):
+        for cc in range(c0 + 1, c0 + w - 1, cell_size):
+            r_end = min(rr + cell_size - 1, r0 + h - 1)
+            c_end = min(cc + cell_size - 1, c0 + w - 1)
+            if r_end - rr >= 1 and c_end - cc >= 1:
+                objmap[rr:r_end, cc:c_end] = 0
+
+
+@pytest.fixture
+def round_colony() -> Image:
+    """Single compact disk colony — should never trigger trimming."""
+    objmap = np.zeros((200, 200), dtype=np.int32)
+    _stamp_disk(objmap, centre=(100, 100), radius=40, label=1)
+    return _make_image(objmap)
+
+
+@pytest.fixture
+def spurred_colony() -> Image:
+    """Disk + narrow rectangular spur extending 3× body radius past envelope."""
+    objmap = np.zeros((250, 400), dtype=np.int32)
+    _stamp_disk(objmap, centre=(125, 100), radius=40, label=1)
+    # A 6-pixel-tall strip extending far to the right.
+    _stamp_rect(objmap, start=(122, 150), end=(128, 350), label=1)
+    return _make_image(objmap)
+
+
+@pytest.fixture
+def linear_branch_colony() -> Image:
+    """Disk + single thin linear branch (topologically a line — 0 holes)."""
+    objmap = np.zeros((250, 400), dtype=np.int32)
+    _stamp_disk(objmap, centre=(125, 100), radius=40, label=1)
+    _stamp_rect(objmap, start=(123, 150), end=(127, 320), label=1)
+    return _make_image(objmap)
+
+
+@pytest.fixture
+def web_noise_colony() -> Image:
+    """Disk + reticulated web region past the envelope (many enclosed holes)."""
+    objmap = np.zeros((250, 400), dtype=np.int32)
+    _stamp_disk(objmap, centre=(125, 100), radius=40, label=1)
+    _stamp_web(
+            objmap,
+            top_left=(90, 160),
+            shape=(70, 180),
+            cell_size=4,
+            label=1,
+    )
+    return _make_image(objmap)
+
+
+@pytest.fixture
+def two_colonies_one_spurred() -> Image:
+    """Two disks; only the right-hand one has a spur."""
+    objmap = np.zeros((250, 500), dtype=np.int32)
+    _stamp_disk(objmap, centre=(125, 60), radius=35, label=1)
+    _stamp_disk(objmap, centre=(125, 300), radius=40, label=2)
+    _stamp_rect(objmap, start=(123, 350), end=(127, 480), label=2)
+    return _make_image(objmap)
+
+
+# =====================================================================
+# Tests
+# =====================================================================
+
+
+class TestCircularColonyNoTrim:
+    """A compact disk colony should never be touched."""
+
+    def test_pure_rsym_mode(self, round_colony: Image) -> None:
+        before = round_colony.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer().apply(round_colony)
+        np.testing.assert_array_equal(refined.objmap[:], before)
+
+    def test_beehive_mode(self, round_colony: Image) -> None:
+        before = round_colony.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer(beehive_threshold=0.002).apply(
+                round_colony
+        )
+        np.testing.assert_array_equal(refined.objmap[:], before)
+
+
+class TestLopsidedSpurPureRsym:
+    """Pure R_sym mode should remove the spur but preserve the disk body."""
+
+    def test_spur_removed_body_preserved(self, spurred_colony: Image) -> None:
+        before_area = int((spurred_colony.objmap[:] == 1).sum())
+        refined = AsymmetricSpurTrimmer().apply(spurred_colony)
+        after_area = int((refined.objmap[:] == 1).sum())
+
+        # Spur should be clearly shorter than before — a meaningful fraction trimmed.
+        assert after_area < before_area, (
+            "Expected spur pixels to be trimmed"
+        )
+        # ... but the disk body (a rough circle of radius 40) should survive.
+        assert after_area >= int(np.pi * 35 ** 2), (
+            "Disk body looks like it was eaten too"
+        )
+
+        # No pixels should survive at the far right where the spur ended.
+        assert not (refined.objmap[:, 340:] > 0).any(), (
+            "Spur tip should be gone"
+        )
+
+
+class TestLinearBranchPreservedBeehiveMode:
+    """Beehive mode keeps long linear branches (holes = 0)."""
+
+    def test_linear_branch_kept(self, linear_branch_colony: Image) -> None:
+        before = linear_branch_colony.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer(beehive_threshold=0.002).apply(
+                linear_branch_colony
+        )
+        # The linear strip past R_sym is topologically linear → holes=0 → kept.
+        # Pixel count should be unchanged.
+        np.testing.assert_array_equal(refined.objmap[:], before)
+
+
+class TestWebNoiseTrimmedBeehiveMode:
+    """Beehive mode removes reticulated web regions past R_sym."""
+
+    def test_web_removed(self, web_noise_colony: Image) -> None:
+        refined = AsymmetricSpurTrimmer(
+                beehive_threshold=0.002,
+                max_trim_fraction=0.9,  # lift the safety cap for this synthetic
+        ).apply(web_noise_colony)
+
+        # The web lives at cols 160-340 ish. After trim, little should survive there.
+        web_cols_after = (refined.objmap[:, 180:330] > 0).sum()
+        assert web_cols_after < 200, (
+            "Web noise should be largely removed"
+        )
+
+
+class TestUniformlyAsymmetricSafetyCap:
+    """A mostly-asymmetric single colony trips the safety cap → no trim."""
+
+    def test_thin_ellipse_untouched(self) -> None:
+        objmap = np.zeros((200, 200), dtype=np.int32)
+        rr, cc = np.indices(objmap.shape)
+        # Thin horizontal ellipse: semi-major=80, semi-minor=8.
+        ellipse = ((rr - 100) / 8.0) ** 2 + ((cc - 100) / 80.0) ** 2 <= 1.0
+        objmap[ellipse] = 1
+        image = _make_image(objmap)
+
+        before = image.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer().apply(image)
+
+        # Safety cap or a non-trivially-large preservation expected.
+        trimmed = int((before > 0).sum()) - int((refined.objmap[:] > 0).sum())
+        original = int((before > 0).sum())
+        assert trimmed / max(original, 1) <= 0.25 + 1e-9, (
+            "Safety cap was not respected"
+        )
+
+
+class TestSmallObjectSkipped:
+    """Objects below min_object_area are ignored entirely."""
+
+    def test_tiny_blob_untouched(self) -> None:
+        objmap = np.zeros((200, 200), dtype=np.int32)
+        _stamp_disk(objmap, centre=(50, 50), radius=3, label=1)
+        image = _make_image(objmap)
+
+        before = image.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer(min_object_area=100).apply(image)
+        np.testing.assert_array_equal(refined.objmap[:], before)
+
+
+class TestSmallCcSkippedBeehiveMode:
+    """Candidate CCs below min_cc_area are preserved in beehive mode."""
+
+    def test_tiny_cc_kept(self) -> None:
+        objmap = np.zeros((250, 400), dtype=np.int32)
+        _stamp_disk(objmap, centre=(125, 100), radius=40, label=1)
+        # A tiny 6-pixel blob well past the disk envelope.
+        objmap[124:127, 260:262] = 1
+        image = _make_image(objmap)
+
+        before = image.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer(
+                beehive_threshold=0.002, min_cc_area=50,
+        ).apply(image)
+        np.testing.assert_array_equal(refined.objmap[:], before)
+
+
+class TestMultiColonyIndependent:
+    """Each colony is handled independently in pure R_sym mode."""
+
+    def test_only_spurred_colony_trimmed(
+            self, two_colonies_one_spurred: Image
+    ) -> None:
+        before = two_colonies_one_spurred.objmap[:].copy()
+        refined = AsymmetricSpurTrimmer(max_trim_fraction=0.9).apply(
+                two_colonies_one_spurred
+        )
+        after = refined.objmap[:]
+
+        # Label-1 disk (no spur) must be byte-for-byte identical.
+        np.testing.assert_array_equal(after == 1, before == 1)
+        # Label 2's spur region must have lost pixels.
+        assert (after == 2).sum() < (before == 2).sum()
+
+
+class TestMaxTrimFractionSafety:
+    """A small colony with a big spur must not be eaten past max_trim_fraction."""
+
+    def test_safety_cap_respected(self) -> None:
+        objmap = np.zeros((150, 500), dtype=np.int32)
+        _stamp_disk(objmap, centre=(75, 50), radius=15, label=1)
+        # Spur dominating the colony by pixel count.
+        _stamp_rect(objmap, start=(73, 80), end=(77, 480), label=1)
+        image = _make_image(objmap)
+
+        original_area = int((image.objmap[:] == 1).sum())
+        refined = AsymmetricSpurTrimmer(max_trim_fraction=0.25).apply(image)
+        after_area = int((refined.objmap[:] == 1).sum())
+
+        trimmed_fraction = (original_area - after_area) / max(original_area, 1)
+        assert trimmed_fraction <= 0.25 + 1e-9, (
+            f"Safety cap violated: trimmed {trimmed_fraction:.2%}"
+        )
+
+
+class TestBeehiveThresholdMonotonic:
+    """Rising beehive_threshold monotonically reduces trimmed pixels."""
+
+    def test_monotonic_decrease(self, web_noise_colony: Image) -> None:
+        trimmed_counts: list[int] = []
+        originals = int((web_noise_colony.objmap[:] > 0).sum())
+        for threshold in [0.0, 0.002, 0.01, 0.05, 1.0]:
+            img = _make_image(web_noise_colony.objmap[:].copy())
+            refined = AsymmetricSpurTrimmer(
+                    beehive_threshold=threshold,
+                    max_trim_fraction=0.9,
+            ).apply(img)
+            trimmed_counts.append(
+                    originals - int((refined.objmap[:] > 0).sum())
+            )
+
+        for earlier, later in zip(trimmed_counts, trimmed_counts[1:]):
+            assert later <= earlier, (
+                f"Expected monotonic decrease; saw {trimmed_counts}"
+            )
+
+
+class TestJsonRoundtrip:
+    """Serialize and deserialize via ImagePipeline; attributes survive."""
+
+    def test_attributes_match(self) -> None:
+        trimmer = AsymmetricSpurTrimmer(
+                symmetry_threshold=0.4,
+                beehive_threshold=0.003,
+                max_trim_fraction=0.3,
+                min_cc_area=75,
+                min_object_area=120,
+                method="intensity",
+        )
+        pipeline = ImagePipeline([trimmer])
+        restored = ImagePipeline.from_json(pipeline.to_json())
+
+        ops = restored.get_ops()
+        restored_trimmer = ops["AsymmetricSpurTrimmer"]
+
+        assert isinstance(restored_trimmer, AsymmetricSpurTrimmer)
+        assert restored_trimmer.symmetry_threshold == 0.4
+        assert restored_trimmer.beehive_threshold == 0.003
+        assert restored_trimmer.max_trim_fraction == 0.3
+        assert restored_trimmer.min_cc_area == 75
+        assert restored_trimmer.min_object_area == 120
+        assert restored_trimmer.method == "intensity"
+
+
+class TestProtectedComponents:
+    """RGB/gray/detect_mat must not be modified by the refiner."""
+
+    def test_rgb_gray_detect_mat_preserved(
+            self, spurred_colony: Image,
+    ) -> None:
+        before_rgb = spurred_colony.rgb[:].copy()
+        before_gray = spurred_colony.gray[:].copy()
+        before_detect = spurred_colony.detect_mat[:].copy()
+
+        refined = AsymmetricSpurTrimmer().apply(spurred_colony)
+
+        np.testing.assert_array_equal(refined.rgb[:], before_rgb)
+        np.testing.assert_array_equal(refined.gray[:], before_gray)
+        np.testing.assert_array_equal(refined.detect_mat[:], before_detect)
+
+
+class TestIntensityModeSmoke:
+    """Smoke-test the intensity-centroid branch end-to-end.
+
+    The distance branch is exercised by every other test. These tests guard
+    the intensity path on (a) a real grayscale image and (b) the degenerate
+    all-zero-gray case that would otherwise produce a NaN weighted centroid.
+    """
+
+    def test_intensity_mode_applies_with_real_gray(self) -> None:
+        """Paint a non-uniform gray under the mask so centroid_weighted is defined."""
+        objmap = np.zeros((250, 400), dtype=np.int32)
+        _stamp_disk(objmap, centre=(125, 100), radius=40, label=1)
+        _stamp_rect(objmap, start=(122, 150), end=(128, 350), label=1)
+
+        rgb = np.zeros((250, 400, 3), dtype=np.uint8)
+        rgb[objmap > 0] = (180, 180, 180)
+        image = Image(arr=rgb)
+        image.objmap[:] = objmap.astype(image.objmap[:].dtype)
+
+        refined = AsymmetricSpurTrimmer(method="intensity").apply(image)
+        # Spur should still be trimmed (intensity-weighted centroid lives on
+        # the disk body since the spur has the same gray level but way fewer pixels).
+        assert (refined.objmap[:] > 0).sum() < (image.objmap[:] > 0).sum()
+
+    def test_intensity_mode_tolerates_zero_gray(
+            self, spurred_colony: Image,
+    ) -> None:
+        """All-zero gray would break centroid_weighted; op must fall back."""
+        # spurred_colony has an all-zero RGB/gray backing; intensity mode must
+        # still run and produce a valid result (fallback to distance centroid).
+        refined = AsymmetricSpurTrimmer(method="intensity").apply(spurred_colony)
+        assert refined.objmap[:].max() >= 0
+
+
+class TestInvalidConstructorArgs:
+    """Constructor validation surfaces obviously bad parameter values."""
+
+    def test_symmetry_threshold_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            AsymmetricSpurTrimmer(symmetry_threshold=1.5)
+
+    def test_negative_beehive_threshold(self) -> None:
+        with pytest.raises(ValueError):
+            AsymmetricSpurTrimmer(beehive_threshold=-0.01)
+
+    def test_max_trim_fraction_zero(self) -> None:
+        with pytest.raises(ValueError):
+            AsymmetricSpurTrimmer(max_trim_fraction=0.0)
+
+    def test_invalid_method(self) -> None:
+        with pytest.raises(ValueError):
+            AsymmetricSpurTrimmer(method="bogus")  # type: ignore[arg-type]

--- a/tests/unit/tools_/test_branch_pathfinding.py
+++ b/tests/unit/tools_/test_branch_pathfinding.py
@@ -3,7 +3,7 @@
 Unit tests for the modules under ``phenotypic.tools_.branch_pathfinding``
 (cost surface composition, fragment prescreening, path quality filtering,
 Dijkstra kernels, dataclasses) and integration tests that exercise them
-via ``FilamentousFungiDetector(enable_reconnection=True)``.
+via ``FilamentousFungiDetector``.
 """
 
 import numpy as np
@@ -371,7 +371,7 @@ class TestPathQuality:
         assert_allclose(metrics.median_raw_cost, 5.0)
 
     def test_short_path_window_cost_equals_median(self):
-        """Path shorter than window_cost uses whole-path median."""
+        """Path shorter than max_gap_length uses whole-path median."""
         cost_surface = np.full((100, 100), 3.0, dtype=np.float32)
         coords = np.column_stack([np.arange(10), np.zeros(10)]).astype(np.int32)
         path = _DuckPath(coords, np.ones(10), total_cost=10.0, path_length=10)
@@ -753,10 +753,10 @@ class TestExtractCalibrationBranches:
 
 
 class TestFilamentousFungiDetectorReconnection:
-    """Integration and backward-compatibility tests for reconnection."""
+    """Integration tests for the reconnection path."""
 
-    def test_enable_reconnection_true_runs_without_error(self, synth_plate):
-        """Reconnection mode runs without errors on synth plate.
+    def test_reconnection_runs_without_error(self, synth_plate):
+        """Reconnection runs without errors on synth plate.
 
         The synth plate has circular yeast colonies, so there will not be
         realistic filamentous reconnection, but the full code path must
@@ -765,13 +765,10 @@ class TestFilamentousFungiDetectorReconnection:
         from phenotypic.detect import (
             FilamentousFungiDetector,
             OtsuDetector,
-            TriangleDetector,
         )
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
-                enable_reconnection=True,
         )
         result = detector.apply(synth_plate.copy())
 
@@ -783,13 +780,10 @@ class TestFilamentousFungiDetectorReconnection:
         from phenotypic.detect import (
             FilamentousFungiDetector,
             OtsuDetector,
-            TriangleDetector,
         )
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
-                enable_reconnection=True,
         )
         result = detector.apply(synth_plate.copy())
 
@@ -799,20 +793,16 @@ class TestFilamentousFungiDetectorReconnection:
         assert_array_equal(objmap > 0, objmask)
 
     def test_reconnection_serialization_roundtrip(self):
-        """Detector with reconnection serializes and restores correctly."""
+        """Detector serializes and restores correctly."""
         from phenotypic import ImagePipeline
         from phenotypic.detect import (
             FilamentousFungiDetector,
             OtsuDetector,
-            TriangleDetector,
         )
 
         detector = FilamentousFungiDetector(
                 inoculum_detector=OtsuDetector(ignore_zeros=True),
-                overall_detector=TriangleDetector(),
-                enable_reconnection=True,
-                delta=2.0,
-                r_screen=15,
+                frag_reach_px=15,
         )
         pipeline = ImagePipeline([detector])
         json_str = pipeline.to_json()
@@ -820,6 +810,4 @@ class TestFilamentousFungiDetectorReconnection:
 
         restored_det = list(restored._ops.values())[0]
         assert isinstance(restored_det, FilamentousFungiDetector)
-        assert restored_det.enable_reconnection is True
-        assert restored_det.delta == 2.0
-        assert restored_det.r_screen == 15
+        assert restored_det.frag_reach_px == 15


### PR DESCRIPTION
## Summary

- **`LinearSoftplusModel`** — a new growth-curve fitter for colonies that grow roughly linearly post-lag. Generalizes the `ModelFitter` ABC so any least-squares model can plug in via a small set of subclass hooks (`_initial_guess`, `_param_bounds`, `_params_to_model_kwargs`, `_loss_func`). MAE/MSE/RMSE/R² and optimizer diagnostics now ship under a shared `MODEL_METRICS` MeasurementInfo, so every subclass produces a consistent diagnostic schema; `LogGrowthModel` collapses to a thin subclass.
- **`AsymmetricSpurTrimmer`** — a new `ObjectRefiner` that trims asymmetric spurs and beehive-like noise past each colony's symmetric-radius envelope. Reuses the five static helpers from `MeasureSymmetricZones` (distance map, radial density, PELT core, Sholl angular coverage, symmetric radius) to define the candidate region, then segments it into connected components. Pure R_sym mode (default) trims every CC past the envelope; an optional Euler-based beehive gate preserves topologically linear branches while removing reticulated web noise.
- **`FilamentousFungiDetector` simplification** — drops the `overall_detector` and `enable_reconnection` parameters. The dual-mask branch detection + Dijkstra reconnection path is now the only supported strategy, eliminating the "ignored when reconnection is enabled" caveats across the detector, the `FilamentousFungiPipeline` prefab, docs, and tests.
- **SLURM finalizer crash fix** — `job_metadata["datasets"]` is written in the nested `{name: {total, images}}` shape but the manifest/finalizer checkpoint readers treated it as flat `{name: int}` and crashed on `sum(...)` every run. Coerced at the boundary (mirroring `_cli_sentinel.py`) with a legacy-flat-int fallback. Also aligned `--recompile` to dispatch analysis plugins from the already-written master CSV via `_run_analysis_plugins`, matching what the finalizer does (no more wasted DuckDB re-aggregation).

## Test plan

- [ ] `uv run pytest tests/unit/analysis/test_linear_softplus_model.py` — new fitter unit tests
- [ ] `uv run pytest tests/unit/analysis/test_log_growth_model.py` — unchanged model behavior after base-class refactor
- [ ] `uv run pytest tests/unit/refine/test_asymmetric_spur_trimmer.py` — new refiner unit tests
- [ ] `uv run pytest tests/unit/detect/test_filamentous_fungi_detector.py tests/unit/tools_/test_branch_pathfinding.py` — detector simplification + reconnection integration
- [ ] `uv run pytest tests/unit/cli/test_cli_checkpoint_handler.py tests/unit/cli/test_cli_recompile.py` — new CLI tests (nested + legacy flat-int schemas, recompile plugin-dispatch)
- [ ] `uv run pytest tests/unit/cli/` — full CLI suite, no regressions (179+ passing)
- [ ] `uv run ruff check --fix` / `uv run mypy src/phenotypic` — lint + type-check
- [ ] End-to-end smoke: run `uv run python -m phenotypic._cli._cli_checkpoint_handler --output-dir <previously-crashed-run> --checkpoint-type manifest` and confirm `progress/manifest.json` is written (no TypeError)
- [ ] End-to-end smoke: `uv run python -m phenotypic --recompile <dir>` — confirm analysis-plugin JSON sidecars and `dashboard.html` are refreshed

🤖 Generated with [Claude Code](https://claude.com/claude-code)