### PR TITLE
Pipeline serialization & grid-shape preset, AutoGridFinder refinement, CLI cleanups

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -60,6 +60,7 @@ jobs:
         working-directory: docs
         env:
           DOCS_VERSION: ${{ env.DOCS_VERSION }}
+          PHENOTYPIC_DOCS_BUILD: "1"
         run: |
           uv run make html
           touch build/html/.nojekyll

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -47,6 +47,8 @@ jobs:
           sudo apt-get install -y pandoc
 
       - name: Build documentation (test only)
+        env:
+          PHENOTYPIC_DOCS_BUILD: "1"
         run: |
           cd docs
           uv run make html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,6 +8,11 @@ SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
+# Signals to phenotypic's plotly init that nbsphinx-executed kernels should
+# emit HTML-renderable Plotly output instead of the default JSON MIME bundle.
+# See src/phenotypic/_core/.../_accessor_dash_handler.py.
+export PHENOTYPIC_DOCS_BUILD = 1
+
 # Put it first so that "make" without argument is like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/tutorials/notebooks/01_your_first_plate_image.ipynb
+++ b/docs/source/tutorials/notebooks/01_your_first_plate_image.ipynb
@@ -87,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plate.dash();"
+    "plate.dash()"
    ]
   },
   {
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plate.rgb.dash();"
+    "plate.rgb.dash()"
    ]
   },
   {
@@ -218,7 +218,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plate.gray.dash();"
+    "plate.gray.dash()"
    ]
   },
   {
@@ -257,7 +257,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plate.detect_mat.dash();"
+    "plate.detect_mat.dash()"
    ]
   },
   {

--- a/src/phenotypic/_cli/_cli_execution_strategies.py
+++ b/src/phenotypic/_cli/_cli_execution_strategies.py
@@ -245,11 +245,8 @@ class LocalParallelStrategy(ExecutionStrategy):
         append_event(event_log, dataset.name, image_path.name, "started")
 
         try:
-            # Prepare read kwargs
-            read_kwargs = {}
-            if self.config.image_type == "GridImage":
-                read_kwargs["nrows"] = self.config.nrows
-                read_kwargs["ncols"] = self.config.ncols
+            # Prepare read kwargs.
+            read_kwargs: Dict[str, Any] = {}
             if self.config.bit_depth:
                 read_kwargs["bit_depth"] = self.config.bit_depth
             if self.config.detect_mode != "gray":
@@ -264,6 +261,8 @@ class LocalParallelStrategy(ExecutionStrategy):
                 image_type=self.config.image_type,
                 read_kwargs=read_kwargs,
                 output_manager=self.output_manager,
+                cli_nrows=self.config.nrows,
+                cli_ncols=self.config.ncols,
             )
 
             # Log success

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -538,7 +538,7 @@ class OutputManager:
         extensions: Dict[str, str],
         include_dataset_column: bool = True,
         overlay_alpha: float = 0.3,
-        save_overlays: bool = False,
+        save_overlays: bool = True,
     ):
         """
         Initialize OutputManager.
@@ -553,8 +553,9 @@ class OutputManager:
             include_dataset_column: Whether to add Metadata_Dataset column to measurements (default: True)
             overlay_alpha: Alpha transparency for label overlay (0.0-1.0, default: 0.3)
             save_overlays: If True, ``create_structure`` provisions an
-                ``overlays/`` directory per dataset; workers should consult
-                this flag before calling :meth:`save_overlay`.
+                ``overlays/`` directory per dataset and workers will save
+                a PNG overlay per image. Defaults to True; set False only
+                for ``--measure`` reruns that should not regenerate overlays.
         """
         self.base_dir = Path(base_dir)
         self.save_layers = save_layers
@@ -576,14 +577,14 @@ class OutputManager:
         ext: str,
         include_dataset_column: bool = True,
         overlay_alpha: float = 0.3,
-        save_overlays: bool = False,
+        save_overlays: bool = True,
     ) -> "OutputManager":
         """Create an OutputManager configured for HDF-centric forward runs.
 
         Forward runs now write a single ``.h5`` per image under
-        ``results/<ds>/hdf/`` (in addition to the parquet measurements and
-        an opt-in overlay PNG). The ``ext`` argument is retained for
-        backward compatibility with callers that still construct overlay
+        ``results/<ds>/hdf/`` plus the parquet measurements and an
+        overlay PNG. The ``ext`` argument is retained for backward
+        compatibility with callers that still construct overlay
         filenames via :meth:`get_output_path`.
 
         Args:
@@ -592,7 +593,10 @@ class OutputManager:
                 no longer the forward-run image-layer switch.
             include_dataset_column: Add Metadata_Dataset to measurements.
             overlay_alpha: Alpha for overlay compositing.
-            save_overlays: If True, provision ``overlays/`` per dataset.
+            save_overlays: If True (default), provision ``overlays/`` per
+                dataset and save an overlay per image. Pass False only
+                for ``--measure`` reruns that should not regenerate
+                overlays.
         """
         return cls(
             base_dir=base_dir,
@@ -608,9 +612,9 @@ class OutputManager:
         Create complete output directory structure.
 
         Always creates dataset-first structure with each dataset in its own
-        folder.  Forward runs provision ``measurements/`` and ``hdf/`` for
-        every dataset; ``overlays/`` is provisioned only when
-        :attr:`save_overlays` is True.
+        folder.  Forward runs provision ``measurements/``, ``hdf/``, and
+        ``overlays/`` for every dataset; ``overlays/`` is skipped only
+        when :attr:`save_overlays` is False (e.g. ``--measure`` reruns).
 
         Args:
             datasets: List of datasets to create directories for

--- a/src/phenotypic/_cli/_cli_process_single.py
+++ b/src/phenotypic/_cli/_cli_process_single.py
@@ -37,6 +37,8 @@ def process_single_image_core(
     image_type: Literal["Image", "GridImage"],
     read_kwargs: Dict[str, Any],
     output_manager: OutputManager,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> bool:
     """
     Core processing logic for a single image.
@@ -47,8 +49,12 @@ def process_single_image_core(
         output_dir: Base output directory
         dataset_name: Dataset name for this image
         image_type: "Image" or "GridImage"
-        read_kwargs: Kwargs for imread (nrows, ncols, bit_depth)
+        read_kwargs: Kwargs for imread (bit_depth, detect_mode). Should NOT
+            include ``nrows``/``ncols`` — those are resolved here from the CLI
+            override (``cli_nrows``/``cli_ncols``) and the pipeline preset.
         output_manager: OutputManager instance
+        cli_nrows: Explicit CLI ``--nrows`` override, or ``None`` if not passed.
+        cli_ncols: Explicit CLI ``--ncols`` override, or ``None`` if not passed.
 
     Returns:
         True if successful. This function always returns True on success;
@@ -64,6 +70,19 @@ def process_single_image_core(
 
     # Determine image class
     image_cls = GridImage if image_type == "GridImage" else Image
+
+    if image_type == "GridImage":
+        from ._cli_utils import resolve_grid_shape
+
+        nrows, ncols = resolve_grid_shape(
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
+            pipeline_nrows=pipeline.nrows,
+            pipeline_ncols=pipeline.ncols,
+        )
+        read_kwargs = dict(read_kwargs)  # local copy; do not mutate caller's dict
+        read_kwargs["nrows"] = nrows
+        read_kwargs["ncols"] = ncols
 
     # Load image
     detect_mode = read_kwargs.pop("detect_mode", "gray")
@@ -167,9 +186,19 @@ def process_single_hdf_measure_core(
     default="GridImage",
     help="Image class to use",
 )
-@click.option("--nrows", type=int, default=8, help="Number of grid rows (for GridImage)")
 @click.option(
-    "--ncols", type=int, default=12, help="Number of grid columns (for GridImage)"
+    "--nrows",
+    type=int,
+    default=None,
+    help="Number of grid rows (for GridImage). Overrides any pipeline-level "
+    "preset; falls back to the pipeline preset or 8 when omitted.",
+)
+@click.option(
+    "--ncols",
+    type=int,
+    default=None,
+    help="Number of grid columns (for GridImage). Overrides any pipeline-level "
+    "preset; falls back to the pipeline preset or 12 when omitted.",
 )
 @click.option("--bit-depth", type=int, default=None, help="Bit depth (8 or 16)")
 @click.option(
@@ -222,8 +251,8 @@ def main(
     output_dir: Path,
     dataset_name: str,
     image_type: str,
-    nrows: int,
-    ncols: int,
+    nrows: Optional[int],
+    ncols: Optional[int],
     bit_depth: Optional[int],
     detect_mode: str,
     ext: str,
@@ -316,9 +345,6 @@ def main(
         else:
             # Forward run: prepare read kwargs and dispatch to the detection path.
             read_kwargs: Dict[str, Any] = {}
-            if image_type == "GridImage":
-                read_kwargs["nrows"] = nrows
-                read_kwargs["ncols"] = ncols
             if bit_depth is not None:
                 read_kwargs["bit_depth"] = bit_depth
             if detect_mode != "gray":
@@ -341,6 +367,8 @@ def main(
                 image_type=image_type,  # type: ignore[arg-type]
                 read_kwargs=read_kwargs,
                 output_manager=output_manager,
+                cli_nrows=nrows,
+                cli_ncols=ncols,
             )
 
         # Log completion if event log provided

--- a/src/phenotypic/_cli/_cli_process_single.py
+++ b/src/phenotypic/_cli/_cli_process_single.py
@@ -240,10 +240,9 @@ def process_single_hdf_measure_core(
     help="Rerun pipeline.measure() on the input HDF; skip detection.",
 )
 @click.option(
-    "--save-overlays",
-    is_flag=True,
-    default=False,
-    help="Save a PNG overlay per image. Ignored in --measure mode.",
+    "--save-overlays/--no-save-overlays",
+    default=True,
+    help="Save a PNG overlay per image (default: on). Ignored in --measure mode.",
 )
 def main(
     pipeline: Path,

--- a/src/phenotypic/_cli/_cli_readme_generator.py
+++ b/src/phenotypic/_cli/_cli_readme_generator.py
@@ -91,7 +91,7 @@ output_folder/
 {dataset_list}
 |       +-- hdf/                  # Processed images as single .h5 per input (layers + metadata + grid state)
 |       +-- measurements/         # Per-image Parquet measurement files
-|       +-- overlays/             # Detection overlay PNGs (only when --save-overlays is set; default: OFF)
+|       +-- overlays/             # Detection overlay PNGs (one per input image)
 +-- dashboard.html                # Live processing dashboard
 +-- analysis.html                 # Analysis & visualization
 +-- master_measurements.csv       # Aggregated measurements (all datasets)
@@ -112,7 +112,7 @@ Each dataset directory contains the following folders:
 |--------|--------|-------------|
 | `hdf/` | HDF5 | Processed image (layers + metadata + grid state) saved as a single `.h5` per input image, reloadable via `Image.load_hdf5` / `GridImage.load_hdf5`. |
 | `measurements/` | Parquet | Per-object measurements. |
-| `overlays/` | PNG | Detection overlay visualizations. Created only when the run was invoked with `--save-overlays` (default: OFF). |"""
+| `overlays/` | PNG | Detection overlay visualizations (always written for forward runs). |"""
 
     def _generate_measurements_section(self) -> str:
         """Generate measurement documentation from pipeline's MeasureFeatures.

--- a/src/phenotypic/_cli/_cli_slurm_array_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_array_scripts.py
@@ -243,7 +243,7 @@ def generate_array_job_script(
     # Measure-only mode supersedes overlay generation; they are mutually exclusive.
     if config.measure_only:
         cmd_parts.append("--measure")
-    elif config.save_overlays:
+    else:
         cmd_parts.append("--save-overlays")
 
     # Add event log

--- a/src/phenotypic/_cli/_cli_slurm_array_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_array_scripts.py
@@ -213,10 +213,12 @@ def generate_array_job_script(
         config.image_type,
     ]
 
-    # Add grid parameters if GridImage
+    # Omit when unset so the worker falls back to the pipeline's preset.
     if config.image_type == "GridImage":
-        cmd_parts.extend(["--nrows", str(config.nrows)])
-        cmd_parts.extend(["--ncols", str(config.ncols)])
+        if config.nrows is not None:
+            cmd_parts.extend(["--nrows", str(config.nrows)])
+        if config.ncols is not None:
+            cmd_parts.extend(["--ncols", str(config.ncols)])
 
     # Add bit depth if specified
     if config.bit_depth is not None:

--- a/src/phenotypic/_cli/_cli_slurm_array_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_array_scripts.py
@@ -65,6 +65,23 @@ def _build_entry_list(
     return entries
 
 
+def _max_images_per_chunk(array_limit: int, checkpoint_interval: int) -> int:
+    """Largest per-chunk image count whose entry list fits ``array_limit``.
+
+    The bash entry list interleaves checkpoint/manifest sentinels every
+    ``checkpoint_interval`` images and may append a checkpoint+manifest+
+    finalizer triple on the last chunk. The ``--array=0-N`` directive is
+    sized from ``len(entries)`` and must satisfy ``len(entries) <=
+    MaxArraySize``. Solves ``C + 2*ceil(C/K) + 3 <= L`` for ``C``.
+    """
+    if array_limit <= 3:
+        return max(1, array_limit)
+    if checkpoint_interval is None or checkpoint_interval <= 0:
+        return max(1, array_limit - 3)
+    k = checkpoint_interval
+    return max(1, (array_limit - 3) * k // (k + 2))
+
+
 def _resolve_checkpoint_interval(config: ExecutionConfig) -> int:
     """Resolve checkpoint interval from config or auto-estimate from SLURM capacity.
 
@@ -411,13 +428,15 @@ def generate_all_array_job_scripts(
     from ._cli_slurm_config import calculate_optimal_array_chunks
 
     checkpoint_interval = _resolve_checkpoint_interval(config)
+    # Reserve array slots for sentinels so len(entries) stays within MaxArraySize.
+    image_chunk_limit = _max_images_per_chunk(array_limit, checkpoint_interval)
     all_scripts: Dict[str, List[Path]] = {}
 
     # Pre-compute chunk lists per dataset so we can identify the last chunk
     # across all datasets for finalizer sentinel placement.
     active_datasets = [ds for ds in datasets if ds.images]
     dataset_chunks = [
-        (ds, calculate_optimal_array_chunks(len(ds.images), array_limit))
+        (ds, calculate_optimal_array_chunks(len(ds.images), image_chunk_limit))
         for ds in active_datasets
     ]
 

--- a/src/phenotypic/_cli/_cli_slurm_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_scripts.py
@@ -106,10 +106,12 @@ def generate_image_processing_script(
         config.image_type,
     ]
 
-    # Add grid parameters if GridImage
+    # Omit when unset so the worker falls back to the pipeline's preset.
     if config.image_type == "GridImage":
-        cmd_parts.extend(["--nrows", str(config.nrows)])
-        cmd_parts.extend(["--ncols", str(config.ncols)])
+        if config.nrows is not None:
+            cmd_parts.extend(["--nrows", str(config.nrows)])
+        if config.ncols is not None:
+            cmd_parts.extend(["--ncols", str(config.ncols)])
 
     # Add bit depth if specified
     if config.bit_depth is not None:

--- a/src/phenotypic/_cli/_cli_state_management.py
+++ b/src/phenotypic/_cli/_cli_state_management.py
@@ -236,16 +236,6 @@ def validate_resume_compatibility(
         if state.config.get("ncols") != config.ncols:
             return False, f"Grid cols mismatch: saved={state.config.get('ncols')}, current={config.ncols}"
 
-    # Check save_overlays flag — default to False for state files written
-    # before --save-overlays existed, so older state files remain resumable.
-    saved_save_overlays = state.config.get("save_overlays", False)
-    current_save_overlays = getattr(config, "save_overlays", False)
-    if saved_save_overlays != current_save_overlays:
-        return False, (
-            f"save_overlays mismatch: saved={saved_save_overlays}, "
-            f"current={current_save_overlays}"
-        )
-
     return True, None
 
 

--- a/src/phenotypic/_cli/_cli_types.py
+++ b/src/phenotypic/_cli/_cli_types.py
@@ -119,8 +119,9 @@ class ExecutionConfig:
     # Detection mode (default: gray)
     detect_mode: str = "gray"
 
-    # Overlay PNG output is opt-in (default: off)
-    save_overlays: bool = False
+    # Overlay PNG output is always-on for forward runs; --measure runs
+    # never regenerate overlays regardless of this flag.
+    save_overlays: bool = True
 
     # Measure-only mode: reload HDFs and rerun pipeline.measure() without detection
     measure_only: bool = False

--- a/src/phenotypic/_cli/_cli_types.py
+++ b/src/phenotypic/_cli/_cli_types.py
@@ -84,10 +84,12 @@ class ExecutionConfig:
     input_path: Path
     output_dir: Optional[Path]
     
-    # Image configuration
+    # Image configuration. ``nrows``/``ncols`` are optional CLI overrides:
+    # ``None`` means "no explicit CLI value, fall back to the pipeline's soft
+    # preset or the built-in default at image-load time".
     image_type: Literal["Image", "GridImage"]
-    nrows: int
-    ncols: int
+    nrows: Optional[int]
+    ncols: Optional[int]
     bit_depth: Optional[int]
 
     # Execution mode

--- a/src/phenotypic/_cli/_cli_utils.py
+++ b/src/phenotypic/_cli/_cli_utils.py
@@ -30,10 +30,52 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 import click
 
+from ._cli_constants import DEFAULT_GRID_ROWS, DEFAULT_GRID_COLS
+
 logger = logging.getLogger(__name__)
 
 # Allowed image file extensions for PhenoTypic processing
 ALLOWED_EXTENSIONS: Set[str] = {".png", ".tif", ".tiff", ".jpg", ".jpeg"}
+
+
+def resolve_grid_shape(
+    cli_nrows: Optional[int],
+    cli_ncols: Optional[int],
+    pipeline_nrows: Optional[int],
+    pipeline_ncols: Optional[int],
+    default_nrows: int = DEFAULT_GRID_ROWS,
+    default_ncols: int = DEFAULT_GRID_COLS,
+) -> Tuple[int, int]:
+    """Resolve effective ``(nrows, ncols)`` for a ``GridImage`` load.
+
+    Precedence: explicit CLI flag > pipeline soft preset > built-in default.
+
+    Args:
+        cli_nrows: Value from the ``--nrows`` flag, or ``None`` if not passed.
+        cli_ncols: Value from the ``--ncols`` flag, or ``None`` if not passed.
+        pipeline_nrows: Pipeline-level preset (``ImagePipeline.nrows``), or
+            ``None`` if unset.
+        pipeline_ncols: Pipeline-level preset (``ImagePipeline.ncols``), or
+            ``None`` if unset.
+        default_nrows: Built-in fallback when neither CLI nor pipeline supplies
+            a value.
+        default_ncols: Built-in fallback when neither CLI nor pipeline supplies
+            a value.
+
+    Returns:
+        Tuple ``(nrows, ncols)`` with all ``None`` values resolved.
+    """
+    nrows = (
+        cli_nrows
+        if cli_nrows is not None
+        else (pipeline_nrows if pipeline_nrows is not None else default_nrows)
+    )
+    ncols = (
+        cli_ncols
+        if cli_ncols is not None
+        else (pipeline_ncols if pipeline_ncols is not None else default_ncols)
+    )
+    return nrows, ncols
 
 # Thread-pinning snippet for SLURM bash scripts. Ensures Polars and NumPy
 # respect the SLURM CPU allocation. Must appear before any Python import.
@@ -91,7 +133,6 @@ def scan_parquets(
         Ordered dict mapping each original *Path* to a lazy frame.
         Files that could not be scanned/read are omitted.
     """
-    import polars as pl
 
     if not parquet_files:
         return {}

--- a/src/phenotypic/_cli/_cli_validation.py
+++ b/src/phenotypic/_cli/_cli_validation.py
@@ -75,11 +75,13 @@ def validate_execution_config(
     if not config.input_path.exists():
         return False, f"Input path not found: {config.input_path}"
     
-    # Check grid dimensions for GridImage
+    # Check grid dimensions for GridImage. ``None`` means "no CLI override —
+    # fall back to the pipeline preset / built-in default at resolve time"
+    # and is valid here; only explicit non-positive values are rejected.
     if config.image_type == "GridImage":
-        if config.nrows <= 0:
+        if config.nrows is not None and config.nrows <= 0:
             return False, f"Invalid nrows: {config.nrows} (must be positive)"
-        if config.ncols <= 0:
+        if config.ncols is not None and config.ncols <= 0:
             return False, f"Invalid ncols: {config.ncols} (must be positive)"
     
     # Check n_jobs is valid

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_dash_handler.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_dash_handler.py
@@ -16,6 +16,18 @@ try:
     import plotly.graph_objects as go
 
     PLOTLY_AVAILABLE = True
+
+    import os as _os
+
+    if _os.environ.get("PHENOTYPIC_DOCS_BUILD"):
+        # nbsphinx captures cell outputs from the kernel's HTML mimetype, but
+        # Plotly's default ``plotly_mimetype+notebook`` renderer emits a JSON
+        # MIME bundle that nbsphinx drops. ``notebook_connected`` swaps that for
+        # an HTML+CDN-script bundle so dash() figures survive into the static
+        # site.
+        import plotly.io as _pio
+
+        _pio.renderers.default = "notebook_connected"
 except ImportError:  # pragma: no cover
     PLOTLY_AVAILABLE = False
 

--- a/src/phenotypic/_core/_pipeline_parts/_image_pipeline_core.py
+++ b/src/phenotypic/_core/_pipeline_parts/_image_pipeline_core.py
@@ -106,6 +106,8 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
             name: Optional[str] = None,
             desc: Optional[str] = None,
             reset: bool = False,
+            nrows: Optional[int] = None,
+            ncols: Optional[int] = None,
     ):
         """
         This class represents a processing and measurement interface for Image operations
@@ -131,6 +133,12 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
             reset: Default reset behavior for the apply() method. When True, the image
                 will be reset before applying operations. Can be overridden per-call
                 in apply() and apply_and_measure(). Defaults to False.
+            nrows: Optional soft preset for the grid row count. When set together with
+                ``ncols``, ``measure()`` auto-injects an ``AutoGridFinder(nrows, ncols)``
+                at the front of the measurement run order if no ``GridFinder`` step is
+                already configured. Consumed by the CLIs to drive grid-aware image
+                construction. ``None`` (default) means "no preset".
+            ncols: Optional soft preset for the grid column count. See ``nrows``.
         """
         # If pipe_cfgs is a list of operations convert to a dictionary
         self._ops: Dict[str, ImageOperation] = {}
@@ -149,6 +157,9 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
         self._benchmark = benchmark
         self._verbose = verbose
         self._reset = reset
+
+        self._nrows: Optional[int] = nrows
+        self._ncols: Optional[int] = ncols
 
         # Set pipeline name (generate UUID4 if not provided)
         self.name = name if name is not None else str(uuid.uuid4())
@@ -179,6 +190,16 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
     def desc(self, value: Optional[str]):
         """Set pipeline description."""
         self._desc = value
+
+    @property
+    def nrows(self) -> Optional[int]:
+        """Soft preset for grid row count, or ``None`` if unset."""
+        return self._nrows
+
+    @property
+    def ncols(self) -> Optional[int]:
+        """Soft preset for grid column count, or ``None`` if unset."""
+        return self._ncols
 
     def set_ops(self, ops: List[ImageOperation | ImagePipeline] | Dict[str, ImageOperation | ImagePipeline]):
         """
@@ -578,6 +599,8 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
             self._measurement_memory = {}
             self._measurement_rss = {}
 
+        meas_to_run: Dict[str, MeasureFeatures] = self._build_measurement_run_order()
+
         # Print message if verbose and benchmark are enabled
         if self._benchmark and self._verbose:
             print("Measuring image properties...")
@@ -613,7 +636,7 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
                 from tqdm import tqdm
 
                 # Create a tqdm instance without items to manually update it
-                total_measurements = len(self._meas)
+                total_measurements = len(meas_to_run)
                 pbar = tqdm(
                         total=total_measurements,
                         desc="Applying measurements",
@@ -626,8 +649,8 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
             has_tqdm = False
 
         # perform measurements
-        for i, (key, measurement) in enumerate(self._meas.items()):
-            logger.debug("Running measurement [%d/%d]: %s", i + 1, len(self._meas), key)
+        for i, (key, measurement) in enumerate(meas_to_run.items()):
+            logger.debug("Running measurement [%d/%d]: %s", i + 1, len(meas_to_run), key)
             try:
                 # Update progress bar description with current measurement
                 if self._benchmark and self._verbose:
@@ -686,6 +709,41 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
             df = post_op.apply(df)
 
         return df
+
+    def _build_measurement_run_order(self) -> Dict[str, MeasureFeatures]:
+        """Return the measurements to execute for this ``measure()`` call.
+
+        Returns a copy of ``self._meas`` with one optional addition: when both
+        ``self._nrows`` and ``self._ncols`` are set and no existing measurement
+        is an instance of :class:`GridFinder`, an ``AutoGridFinder`` configured
+        with the preset is prepended so it runs before downstream grid-aware
+        measurements. The persistent ``self._meas`` mapping is never mutated,
+        which keeps repeat ``measure()`` calls idempotent and serialization
+        unaffected.
+
+        Returns:
+            Dict[str, MeasureFeatures]: Ordered measurement dict for this run.
+        """
+        if self._nrows is None or self._ncols is None:
+            return self._meas
+
+        # Lazy imports to avoid circular dependency with phenotypic.grid.
+        from phenotypic.abc_ import GridFinder
+        from phenotypic.grid import AutoGridFinder
+
+        if any(isinstance(m, GridFinder) for m in self._meas.values()):
+            return self._meas
+
+        injected_key = (
+            "AutoGridFinder"
+            if "AutoGridFinder" not in self._meas
+            else "_AutoGridFinder_preset"
+        )
+        run_order: Dict[str, MeasureFeatures] = {
+            injected_key: AutoGridFinder(nrows=self._nrows, ncols=self._ncols),
+        }
+        run_order.update(self._meas)
+        return run_order
 
     def apply_and_measure(
             self,

--- a/src/phenotypic/_core/_pipeline_parts/_serializable_pipeline.py
+++ b/src/phenotypic/_core/_pipeline_parts/_serializable_pipeline.py
@@ -83,7 +83,7 @@ class SerializablePipeline(NapariPipelineViewer):
             in a human-readable manner. This includes the phenotypic version, pipeline
             name, description, and the lists of operations and measurements.
         """
-        config = {
+        config: Dict[str, object] = {
             "version"  : __version__,
             "name"     : self.name,
             "desc"     : self._desc,
@@ -92,6 +92,12 @@ class SerializablePipeline(NapariPipelineViewer):
             "meas"     : self._serialize_operations(self._meas),
             "post"     : self._serialize_operations(self._post),
         }
+
+        # Omit when unset so legacy JSONs round-trip unchanged.
+        if self._nrows is not None:
+            config["nrows"] = self._nrows
+        if self._ncols is not None:
+            config["ncols"] = self._ncols
 
         return json.dumps(config, indent=2)
 
@@ -163,6 +169,8 @@ class SerializablePipeline(NapariPipelineViewer):
         name = config.get("name", None)
         desc = config.get("desc", None)
         reset = config.get("reset", False)  # Default False for backwards compatibility
+        nrows = config.get("nrows", None)
+        ncols = config.get("ncols", None)
         saved_version = config.get("version", None)
 
         # Check version compatibility
@@ -177,7 +185,7 @@ class SerializablePipeline(NapariPipelineViewer):
 
         # Create and return new pipeline instance
         return cls(ops=ops, meas=meas, post=post, benchmark=benchmark, verbose=verbose,
-                   name=name, desc=desc, reset=reset)
+                   name=name, desc=desc, reset=reset, nrows=nrows, ncols=ncols)
 
     @staticmethod
     def _serialize_operations(

--- a/src/phenotypic/_core/_pipeline_parts/_serializable_pipeline.py
+++ b/src/phenotypic/_core/_pipeline_parts/_serializable_pipeline.py
@@ -37,7 +37,7 @@ class SerializablePipeline(NapariPipelineViewer):
     automatically excluded from serialization.
     """
 
-    def to_json(self, filepath: Optional[Union[str, Path]] = None) -> str:
+    def to_json(self, filepath: Optional[Union[str, Path]] = None) -> str | None:
         """
         Serialize the pipeline configuration to JSON format.
 
@@ -66,8 +66,9 @@ class SerializablePipeline(NapariPipelineViewer):
 
         if filepath is not None:
             Path(filepath).write_text(json_str)
-
-        return json_str
+            return None
+        else:
+            return json_str
 
     def __str__(self) -> str:
         """
@@ -209,15 +210,17 @@ class SerializablePipeline(NapariPipelineViewer):
             # Handle operations that are themselves pipelines (e.g., PrefabPipeline as op)
             if isinstance(op, SerializablePipeline):
                 serialized[name] = {
-                    "class": class_name,
+                    "class"   : class_name,
                     "__type__": "pipeline_operation",
-                    "config": {
-                        "version": __version__,
-                        "name": op.name,
-                        "desc": op._desc,
-                        "reset": op._reset,
-                        "pipe_cfgs": SerializablePipeline._serialize_operations(op._ops),
-                        "meas": SerializablePipeline._serialize_operations(op._meas),
+                    "config"  : {
+                        "version"  : __version__,
+                        "name"     : op.name,
+                        "desc"     : op._desc,
+                        "reset"    : op._reset,
+                        "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                op._ops),
+                        "meas"     : SerializablePipeline._serialize_operations(
+                                op._meas),
                     },
                 }
                 continue
@@ -237,44 +240,52 @@ class SerializablePipeline(NapariPipelineViewer):
                 if isinstance(value, (ImageOperation, MeasureFeatures)):
                     params[key] = {
                         "__type__": "operation",
-                        "class": value.__class__.__name__,
-                        "params": SerializablePipeline._serialize_single_operation(value)
+                        "class"   : value.__class__.__name__,
+                        "params"  : SerializablePipeline._serialize_single_operation(
+                                value)
                     }
                     continue
 
                 # Handle nested ImagePipeline instances (check before operations)
                 if isinstance(value, SerializablePipeline):
                     pipeline_config = {
-                        "version": __version__,
-                        "name": value.name,
-                        "desc": value._desc,
-                        "pipe_cfgs": SerializablePipeline._serialize_operations(value._ops),
-                        "meas": SerializablePipeline._serialize_operations(value._meas),
+                        "version"  : __version__,
+                        "name"     : value.name,
+                        "desc"     : value._desc,
+                        "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                value._ops),
+                        "meas"     : SerializablePipeline._serialize_operations(
+                                value._meas),
                     }
                     params[key] = {
                         "__type__": "pipeline",
-                        "config": pipeline_config
+                        "config"  : pipeline_config
                     }
                     continue
 
                 # Handle lists - check for mixed types (operations and/or pipelines)
                 if isinstance(value, list) and value:
                     # Check if list contains any pipelines
-                    has_pipeline = any(isinstance(item, SerializablePipeline) for item in value)
-                    has_operation = any(isinstance(item, (ImageOperation, MeasureFeatures)) for item in value)
+                    has_pipeline = any(
+                            isinstance(item, SerializablePipeline) for item in value)
+                    has_operation = any(
+                            isinstance(item, (ImageOperation, MeasureFeatures)) for item
+                            in value)
 
                     if has_pipeline and not has_operation:
                         # Pure pipeline list
                         params[key] = {
                             "__type__": "pipeline_list",
-                            "items": [
+                            "items"   : [
                                 {
                                     "config": {
-                                        "version": __version__,
-                                        "name": item.name,
-                                        "desc": item._desc,
-                                        "pipe_cfgs": SerializablePipeline._serialize_operations(item._ops),
-                                        "meas": SerializablePipeline._serialize_operations(item._meas),
+                                        "version"  : __version__,
+                                        "name"     : item.name,
+                                        "desc"     : item._desc,
+                                        "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                                item._ops),
+                                        "meas"     : SerializablePipeline._serialize_operations(
+                                                item._meas),
                                     }
                                 }
                                 for item in value
@@ -285,10 +296,11 @@ class SerializablePipeline(NapariPipelineViewer):
                         # Pure operation list
                         params[key] = {
                             "__type__": "operation_list",
-                            "items": [
+                            "items"   : [
                                 {
-                                    "class": item.__class__.__name__,
-                                    "params": SerializablePipeline._serialize_single_operation(item)
+                                    "class" : item.__class__.__name__,
+                                    "params": SerializablePipeline._serialize_single_operation(
+                                            item)
                                 }
                                 for item in value
                             ]
@@ -301,22 +313,25 @@ class SerializablePipeline(NapariPipelineViewer):
                             if isinstance(item, SerializablePipeline):
                                 items.append({
                                     "__type__": "pipeline",
-                                    "config": {
-                                        "version": __version__,
-                                        "name": item.name,
-                                        "desc": item._desc,
-                                        "pipe_cfgs": SerializablePipeline._serialize_operations(item._ops),
-                                        "meas": SerializablePipeline._serialize_operations(item._meas),
+                                    "config"  : {
+                                        "version"  : __version__,
+                                        "name"     : item.name,
+                                        "desc"     : item._desc,
+                                        "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                                item._ops),
+                                        "meas"     : SerializablePipeline._serialize_operations(
+                                                item._meas),
                                     }
                                 })
                             else:
                                 items.append({
-                                    "class": item.__class__.__name__,
-                                    "params": SerializablePipeline._serialize_single_operation(item)
+                                    "class" : item.__class__.__name__,
+                                    "params": SerializablePipeline._serialize_single_operation(
+                                            item)
                                 })
                         params[key] = {
                             "__type__": "operation_list",
-                            "items": items
+                            "items"   : items
                         }
                         continue
 
@@ -358,15 +373,16 @@ class SerializablePipeline(NapariPipelineViewer):
             # Handle nested ImagePipeline instances (check before operations)
             if isinstance(value, SerializablePipeline):
                 pipeline_config = {
-                    "version": __version__,
-                    "name": value.name,
-                    "desc": value._desc,
+                    "version"  : __version__,
+                    "name"     : value.name,
+                    "desc"     : value._desc,
                     "pipe_cfgs": SerializablePipeline._serialize_operations(value._ops),
-                    "meas": SerializablePipeline._serialize_operations(value._meas),
+                    "meas"     : SerializablePipeline._serialize_operations(
+                            value._meas),
                 }
                 params[key] = {
                     "__type__": "pipeline",
-                    "config": pipeline_config
+                    "config"  : pipeline_config
                 }
                 continue
 
@@ -374,29 +390,34 @@ class SerializablePipeline(NapariPipelineViewer):
             if isinstance(value, (ImageOperation, MeasureFeatures)):
                 params[key] = {
                     "__type__": "operation",
-                    "class": value.__class__.__name__,
-                    "params": SerializablePipeline._serialize_single_operation(value)
+                    "class"   : value.__class__.__name__,
+                    "params"  : SerializablePipeline._serialize_single_operation(value)
                 }
                 continue
 
             # Handle lists - check for mixed types (operations and/or pipelines)
             if isinstance(value, list) and value:
                 # Check if list contains any pipelines
-                has_pipeline = any(isinstance(item, SerializablePipeline) for item in value)
-                has_operation = any(isinstance(item, (ImageOperation, MeasureFeatures)) for item in value)
+                has_pipeline = any(
+                        isinstance(item, SerializablePipeline) for item in value)
+                has_operation = any(
+                        isinstance(item, (ImageOperation, MeasureFeatures)) for item in
+                        value)
 
                 if has_pipeline and not has_operation:
                     # Pure pipeline list
                     params[key] = {
                         "__type__": "pipeline_list",
-                        "items": [
+                        "items"   : [
                             {
                                 "config": {
-                                    "version": __version__,
-                                    "name": item.name,
-                                    "desc": item._desc,
-                                    "pipe_cfgs": SerializablePipeline._serialize_operations(item._ops),
-                                    "meas": SerializablePipeline._serialize_operations(item._meas),
+                                    "version"  : __version__,
+                                    "name"     : item.name,
+                                    "desc"     : item._desc,
+                                    "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                            item._ops),
+                                    "meas"     : SerializablePipeline._serialize_operations(
+                                            item._meas),
                                 }
                             }
                             for item in value
@@ -407,10 +428,11 @@ class SerializablePipeline(NapariPipelineViewer):
                     # Pure operation list
                     params[key] = {
                         "__type__": "operation_list",
-                        "items": [
+                        "items"   : [
                             {
-                                "class": item.__class__.__name__,
-                                "params": SerializablePipeline._serialize_single_operation(item)
+                                "class" : item.__class__.__name__,
+                                "params": SerializablePipeline._serialize_single_operation(
+                                        item)
                             }
                             for item in value
                         ]
@@ -423,22 +445,25 @@ class SerializablePipeline(NapariPipelineViewer):
                         if isinstance(item, SerializablePipeline):
                             items.append({
                                 "__type__": "pipeline",
-                                "config": {
-                                    "version": __version__,
-                                    "name": item.name,
-                                    "desc": item._desc,
-                                    "pipe_cfgs": SerializablePipeline._serialize_operations(item._ops),
-                                    "meas": SerializablePipeline._serialize_operations(item._meas),
+                                "config"  : {
+                                    "version"  : __version__,
+                                    "name"     : item.name,
+                                    "desc"     : item._desc,
+                                    "pipe_cfgs": SerializablePipeline._serialize_operations(
+                                            item._ops),
+                                    "meas"     : SerializablePipeline._serialize_operations(
+                                            item._meas),
                                 }
                             })
                         else:
                             items.append({
-                                "class": item.__class__.__name__,
-                                "params": SerializablePipeline._serialize_single_operation(item)
+                                "class" : item.__class__.__name__,
+                                "params": SerializablePipeline._serialize_single_operation(
+                                        item)
                             })
                     params[key] = {
                         "__type__": "operation_list",
-                        "items": items
+                        "items"   : items
                     }
                     continue
 
@@ -477,6 +502,7 @@ class SerializablePipeline(NapariPipelineViewer):
             # Handle pipeline-as-operation entries
             if op_data.get("__type__") == "pipeline_operation":
                 from phenotypic._core._image_pipeline import ImagePipeline
+
                 pipeline = ImagePipeline.from_json(op_data["config"])
                 # Re-tag to specific subclass if found
                 op_class = SerializablePipeline._find_class_in_phenotypic(class_name)
@@ -531,8 +557,8 @@ class SerializablePipeline(NapariPipelineViewer):
             op_class = cls._find_class_in_phenotypic(value["class"])
             if op_class is None:
                 raise AttributeError(
-                    f"Class '{value['class']}' not found in phenotypic namespace. "
-                    f"Make sure it's properly imported in phenotypic.__init__.py"
+                        f"Class '{value['class']}' not found in phenotypic namespace. "
+                        f"Make sure it's properly imported in phenotypic.__init__.py"
                 )
             instance = op_class()
             for nested_key, nested_value in value["params"].items():
@@ -546,6 +572,7 @@ class SerializablePipeline(NapariPipelineViewer):
                 # Check if item is a pipeline
                 if item_data.get("__type__") == "pipeline":
                     from phenotypic import ImagePipeline
+
                     json_str = json.dumps(item_data["config"])
                     pipeline = ImagePipeline.from_json(json_str)
                     operation_list.append(pipeline)
@@ -554,18 +581,20 @@ class SerializablePipeline(NapariPipelineViewer):
                     item_class = cls._find_class_in_phenotypic(item_data["class"])
                     if item_class is None:
                         raise AttributeError(
-                            f"Class '{item_data['class']}' not found in phenotypic namespace. "
-                            f"Make sure it's properly imported in phenotypic.__init__.py"
+                                f"Class '{item_data['class']}' not found in phenotypic namespace. "
+                                f"Make sure it's properly imported in phenotypic.__init__.py"
                         )
                     item_instance = item_class()
                     for item_key, item_value in item_data["params"].items():
-                        setattr(item_instance, item_key, cls._deserialize_value(item_value))
+                        setattr(item_instance, item_key,
+                                cls._deserialize_value(item_value))
                     operation_list.append(item_instance)
             return operation_list
 
         # Handle nested ImagePipeline
         elif isinstance(value, dict) and value.get("__type__") == "pipeline":
             from phenotypic import ImagePipeline
+
             json_str = json.dumps(value["config"])
             pipeline = ImagePipeline.from_json(json_str)
             return pipeline
@@ -573,6 +602,7 @@ class SerializablePipeline(NapariPipelineViewer):
         # Handle list of ImagePipeline instances
         elif isinstance(value, dict) and value.get("__type__") == "pipeline_list":
             from phenotypic import ImagePipeline
+
             pipeline_list = []
             for item_data in value["items"]:
                 json_str = json.dumps(item_data["config"])

--- a/src/phenotypic/data/_sample_image_data.py
+++ b/src/phenotypic/data/_sample_image_data.py
@@ -182,7 +182,7 @@ def load_yeast_plate(
                                  "RhodotorulaYeastCenterCrop.png",
             mode=mode,
             nrows=2,
-            ncols=4
+            ncols=3
     )
 
 

--- a/src/phenotypic/data/_sample_image_data.py
+++ b/src/phenotypic/data/_sample_image_data.py
@@ -182,7 +182,7 @@ def load_yeast_plate(
                                  "RhodotorulaYeastCenterCrop.png",
             mode=mode,
             nrows=2,
-            ncols=3
+            ncols=4
     )
 
 

--- a/src/phenotypic/grid/_auto_grid_finder.py
+++ b/src/phenotypic/grid/_auto_grid_finder.py
@@ -132,83 +132,6 @@ class AutoGridFinder(GridFinder):
         return float((centers[-1] - centers[0]) / max(n_expected - 1, 1))
 
     @staticmethod
-    def _robust_pitch_estimate(
-            centers: np.ndarray, n_expected: int, image_dim: int,
-    ) -> float:
-        """Estimate grid pitch robustly using the mode of successive differences.
-
-        Two reference pitches are computed: ``span_pitch`` from
-        ``(max - min) / (n_expected - 1)`` and ``image_pitch`` from
-        ``image_dim / n_expected``. The mode of successive differences
-        is binned at ``image_pitch / 4`` (more reliable than span-based
-        binning when edge wells are missing). The mode is accepted when
-        it falls within ``[0.5x, 2.0x]`` of *either* reference; when
-        neither agrees the function falls back to whichever reference
-        is closer to the mode. This dual-reference scheme tolerates
-        edge-row/col detection dropouts (where ``span_pitch`` shrinks
-        artificially) without losing protection against mode estimates
-        dominated by within-cell fragmentation.
-
-        Args:
-            centers: Sorted 1-D array of object center coordinates.
-            n_expected: Number of expected grid positions along this axis.
-            image_dim: Image extent along this axis, used to compute the
-                structural ``image_pitch`` reference.
-
-        Returns:
-            Estimated pitch in pixels.
-        """
-        span_pitch = AutoGridFinder._estimate_pitch(centers, n_expected)
-        image_pitch = float(image_dim / n_expected)
-        if span_pitch <= 0:
-            warnings.warn(
-                f"AutoGridFinder._robust_pitch_estimate: span pitch <= 0 "
-                f"(span_pitch={span_pitch}); returning as-is.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=4,
-            )
-            return span_pitch
-
-        diffs = np.diff(centers)
-        diffs = diffs[diffs > 0]
-        if len(diffs) < 2:
-            warnings.warn(
-                f"AutoGridFinder._robust_pitch_estimate: only {len(diffs)} "
-                f"positive successive differences; falling back to span pitch "
-                f"({span_pitch:.2f}).",
-                AutoGridFinderFallbackWarning,
-                stacklevel=4,
-            )
-            return span_pitch
-
-        bin_width = image_pitch / 4.0
-        n_bins = max(int(np.ceil(diffs.max() / bin_width)), 1)
-        counts, bin_edges = np.histogram(diffs, bins=n_bins, range=(0, diffs.max() + bin_width))
-        mode_bin = np.argmax(counts)
-        mode_pitch = float((bin_edges[mode_bin] + bin_edges[mode_bin + 1]) / 2.0)
-
-        ref_low = min(0.5 * span_pitch, 0.5 * image_pitch)
-        ref_high = max(2.0 * span_pitch, 2.0 * image_pitch)
-        if not (ref_low <= mode_pitch <= ref_high):
-            closer_ref = (
-                image_pitch
-                if abs(mode_pitch - image_pitch) < abs(mode_pitch - span_pitch)
-                else span_pitch
-            )
-            which = "image" if closer_ref == image_pitch else "span"
-            warnings.warn(
-                f"AutoGridFinder._robust_pitch_estimate: mode pitch "
-                f"({mode_pitch:.2f}) outside [{ref_low:.2f}, {ref_high:.2f}] "
-                f"of either span_pitch ({span_pitch:.2f}) or image_pitch "
-                f"({image_pitch:.2f}); falling back to {which}_pitch "
-                f"({closer_ref:.2f}).",
-                AutoGridFinderFallbackWarning,
-                stacklevel=4,
-            )
-            return closer_ref
-        return mode_pitch
-
-    @staticmethod
     def _assign_grid_indices(
             centers: np.ndarray,
             pitch: float,
@@ -334,6 +257,53 @@ class AutoGridFinder(GridFinder):
             pitch, pitch / 2, n_expected, image_dim,
         )
 
+    @staticmethod
+    def _image_pitch_indices(
+            centers: np.ndarray, n_expected: int, image_dim: int,
+    ) -> np.ndarray:
+        """Assign cell indices using image-pitch prior (sparse-robust).
+
+        Independent of any fitted pitch, so usable as diagnostic ground
+        truth even when the fitter has failed. Centers are rounded to
+        the nearest cell using ``image_dim / n_expected`` as pitch with
+        cell 0 anchored at ``image_pitch / 2``. Indices are clipped to
+        ``[0, n_expected - 1]``.
+        """
+        if len(centers) == 0:
+            return np.empty(0, dtype=int)
+        image_pitch = image_dim / n_expected
+        anchor = image_pitch / 2.0
+        idx = np.rint((centers - anchor) / image_pitch).astype(int)
+        return np.clip(idx, 0, n_expected - 1)
+
+    @staticmethod
+    def _classify_axis_pipeline(
+            centers: np.ndarray, n_expected: int, image_dim: int,
+    ) -> str:
+        """Return ``"iterative"`` or ``"simple"`` per the per-axis gate.
+
+        The simple pipeline runs only when BOTH the raw count and the
+        per-axis occupancy (via :meth:`_image_pitch_indices`) are too
+        low for iterative refinement to seed reliably:
+
+        - ``count_low``: ``len(centers) < 1.5 * n_expected``
+        - ``occupancy_low``: ``n_occupied < 0.5 * n_expected``
+
+        Either condition alone routes to ``"iterative"``. This helper
+        is the single source of truth for the gate, used by
+        :meth:`_fit_axis_edges` (dispatch) and
+        :meth:`_run_timed_pipeline` (dashboard label).
+        """
+        if len(centers) < 2:
+            return "iterative"  # caller handles len < 2 separately
+        axis_indices = AutoGridFinder._image_pitch_indices(
+            centers, n_expected, image_dim,
+        )
+        n_occupied = int(np.unique(axis_indices).size)
+        count_low = len(centers) < 1.5 * n_expected
+        occupancy_low = n_occupied < 0.5 * n_expected
+        return "simple" if (count_low and occupancy_low) else "iterative"
+
     def _fit_axis_edges_simple(
             self,
             centers: np.ndarray,
@@ -407,6 +377,140 @@ class AutoGridFinder(GridFinder):
 
         return self._compute_grid_edges(pitch, offset, n_expected, image_dim)
 
+    def _fit_axis_edges_iterative(
+            self,
+            centers: np.ndarray,
+            n_expected: int,
+            image_dim: int,
+            axis_label: str = "axis",
+    ) -> np.ndarray:
+        """Iterative cell-median refinement seeded from image-pitch indices.
+
+        Each iteration: aggregate centers to one median per occupied cell,
+        closed-form fit ``center = pitch * idx + offset``, reassign
+        indices using the new fit. Terminates when index assignments
+        stop changing (or only a single boundary cell flickers after
+        an initial stabilization phase) or after ``MAX_ITER``
+        iterations. The image-pitch seed makes this robust to sparse
+        plates and within-cell fragmentation, since the initial
+        assignment uses only the structural prior, not the diff
+        distribution.
+        """
+        # MAX_ITER=16 covers the empirical worst case observed on dense
+        # plates (~1500 centers, convergence at iter 10). Each iteration
+        # is cheap (one closed-form fit + index reassignment).
+        MAX_ITER = 16
+        # After a stabilization phase, accept a single border-cell
+        # flicker as converged: the resulting fit drift is sub-pixel
+        # (e.g. on km-plate-12hr at iter 7, pitch=161.22 vs true
+        # convergence pitch=161.16, a 0.04% difference irrelevant
+        # post-rounding to integer edges).
+        STABILITY_PHASE = 4
+        STABILITY_TOL = 1
+
+        image_pitch = image_dim / n_expected
+        indices = self._image_pitch_indices(centers, n_expected, image_dim)
+        pitch, offset = image_pitch, image_pitch / 2.0
+
+        converged = False
+        for iter_num in range(MAX_ITER):
+            medians, unique_idx = self._aggregate_to_cell_medians(
+                centers, indices,
+            )
+            new_pitch, new_offset = self._fit_pitch_and_offset(
+                medians, unique_idx,
+            )
+            if new_pitch <= 0:
+                warnings.warn(
+                    f"AutoGridFinder ({axis_label}, iterative): degenerate "
+                    f"fit pitch <= 0 ({new_pitch}) at iter {iter_num}; "
+                    f"falling back to uniform edges.",
+                    AutoGridFinderFallbackWarning,
+                    stacklevel=4,
+                )
+                return self._uniform_edges(n_expected, image_dim)
+
+            new_indices = np.rint(
+                (centers - new_offset) / new_pitch,
+            ).astype(int)
+            new_indices = np.clip(new_indices, 0, n_expected - 1)
+
+            n_changed = int(np.sum(new_indices != indices))
+            pitch, offset = new_pitch, new_offset
+            if n_changed == 0:
+                converged = True
+                indices = new_indices
+                break
+            if iter_num >= STABILITY_PHASE and n_changed <= STABILITY_TOL:
+                # Single boundary cell flickering after stabilization
+                converged = True
+                indices = new_indices
+                break
+            indices = new_indices
+
+        if not converged:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, iterative): index "
+                f"assignments did not stabilize after {MAX_ITER} iterations; "
+                f"using last fit.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
+
+        # Final outlier rejection + refit on inlier cells
+        medians, unique_idx = self._aggregate_to_cell_medians(centers, indices)
+        threshold = pitch * self.residual_fraction
+        inlier_mask = self._identify_inliers(
+            medians, unique_idx, pitch, offset, threshold,
+        )
+        n_inliers = int(inlier_mask.sum())
+        if n_inliers >= 2:
+            pitch, offset = self._fit_pitch_and_offset(
+                medians[inlier_mask], unique_idx[inlier_mask],
+            )
+        else:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, iterative): only {n_inliers} "
+                f"cell-median inliers of {len(medians)} cells within residual "
+                f"threshold ({threshold:.2f}); skipping refit and using last "
+                f"fit.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
+        if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, iterative): refit pitch "
+                f"<= 0 ({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
+            return self._uniform_edges(n_expected, image_dim)
+
+        # Symmetry anchoring when detected span < expected.
+        #
+        # NOTE (latent design choice): unique_idx is post-clip to
+        # [0, n_expected - 1], so a single spurious detection past the
+        # image edge inflates the span and suppresses anchoring even
+        # when real coverage is genuinely sparse. The deleted robust
+        # path had the same blind spot. Tightening this would require
+        # an occupancy-based gate or a pitch-drift sanity guard
+        # (deferred per plan; see "Future enhancement" in
+        # /Users/alex/.claude/plans/lively-baking-plum.md).
+        span = int(unique_idx.max() - unique_idx.min()) + 1
+        if span < n_expected:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, iterative): detected span "
+                f"({span}) < n_expected ({n_expected}); recentering grid on "
+                f"image (symmetry anchoring overrides fitted offset).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
+            image_center = image_dim / 2.0
+            grid_center_idx = (n_expected - 1) / 2.0
+            offset = image_center - pitch * grid_center_idx
+
+        return self._compute_grid_edges(pitch, offset, n_expected, image_dim)
+
     def _fit_axis_edges(
             self,
             info_table: pd.DataFrame,
@@ -414,11 +518,12 @@ class AutoGridFinder(GridFinder):
             n_expected: int,
             image_dim: int,
     ) -> np.ndarray:
-        """Full pipeline: extract centers → fit → reject → refit → edges.
+        """Full pipeline: extract centers → fit → edges.
 
         Falls back to uniform spacing when fewer than 2 objects are found.
-        Uses the simple pipeline for low object counts and the robust
-        pipeline (median aggregation + robust pitch) for high counts.
+        Uses the simple pipeline for low-count *and* low-occupancy axes;
+        otherwise routes to the iterative pipeline (image-pitch seed +
+        cell-median refinement).
         """
         axis_label = (
             "rows" if axis == 0 else "cols" if axis == 1 else f"axis {axis}"
@@ -443,12 +548,20 @@ class AutoGridFinder(GridFinder):
             )
             return self._uniform_edges(n_expected, image_dim)
 
-        # Low-N guard: use simple pipeline when few objects
-        if len(centers) < 2 * n_expected:
+        # Per-axis sparsity gate: shared with `_run_timed_pipeline` via
+        # `_classify_axis_pipeline` so the dashboard label and the
+        # actual dispatch can never drift apart.
+        if self._classify_axis_pipeline(
+            centers, n_expected, image_dim,
+        ) == "simple":
+            n_occupied = int(np.unique(self._image_pitch_indices(
+                centers, n_expected, image_dim,
+            )).size)
             warnings.warn(
-                f"AutoGridFinder ({axis_label}): {len(centers)} centers < "
-                f"2 * n_expected ({2 * n_expected}); using simple pipeline "
-                f"instead of robust pipeline.",
+                f"AutoGridFinder ({axis_label}): {len(centers)} centers "
+                f"(< 1.5 * n_expected = {1.5 * n_expected:.1f}) and "
+                f"{n_occupied}/{n_expected} occupied cells (< 50%); using "
+                f"simple pipeline instead of iterative pipeline.",
                 AutoGridFinderFallbackWarning,
                 stacklevel=3,
             )
@@ -468,81 +581,9 @@ class AutoGridFinder(GridFinder):
             )
             return self._uniform_edges(n_expected, image_dim)
 
-        # --- Robust pipeline for high object counts ---
-
-        # Step 1: robust pitch estimate (mode of successive differences)
-        pitch = self._robust_pitch_estimate(centers, n_expected, image_dim)
-        if pitch <= 0:
-            warnings.warn(
-                f"AutoGridFinder ({axis_label}): robust pitch estimate "
-                f"<= 0 ({pitch}); falling back to uniform edges.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=3,
-            )
-            return self._uniform_edges(n_expected, image_dim)
-
-        # Step 2: assign grid indices with median anchor
-        anchor = float(np.median(centers))
-        indices = self._assign_grid_indices(centers, pitch, anchor=anchor)
-
-        # Step 3: aggregate to one median per grid cell
-        medians, unique_idx = self._aggregate_to_cell_medians(
-            centers, indices,
+        return self._fit_axis_edges_iterative(
+            centers, n_expected, image_dim, axis_label=axis_label,
         )
-
-        # Step 4: fit on aggregated medians (equal weight per cell)
-        pitch, offset = self._fit_pitch_and_offset(medians, unique_idx)
-        if pitch <= 0:
-            warnings.warn(
-                f"AutoGridFinder ({axis_label}): initial cell-median fit "
-                f"pitch <= 0 ({pitch}); falling back to uniform edges.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=3,
-            )
-            return self._uniform_edges(n_expected, image_dim)
-
-        # Step 5: outlier rejection + refit on cells
-        threshold = pitch * self.residual_fraction
-        inlier_mask = self._identify_inliers(
-            medians, unique_idx, pitch, offset, threshold,
-        )
-        n_inliers = int(inlier_mask.sum())
-        if n_inliers >= 2:
-            pitch, offset = self._fit_pitch_and_offset(
-                medians[inlier_mask], unique_idx[inlier_mask],
-            )
-        else:
-            warnings.warn(
-                f"AutoGridFinder ({axis_label}): only {n_inliers} cell-median "
-                f"inliers of {len(medians)} cells within residual threshold "
-                f"({threshold:.2f}); skipping refit and using initial fit.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=3,
-            )
-        if pitch <= 0:
-            warnings.warn(
-                f"AutoGridFinder ({axis_label}): refit pitch <= 0 ({pitch}); "
-                f"falling back to uniform edges.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=3,
-            )
-            return self._uniform_edges(n_expected, image_dim)
-
-        # Step 6: symmetry anchoring when detected span < expected
-        span = int(unique_idx.max() - unique_idx.min()) + 1
-        if span < n_expected:
-            warnings.warn(
-                f"AutoGridFinder ({axis_label}): detected span ({span}) < "
-                f"n_expected ({n_expected}); recentering grid on image "
-                f"(symmetry anchoring overrides fitted offset).",
-                AutoGridFinderFallbackWarning,
-                stacklevel=3,
-            )
-            image_center = image_dim / 2.0
-            grid_center_idx = (n_expected - 1) / 2.0
-            offset = image_center - pitch * grid_center_idx
-
-        return self._compute_grid_edges(pitch, offset, n_expected, image_dim)
 
     # ------------------------------------------------------------------
     # Public interface
@@ -743,12 +784,29 @@ class AutoGridFinder(GridFinder):
             n_centers = len(info_table)
             if n_centers < 2:
                 pipeline_path = "uniform (< 2 objects)"
-            elif n_centers < 2 * self.nrows:
-                pipeline_path = "simple"
             elif n_centers > self._MAX_OBJECTS_PER_CELL * self.nrows:
                 pipeline_path = "uniform (object count guard)"
             else:
-                pipeline_path = "robust"
+                # Per-axis labels via the shared classifier; reported as
+                # "rows: X / cols: Y" so divergent decisions are visible.
+                row_centers = AutoGridFinder._extract_axis_centers(
+                    info_table, 0,
+                )
+                col_centers = AutoGridFinder._extract_axis_centers(
+                    info_table, 1,
+                )
+                row_label = AutoGridFinder._classify_axis_pipeline(
+                    row_centers, self.nrows, image.shape[0],
+                )
+                col_label = AutoGridFinder._classify_axis_pipeline(
+                    col_centers, self.ncols, image.shape[1],
+                )
+                if row_label == col_label:
+                    pipeline_path = row_label
+                else:
+                    pipeline_path = (
+                        f"rows: {row_label} / cols: {col_label}"
+                    )
             row_edges = self._fit_axis_edges(
                 info_table, axis=0, n_expected=self.nrows,
                 image_dim=image.shape[0],
@@ -917,6 +975,155 @@ class AutoGridFinder(GridFinder):
             return pane
 
     @classmethod
+    def _plot_successive_diffs(
+        cls, info_table: pd.DataFrame, nrows: int, ncols: int,
+        image_shape: tuple[int, ...],
+    ):
+        """Histogram of successive center diffs with image-pitch markers.
+
+        Two subplots (rows, cols) showing ``np.diff(sorted(centers))`` per
+        axis, with vertical reference lines at 1x, 2x, 3x ``image_pitch``.
+        A peak at 1x means dense, well-separated detections; secondary
+        peaks at 2x or 3x indicate sparse plates with missing cells; a
+        peak below 1x indicates within-cell fragmentation.
+        """
+        import panel as pn
+        import matplotlib.pyplot as plt
+
+        with plt.rc_context(cls._dashboard_rcparams()):
+            fig, axes = plt.subplots(1, 2, figsize=(8.5, 3.0))
+
+            for ax, axis, n_expected, dim, label in [
+                (axes[0], 0, nrows, image_shape[0], "Row"),
+                (axes[1], 1, ncols, image_shape[1], "Col"),
+            ]:
+                image_pitch = dim / n_expected
+
+                if info_table.empty:
+                    ax.text(
+                        0.5, 0.5, "No objects detected",
+                        ha="center", va="center", fontsize=10,
+                        color="#8892a4", transform=ax.transAxes,
+                    )
+                    ax.set_title(f"{label} diffs")
+                    continue
+
+                centers = cls._extract_axis_centers(info_table, axis)
+                if len(centers) < 2:
+                    ax.text(
+                        0.5, 0.5, "<2 centers",
+                        ha="center", va="center", fontsize=10,
+                        color="#8892a4", transform=ax.transAxes,
+                    )
+                    ax.set_title(f"{label} diffs")
+                    continue
+
+                diffs = np.diff(centers)
+                diffs = diffs[diffs > 0]
+                if len(diffs) == 0:
+                    ax.text(
+                        0.5, 0.5, "No positive diffs",
+                        ha="center", va="center", fontsize=10,
+                        color="#8892a4", transform=ax.transAxes,
+                    )
+                    ax.set_title(f"{label} diffs")
+                    continue
+
+                bin_width = image_pitch / 8.0
+                upper = max(float(diffs.max()), 3.5 * image_pitch)
+                n_bins = max(int(np.ceil(upper / bin_width)), 1)
+                ax.hist(
+                    diffs, bins=n_bins, range=(0, upper + bin_width),
+                    color=cls._OI_NAVY, alpha=0.85,
+                )
+                ax.axvline(
+                    image_pitch, color=cls._OI_VERMILION, ls="--", lw=1.2,
+                    label=f"1x ({image_pitch:.0f})",
+                )
+                ax.axvline(
+                    2 * image_pitch, color=cls._OI_GREY, ls="--", lw=1.0,
+                    label="2x",
+                )
+                ax.axvline(
+                    3 * image_pitch, color=cls._OI_GREY, ls=":", lw=1.0,
+                    label="3x",
+                )
+
+                ax.set_xlabel("Δ between adjacent centers (px)")
+                ax.set_ylabel("count")
+                ax.set_title(f"{label} diffs (image_pitch={image_pitch:.0f})")
+                ax.legend(fontsize=7, framealpha=0.8)
+
+            fig.tight_layout()
+            pane = pn.pane.Matplotlib(fig, tight=True, dpi=100)
+            plt.close(fig)
+            return pane
+
+    @classmethod
+    def _plot_axis_occupancy(
+        cls, info_table: pd.DataFrame, nrows: int, ncols: int,
+        image_shape: tuple[int, ...],
+    ):
+        """Bar chart of detection counts per cell index per axis.
+
+        Cells assigned via ``_image_pitch_indices`` so the result is
+        independent of the fitted pitch. Empty cells (count 0) are drawn
+        in vermilion to make missing rows/columns visually obvious.
+        """
+        import panel as pn
+        import matplotlib.pyplot as plt
+
+        with plt.rc_context(cls._dashboard_rcparams()):
+            fig, axes = plt.subplots(1, 2, figsize=(8.5, 3.0))
+
+            for ax, axis, n_expected, dim, label in [
+                (axes[0], 0, nrows, image_shape[0], "Row"),
+                (axes[1], 1, ncols, image_shape[1], "Col"),
+            ]:
+                if info_table.empty:
+                    ax.text(
+                        0.5, 0.5, "No objects detected",
+                        ha="center", va="center", fontsize=10,
+                        color="#8892a4", transform=ax.transAxes,
+                    )
+                    ax.set_title(f"{label} occupancy")
+                    continue
+
+                centers = cls._extract_axis_centers(info_table, axis)
+                indices = cls._image_pitch_indices(centers, n_expected, dim)
+                counts = np.bincount(indices, minlength=n_expected)
+                occupied = int((counts > 0).sum())
+
+                colors = [
+                    cls._OI_VERMILION if c == 0 else cls._OI_NAVY
+                    for c in counts
+                ]
+                bars = ax.bar(
+                    range(n_expected), counts, color=colors, alpha=0.85,
+                )
+                for bar, c in zip(bars, counts):
+                    if c > 0:
+                        ax.text(
+                            bar.get_x() + bar.get_width() / 2,
+                            bar.get_height(), str(int(c)),
+                            ha="center", va="bottom",
+                            fontsize=7, fontfamily="monospace",
+                            color="#2e3a4e",
+                        )
+
+                ax.set_xticks(range(n_expected))
+                ax.set_xlabel(f"{label} index")
+                ax.set_ylabel("# detections")
+                ax.set_title(
+                    f"{label} occupancy ({occupied}/{n_expected} cells)"
+                )
+
+            fig.tight_layout()
+            pane = pn.pane.Matplotlib(fig, tight=True, dpi=100)
+            plt.close(fig)
+            return pane
+
+    @classmethod
     def _build_inspect_summary(
         cls, result: dict, nrows: int, ncols: int,
         image_shape: tuple[int, ...],
@@ -964,6 +1171,30 @@ class AutoGridFinder(GridFinder):
         row_pitch = float(np.median(np.diff(row_edges)))
         col_pitch = float(np.median(np.diff(col_edges)))
 
+        # Sparse-plate diagnostics: image-pitch indices give occupancy
+        # and span coverage independent of the fitted pitch
+        if not info_table.empty:
+            row_centers = AutoGridFinder._extract_axis_centers(info_table, 0)
+            col_centers = AutoGridFinder._extract_axis_centers(info_table, 1)
+            row_idx = AutoGridFinder._image_pitch_indices(
+                row_centers, nrows, image_shape[0],
+            )
+            col_idx = AutoGridFinder._image_pitch_indices(
+                col_centers, ncols, image_shape[1],
+            )
+            row_counts = np.bincount(row_idx, minlength=nrows)
+            col_counts = np.bincount(col_idx, minlength=ncols)
+            occupied_rows = int((row_counts > 0).sum())
+            occupied_cols = int((col_counts > 0).sum())
+            row_span = (
+                int(row_idx.max() - row_idx.min() + 1) if len(row_idx) else 0
+            )
+            col_span = (
+                int(col_idx.max() - col_idx.min() + 1) if len(col_idx) else 0
+            )
+        else:
+            occupied_rows = occupied_cols = row_span = col_span = 0
+
         md = (
             f"### Summary\n\n"
             f"| Metric | Value |\n"
@@ -977,6 +1208,14 @@ class AutoGridFinder(GridFinder):
             f"| Row pitch | {row_pitch:.1f} px |\n"
             f"| Col pitch | {col_pitch:.1f} px |\n"
             f"| Pipeline path | {result['pipeline_path']} |\n"
+            f"| Row occupancy | {occupied_rows}/{nrows} "
+            f"({occupied_rows / nrows:.0%}) |\n"
+            f"| Col occupancy | {occupied_cols}/{ncols} "
+            f"({occupied_cols / ncols:.0%}) |\n"
+            f"| Row span coverage | {row_span}/{nrows} "
+            f"({row_span / nrows:.0%}) |\n"
+            f"| Col span coverage | {col_span}/{ncols} "
+            f"({col_span / ncols:.0%}) |\n"
             f"| Total time | {total_time:.3f} s |\n"
         )
         return pn.pane.Markdown(
@@ -1034,11 +1273,18 @@ class AutoGridFinder(GridFinder):
         p4 = self._build_inspect_summary(
             result, self.nrows, self.ncols, image.shape,
         )
+        p5 = self._plot_successive_diffs(
+            result["info_table"], self.nrows, self.ncols, image.shape,
+        )
+        p6 = self._plot_axis_occupancy(
+            result["info_table"], self.nrows, self.ncols, image.shape,
+        )
 
         return pn.Column(
             header,
             pn.Row(p1, p4),
             pn.Row(p3, p2),
+            pn.Row(p5, p6),
         )
 
 

--- a/src/phenotypic/grid/_auto_grid_finder.py
+++ b/src/phenotypic/grid/_auto_grid_finder.py
@@ -132,20 +132,34 @@ class AutoGridFinder(GridFinder):
         return float((centers[-1] - centers[0]) / max(n_expected - 1, 1))
 
     @staticmethod
-    def _robust_pitch_estimate(centers: np.ndarray, n_expected: int) -> float:
+    def _robust_pitch_estimate(
+            centers: np.ndarray, n_expected: int, image_dim: int,
+    ) -> float:
         """Estimate grid pitch robustly using the mode of successive differences.
 
-        Falls back to span-based estimation when the mode is outside a
-        plausible range (0.5x–2.0x the span estimate).
+        Two reference pitches are computed: ``span_pitch`` from
+        ``(max - min) / (n_expected - 1)`` and ``image_pitch`` from
+        ``image_dim / n_expected``. The mode of successive differences
+        is binned at ``image_pitch / 4`` (more reliable than span-based
+        binning when edge wells are missing). The mode is accepted when
+        it falls within ``[0.5x, 2.0x]`` of *either* reference; when
+        neither agrees the function falls back to whichever reference
+        is closer to the mode. This dual-reference scheme tolerates
+        edge-row/col detection dropouts (where ``span_pitch`` shrinks
+        artificially) without losing protection against mode estimates
+        dominated by within-cell fragmentation.
 
         Args:
             centers: Sorted 1-D array of object center coordinates.
             n_expected: Number of expected grid positions along this axis.
+            image_dim: Image extent along this axis, used to compute the
+                structural ``image_pitch`` reference.
 
         Returns:
             Estimated pitch in pixels.
         """
         span_pitch = AutoGridFinder._estimate_pitch(centers, n_expected)
+        image_pitch = float(image_dim / n_expected)
         if span_pitch <= 0:
             warnings.warn(
                 f"AutoGridFinder._robust_pitch_estimate: span pitch <= 0 "
@@ -167,29 +181,31 @@ class AutoGridFinder(GridFinder):
             )
             return span_pitch
 
-        bin_width = span_pitch / 4.0
+        bin_width = image_pitch / 4.0
         n_bins = max(int(np.ceil(diffs.max() / bin_width)), 1)
         counts, bin_edges = np.histogram(diffs, bins=n_bins, range=(0, diffs.max() + bin_width))
         mode_bin = np.argmax(counts)
         mode_pitch = float((bin_edges[mode_bin] + bin_edges[mode_bin + 1]) / 2.0)
 
-        # TODO: revisit with Option 2 — use image_dim / n_expected as a
-        # complementary reference. The span-based ratio guard below
-        # rejects mode_pitch on plates with edge-row/col detection
-        # dropouts (span_pitch then artificially shrinks, pushing the
-        # mode/span ratio above 2x even though mode_pitch is correct).
-        # Re-enable once image_dim is threaded into this helper and
-        # mode_pitch is accepted if it agrees with either span_pitch or
-        # image_pitch.
-        # if mode_pitch < 0.5 * span_pitch or mode_pitch > 2.0 * span_pitch:
-        #     warnings.warn(
-        #         f"AutoGridFinder._robust_pitch_estimate: mode pitch "
-        #         f"({mode_pitch:.2f}) outside [0.5x, 2.0x] of span pitch "
-        #         f"({span_pitch:.2f}); falling back to span pitch.",
-        #         AutoGridFinderFallbackWarning,
-        #         stacklevel=4,
-        #     )
-        #     return span_pitch
+        ref_low = min(0.5 * span_pitch, 0.5 * image_pitch)
+        ref_high = max(2.0 * span_pitch, 2.0 * image_pitch)
+        if not (ref_low <= mode_pitch <= ref_high):
+            closer_ref = (
+                image_pitch
+                if abs(mode_pitch - image_pitch) < abs(mode_pitch - span_pitch)
+                else span_pitch
+            )
+            which = "image" if closer_ref == image_pitch else "span"
+            warnings.warn(
+                f"AutoGridFinder._robust_pitch_estimate: mode pitch "
+                f"({mode_pitch:.2f}) outside [{ref_low:.2f}, {ref_high:.2f}] "
+                f"of either span_pitch ({span_pitch:.2f}) or image_pitch "
+                f"({image_pitch:.2f}); falling back to {which}_pitch "
+                f"({closer_ref:.2f}).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
+            return closer_ref
         return mode_pitch
 
     @staticmethod
@@ -455,7 +471,7 @@ class AutoGridFinder(GridFinder):
         # --- Robust pipeline for high object counts ---
 
         # Step 1: robust pitch estimate (mode of successive differences)
-        pitch = self._robust_pitch_estimate(centers, n_expected)
+        pitch = self._robust_pitch_estimate(centers, n_expected, image_dim)
         if pitch <= 0:
             warnings.warn(
                 f"AutoGridFinder ({axis_label}): robust pitch estimate "

--- a/src/phenotypic/grid/_auto_grid_finder.py
+++ b/src/phenotypic/grid/_auto_grid_finder.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -54,6 +55,9 @@ class AutoGridFinder(GridFinder):
             whose fit residual exceeds ``pitch * residual_fraction`` are
             excluded from the refined fit (default 0.25).
 
+        warn: Whether to emit :class:`AutoGridFinderFallbackWarning`
+            diagnostics for fallbacks and geometry overrides. Defaults
+            to ``False`` (silent); set to ``True`` to surface them.
         tol: Deprecated. Accepted for backward compatibility but ignored.
         max_iter: Deprecated. Accepted for backward compatibility but ignored.
 
@@ -81,11 +85,13 @@ class AutoGridFinder(GridFinder):
             ncols: int = 12,
             residual_fraction: float = 0.25,
             *,
+            warn: bool = False,
             tol: float | None = None,
             max_iter: int | None = None,
     ):
         super().__init__(nrows=nrows, ncols=ncols)
         self.residual_fraction: float = residual_fraction
+        self.warn: bool = warn
 
         if tol is not None:
             warnings.warn(
@@ -101,6 +107,16 @@ class AutoGridFinder(GridFinder):
                 DeprecationWarning,
                 stacklevel=2,
             )
+
+    @contextmanager
+    def _warning_filter(self):
+        """Suppress :class:`AutoGridFinderFallbackWarning` when ``self.warn`` is False."""
+        if self.warn:
+            yield
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", AutoGridFinderFallbackWarning)
+                yield
 
     # ------------------------------------------------------------------
     # Static helper methods
@@ -598,18 +614,20 @@ class AutoGridFinder(GridFinder):
         Returns:
             Integer array of length ``nrows + 1``.
         """
-        if image.num_objects == 0:
-            warnings.warn(
-                "AutoGridFinder.get_row_edges: no objects detected; "
-                "falling back to uniform row edges.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=2,
+        with self._warning_filter():
+            if image.num_objects == 0:
+                warnings.warn(
+                    "AutoGridFinder.get_row_edges: no objects detected; "
+                    "falling back to uniform row edges.",
+                    AutoGridFinderFallbackWarning,
+                    stacklevel=2,
+                )
+                return self._uniform_edges(self.nrows, image.shape[0])
+            info_table = image.objects.info(include_metadata=False)
+            return self._fit_axis_edges(
+                info_table, axis=0, n_expected=self.nrows,
+                image_dim=image.shape[0],
             )
-            return self._uniform_edges(self.nrows, image.shape[0])
-        info_table = image.objects.info(include_metadata=False)
-        return self._fit_axis_edges(
-            info_table, axis=0, n_expected=self.nrows, image_dim=image.shape[0],
-        )
 
     def get_col_edges(self, image: Image) -> np.ndarray:
         """Return column edge coordinates for *image*.
@@ -620,18 +638,20 @@ class AutoGridFinder(GridFinder):
         Returns:
             Integer array of length ``ncols + 1``.
         """
-        if image.num_objects == 0:
-            warnings.warn(
-                "AutoGridFinder.get_col_edges: no objects detected; "
-                "falling back to uniform column edges.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=2,
+        with self._warning_filter():
+            if image.num_objects == 0:
+                warnings.warn(
+                    "AutoGridFinder.get_col_edges: no objects detected; "
+                    "falling back to uniform column edges.",
+                    AutoGridFinderFallbackWarning,
+                    stacklevel=2,
+                )
+                return self._uniform_edges(self.ncols, image.shape[1])
+            info_table = image.objects.info(include_metadata=False)
+            return self._fit_axis_edges(
+                info_table, axis=1, n_expected=self.ncols,
+                image_dim=image.shape[1],
             )
-            return self._uniform_edges(self.ncols, image.shape[1])
-        info_table = image.objects.info(include_metadata=False)
-        return self._fit_axis_edges(
-            info_table, axis=1, n_expected=self.ncols, image_dim=image.shape[1],
-        )
 
     def _operate(self, image: Image) -> pd.DataFrame:
         """Compute grid edges and assign each detected object to a grid cell.
@@ -642,29 +662,32 @@ class AutoGridFinder(GridFinder):
         Returns:
             DataFrame with grid assignments (ROW_NUM, COL_NUM, ROW_MAJOR_IDX).
         """
-        if image.num_objects == 0:
-            warnings.warn(
-                "AutoGridFinder._operate: no objects detected; falling back "
-                "to uniform grid edges for both axes.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=2,
+        with self._warning_filter():
+            if image.num_objects == 0:
+                warnings.warn(
+                    "AutoGridFinder._operate: no objects detected; falling "
+                    "back to uniform grid edges for both axes.",
+                    AutoGridFinderFallbackWarning,
+                    stacklevel=2,
+                )
+                return super()._get_grid_info(
+                    image=image,
+                    row_edges=self._uniform_edges(self.nrows, image.shape[0]),
+                    col_edges=self._uniform_edges(self.ncols, image.shape[1]),
+                )
+            info_table = image.objects.info(include_metadata=False)
+            row_edges = self._fit_axis_edges(
+                info_table, axis=0, n_expected=self.nrows,
+                image_dim=image.shape[0],
+            )
+            col_edges = self._fit_axis_edges(
+                info_table, axis=1, n_expected=self.ncols,
+                image_dim=image.shape[1],
             )
             return super()._get_grid_info(
-                image=image,
-                row_edges=self._uniform_edges(self.nrows, image.shape[0]),
-                col_edges=self._uniform_edges(self.ncols, image.shape[1]),
+                image=image, row_edges=row_edges, col_edges=col_edges,
+                info_table=info_table,
             )
-        info_table = image.objects.info(include_metadata=False)
-        row_edges = self._fit_axis_edges(
-            info_table, axis=0, n_expected=self.nrows, image_dim=image.shape[0],
-        )
-        col_edges = self._fit_axis_edges(
-            info_table, axis=1, n_expected=self.ncols, image_dim=image.shape[1],
-        )
-        return super()._get_grid_info(
-            image=image, row_edges=row_edges, col_edges=col_edges,
-            info_table=info_table,
-        )
 
     # ------------------------------------------------------------------
     # Diagnostic inspect() method
@@ -768,69 +791,70 @@ class AutoGridFinder(GridFinder):
                 else:  # tqdm
                     pbar.update(1)
 
-        # Step 1: regionprops
-        t0 = time.perf_counter()
-        if image.num_objects == 0:
-            info_table = pd.DataFrame()
-        else:
-            info_table = image.objects.info(include_metadata=False)
-        _tick("regionprops", t0)
-
-        # Step 2: fit rows
-        t0 = time.perf_counter()
-        if image.num_objects == 0:
-            row_edges = self._uniform_edges(self.nrows, image.shape[0])
-        else:
-            n_centers = len(info_table)
-            if n_centers < 2:
-                pipeline_path = "uniform (< 2 objects)"
-            elif n_centers > self._MAX_OBJECTS_PER_CELL * self.nrows:
-                pipeline_path = "uniform (object count guard)"
+        with self._warning_filter():
+            # Step 1: regionprops
+            t0 = time.perf_counter()
+            if image.num_objects == 0:
+                info_table = pd.DataFrame()
             else:
-                # Per-axis labels via the shared classifier; reported as
-                # "rows: X / cols: Y" so divergent decisions are visible.
-                row_centers = AutoGridFinder._extract_axis_centers(
-                    info_table, 0,
-                )
-                col_centers = AutoGridFinder._extract_axis_centers(
-                    info_table, 1,
-                )
-                row_label = AutoGridFinder._classify_axis_pipeline(
-                    row_centers, self.nrows, image.shape[0],
-                )
-                col_label = AutoGridFinder._classify_axis_pipeline(
-                    col_centers, self.ncols, image.shape[1],
-                )
-                if row_label == col_label:
-                    pipeline_path = row_label
+                info_table = image.objects.info(include_metadata=False)
+            _tick("regionprops", t0)
+
+            # Step 2: fit rows
+            t0 = time.perf_counter()
+            if image.num_objects == 0:
+                row_edges = self._uniform_edges(self.nrows, image.shape[0])
+            else:
+                n_centers = len(info_table)
+                if n_centers < 2:
+                    pipeline_path = "uniform (< 2 objects)"
+                elif n_centers > self._MAX_OBJECTS_PER_CELL * self.nrows:
+                    pipeline_path = "uniform (object count guard)"
                 else:
-                    pipeline_path = (
-                        f"rows: {row_label} / cols: {col_label}"
+                    # Per-axis labels via the shared classifier; reported as
+                    # "rows: X / cols: Y" so divergent decisions are visible.
+                    row_centers = AutoGridFinder._extract_axis_centers(
+                        info_table, 0,
                     )
-            row_edges = self._fit_axis_edges(
-                info_table, axis=0, n_expected=self.nrows,
-                image_dim=image.shape[0],
-            )
-        _tick("fit rows", t0)
+                    col_centers = AutoGridFinder._extract_axis_centers(
+                        info_table, 1,
+                    )
+                    row_label = AutoGridFinder._classify_axis_pipeline(
+                        row_centers, self.nrows, image.shape[0],
+                    )
+                    col_label = AutoGridFinder._classify_axis_pipeline(
+                        col_centers, self.ncols, image.shape[1],
+                    )
+                    if row_label == col_label:
+                        pipeline_path = row_label
+                    else:
+                        pipeline_path = (
+                            f"rows: {row_label} / cols: {col_label}"
+                        )
+                row_edges = self._fit_axis_edges(
+                    info_table, axis=0, n_expected=self.nrows,
+                    image_dim=image.shape[0],
+                )
+            _tick("fit rows", t0)
 
-        # Step 3: fit cols
-        t0 = time.perf_counter()
-        if image.num_objects == 0:
-            col_edges = self._uniform_edges(self.ncols, image.shape[1])
-        else:
-            col_edges = self._fit_axis_edges(
-                info_table, axis=1, n_expected=self.ncols,
-                image_dim=image.shape[1],
-            )
-        _tick("fit cols", t0)
+            # Step 3: fit cols
+            t0 = time.perf_counter()
+            if image.num_objects == 0:
+                col_edges = self._uniform_edges(self.ncols, image.shape[1])
+            else:
+                col_edges = self._fit_axis_edges(
+                    info_table, axis=1, n_expected=self.ncols,
+                    image_dim=image.shape[1],
+                )
+            _tick("fit cols", t0)
 
-        # Step 4: grid assignment
-        t0 = time.perf_counter()
-        grid_df = super()._get_grid_info(
-            image=image, row_edges=row_edges, col_edges=col_edges,
-            info_table=info_table if not info_table.empty else None,
-        )
-        _tick("grid assignment", t0)
+            # Step 4: grid assignment
+            t0 = time.perf_counter()
+            grid_df = super()._get_grid_info(
+                image=image, row_edges=row_edges, col_edges=col_edges,
+                info_table=info_table if not info_table.empty else None,
+            )
+            _tick("grid assignment", t0)
 
         if pbar is not None and hasattr(pbar, "close"):
             pbar.close()

--- a/src/phenotypic/grid/_auto_grid_finder.py
+++ b/src/phenotypic/grid/_auto_grid_finder.py
@@ -13,6 +13,25 @@ from phenotypic.abc_ import GridFinder
 from phenotypic.tools_.measurement_info import BBOX, GRID
 
 
+class AutoGridFinderFallbackWarning(UserWarning):
+    """Warning category for fallbacks and geometry overrides in
+    :class:`AutoGridFinder`.
+
+    Emitted whenever the grid fitter takes a fallback (uniform spacing,
+    switch to simple pipeline, span-based pitch) or overrides the
+    fitted offset (symmetry anchoring, pitch shrink). Use this category
+    to filter only AutoGridFinder diagnostics in batch runs::
+
+        import warnings
+        from phenotypic.grid._auto_grid_finder import (
+            AutoGridFinderFallbackWarning,
+        )
+        warnings.filterwarnings(
+            "ignore", category=AutoGridFinderFallbackWarning,
+        )
+    """
+
+
 class AutoGridFinder(GridFinder):
     """
     Automatically determines grid row and column edges from detected object
@@ -37,6 +56,21 @@ class AutoGridFinder(GridFinder):
 
         tol: Deprecated. Accepted for backward compatibility but ignored.
         max_iter: Deprecated. Accepted for backward compatibility but ignored.
+
+    Notes:
+        Diagnostic warnings of category
+        :class:`AutoGridFinderFallbackWarning` are emitted at every
+        fallback (uniform spacing, simple-pipeline switch, span-based
+        pitch) and geometry override (symmetry anchoring, pitch shrink).
+        Suppress them in batch runs with::
+
+            import warnings
+            from phenotypic.grid._auto_grid_finder import (
+                AutoGridFinderFallbackWarning,
+            )
+            warnings.filterwarnings(
+                "ignore", category=AutoGridFinderFallbackWarning,
+            )
     """
 
     _MAX_OBJECTS_PER_CELL: int = 250
@@ -113,11 +147,24 @@ class AutoGridFinder(GridFinder):
         """
         span_pitch = AutoGridFinder._estimate_pitch(centers, n_expected)
         if span_pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder._robust_pitch_estimate: span pitch <= 0 "
+                f"(span_pitch={span_pitch}); returning as-is.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return span_pitch
 
         diffs = np.diff(centers)
         diffs = diffs[diffs > 0]
         if len(diffs) < 2:
+            warnings.warn(
+                f"AutoGridFinder._robust_pitch_estimate: only {len(diffs)} "
+                f"positive successive differences; falling back to span pitch "
+                f"({span_pitch:.2f}).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return span_pitch
 
         bin_width = span_pitch / 4.0
@@ -127,6 +174,13 @@ class AutoGridFinder(GridFinder):
         mode_pitch = float((bin_edges[mode_bin] + bin_edges[mode_bin + 1]) / 2.0)
 
         if mode_pitch < 0.5 * span_pitch or mode_pitch > 2.0 * span_pitch:
+            warnings.warn(
+                f"AutoGridFinder._robust_pitch_estimate: mode pitch "
+                f"({mode_pitch:.2f}) outside [0.5x, 2.0x] of span pitch "
+                f"({span_pitch:.2f}); falling back to span pitch.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return span_pitch
         return mode_pitch
 
@@ -176,6 +230,13 @@ class AutoGridFinder(GridFinder):
         idx_dev = indices - idx_mean
         denom = float(idx_dev @ idx_dev)
         if denom == 0.0:
+            warnings.warn(
+                f"AutoGridFinder._fit_pitch_and_offset: degenerate indices "
+                f"(all {len(indices)} centers map to the same grid index); "
+                f"pitch set to 0.0, offset to centers mean ({ctr_mean:.2f}).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return 0.0, ctr_mean
         pitch = float(idx_dev @ (centers - ctr_mean)) / denom
         offset = ctr_mean - pitch * idx_mean
@@ -217,6 +278,14 @@ class AutoGridFinder(GridFinder):
         max_offset = image_dim - pitch * n_bins + half  # last edge <= image_dim
 
         if min_offset > max_offset:
+            warnings.warn(
+                f"AutoGridFinder._compute_grid_edges: fitted pitch "
+                f"({pitch:.2f}) too large for image_dim={image_dim} with "
+                f"n_bins={n_bins}; shrinking pitch to "
+                f"{image_dim / n_bins:.2f} and recentering.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             # Pitch is too large for the image — shrink to fit
             pitch = image_dim / n_bins
             half = pitch / 2.0
@@ -246,6 +315,7 @@ class AutoGridFinder(GridFinder):
             centers: np.ndarray,
             n_expected: int,
             image_dim: int,
+            axis_label: str = "axis",
     ) -> np.ndarray:
         """Simple pipeline used when the object count is low.
 
@@ -253,26 +323,60 @@ class AutoGridFinder(GridFinder):
         """
         pitch = self._estimate_pitch(centers, n_expected)
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, simple): span-based pitch "
+                f"<= 0 ({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         indices = self._assign_grid_indices(centers, pitch)
         pitch, offset = self._fit_pitch_and_offset(centers, indices)
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, simple): initial fit pitch "
+                f"<= 0 ({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         threshold = pitch * self.residual_fraction
         inlier_mask = self._identify_inliers(
             centers, indices, pitch, offset, threshold,
         )
-        if inlier_mask.sum() >= 2:
+        n_inliers = int(inlier_mask.sum())
+        if n_inliers >= 2:
             pitch, offset = self._fit_pitch_and_offset(
                 centers[inlier_mask], indices[inlier_mask],
             )
+        else:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, simple): only {n_inliers} "
+                f"inliers of {len(centers)} centers within residual threshold "
+                f"({threshold:.2f}); skipping refit and using initial fit.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, simple): refit pitch <= 0 "
+                f"({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         span = int(indices.max() - indices.min()) + 1
         if span < n_expected:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}, simple): detected span "
+                f"({span}) < n_expected ({n_expected}); recentering grid on "
+                f"image (symmetry anchoring overrides fitted offset).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=4,
+            )
             image_center = image_dim / 2.0
             grid_center_idx = (n_expected - 1) / 2.0
             offset = image_center - pitch * grid_center_idx
@@ -292,27 +396,51 @@ class AutoGridFinder(GridFinder):
         Uses the simple pipeline for low object counts and the robust
         pipeline (median aggregation + robust pitch) for high counts.
         """
+        axis_label = (
+            "rows" if axis == 0 else "cols" if axis == 1 else f"axis {axis}"
+        )
         try:
             centers = self._extract_axis_centers(info_table, axis)
-        except (KeyError, IndexError):
-            centers = np.array([])
+        except (KeyError, IndexError) as exc:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): could not extract centers "
+                f"({type(exc).__name__}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
+            return self._uniform_edges(n_expected, image_dim)
 
         if len(centers) < 2:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): {len(centers)} centers "
+                f"available (< 2); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         # Low-N guard: use simple pipeline when few objects
         if len(centers) < 2 * n_expected:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): {len(centers)} centers < "
+                f"2 * n_expected ({2 * n_expected}); using simple pipeline "
+                f"instead of robust pipeline.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             return self._fit_axis_edges_simple(
-                centers, n_expected, image_dim,
+                centers, n_expected, image_dim, axis_label=axis_label,
             )
 
         # High-N guard: skip fitting for pathological object counts
         if len(centers) > self._MAX_OBJECTS_PER_CELL * n_expected:
             warnings.warn(
-                f"Detected {len(centers)} objects for {n_expected} expected "
-                f"grid positions (>{self._MAX_OBJECTS_PER_CELL} per cell). "
-                f"Falling back to uniform grid spacing.",
-                stacklevel=2,
+                f"AutoGridFinder ({axis_label}): detected {len(centers)} "
+                f"objects for {n_expected} expected grid positions "
+                f"(>{self._MAX_OBJECTS_PER_CELL} per cell). Falling back to "
+                f"uniform grid spacing.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
             )
             return self._uniform_edges(n_expected, image_dim)
 
@@ -321,6 +449,12 @@ class AutoGridFinder(GridFinder):
         # Step 1: robust pitch estimate (mode of successive differences)
         pitch = self._robust_pitch_estimate(centers, n_expected)
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): robust pitch estimate "
+                f"<= 0 ({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         # Step 2: assign grid indices with median anchor
@@ -335,6 +469,12 @@ class AutoGridFinder(GridFinder):
         # Step 4: fit on aggregated medians (equal weight per cell)
         pitch, offset = self._fit_pitch_and_offset(medians, unique_idx)
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): initial cell-median fit "
+                f"pitch <= 0 ({pitch}); falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         # Step 5: outlier rejection + refit on cells
@@ -342,16 +482,38 @@ class AutoGridFinder(GridFinder):
         inlier_mask = self._identify_inliers(
             medians, unique_idx, pitch, offset, threshold,
         )
-        if inlier_mask.sum() >= 2:
+        n_inliers = int(inlier_mask.sum())
+        if n_inliers >= 2:
             pitch, offset = self._fit_pitch_and_offset(
                 medians[inlier_mask], unique_idx[inlier_mask],
             )
+        else:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): only {n_inliers} cell-median "
+                f"inliers of {len(medians)} cells within residual threshold "
+                f"({threshold:.2f}); skipping refit and using initial fit.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
         if pitch <= 0:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): refit pitch <= 0 ({pitch}); "
+                f"falling back to uniform edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             return self._uniform_edges(n_expected, image_dim)
 
         # Step 6: symmetry anchoring when detected span < expected
         span = int(unique_idx.max() - unique_idx.min()) + 1
         if span < n_expected:
+            warnings.warn(
+                f"AutoGridFinder ({axis_label}): detected span ({span}) < "
+                f"n_expected ({n_expected}); recentering grid on image "
+                f"(symmetry anchoring overrides fitted offset).",
+                AutoGridFinderFallbackWarning,
+                stacklevel=3,
+            )
             image_center = image_dim / 2.0
             grid_center_idx = (n_expected - 1) / 2.0
             offset = image_center - pitch * grid_center_idx
@@ -372,6 +534,12 @@ class AutoGridFinder(GridFinder):
             Integer array of length ``nrows + 1``.
         """
         if image.num_objects == 0:
+            warnings.warn(
+                "AutoGridFinder.get_row_edges: no objects detected; "
+                "falling back to uniform row edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=2,
+            )
             return self._uniform_edges(self.nrows, image.shape[0])
         info_table = image.objects.info(include_metadata=False)
         return self._fit_axis_edges(
@@ -388,6 +556,12 @@ class AutoGridFinder(GridFinder):
             Integer array of length ``ncols + 1``.
         """
         if image.num_objects == 0:
+            warnings.warn(
+                "AutoGridFinder.get_col_edges: no objects detected; "
+                "falling back to uniform column edges.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=2,
+            )
             return self._uniform_edges(self.ncols, image.shape[1])
         info_table = image.objects.info(include_metadata=False)
         return self._fit_axis_edges(
@@ -404,6 +578,12 @@ class AutoGridFinder(GridFinder):
             DataFrame with grid assignments (ROW_NUM, COL_NUM, ROW_MAJOR_IDX).
         """
         if image.num_objects == 0:
+            warnings.warn(
+                "AutoGridFinder._operate: no objects detected; falling back "
+                "to uniform grid edges for both axes.",
+                AutoGridFinderFallbackWarning,
+                stacklevel=2,
+            )
             return super()._get_grid_info(
                 image=image,
                 row_edges=self._uniform_edges(self.nrows, image.shape[0]),

--- a/src/phenotypic/grid/_auto_grid_finder.py
+++ b/src/phenotypic/grid/_auto_grid_finder.py
@@ -173,15 +173,23 @@ class AutoGridFinder(GridFinder):
         mode_bin = np.argmax(counts)
         mode_pitch = float((bin_edges[mode_bin] + bin_edges[mode_bin + 1]) / 2.0)
 
-        if mode_pitch < 0.5 * span_pitch or mode_pitch > 2.0 * span_pitch:
-            warnings.warn(
-                f"AutoGridFinder._robust_pitch_estimate: mode pitch "
-                f"({mode_pitch:.2f}) outside [0.5x, 2.0x] of span pitch "
-                f"({span_pitch:.2f}); falling back to span pitch.",
-                AutoGridFinderFallbackWarning,
-                stacklevel=4,
-            )
-            return span_pitch
+        # TODO: revisit with Option 2 — use image_dim / n_expected as a
+        # complementary reference. The span-based ratio guard below
+        # rejects mode_pitch on plates with edge-row/col detection
+        # dropouts (span_pitch then artificially shrinks, pushing the
+        # mode/span ratio above 2x even though mode_pitch is correct).
+        # Re-enable once image_dim is threaded into this helper and
+        # mode_pitch is accepted if it agrees with either span_pitch or
+        # image_pitch.
+        # if mode_pitch < 0.5 * span_pitch or mode_pitch > 2.0 * span_pitch:
+        #     warnings.warn(
+        #         f"AutoGridFinder._robust_pitch_estimate: mode pitch "
+        #         f"({mode_pitch:.2f}) outside [0.5x, 2.0x] of span pitch "
+        #         f"({span_pitch:.2f}); falling back to span pitch.",
+        #         AutoGridFinderFallbackWarning,
+        #         stacklevel=4,
+        #     )
+        #     return span_pitch
         return mode_pitch
 
     @staticmethod

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -55,9 +55,6 @@ Examples:
     uv run python -m phenotypic pipeline.json ./plates \
         --image-type GridImage --nrows 16 --ncols 24
 
-    # Save PNG overlays alongside HDFs (opt-in; default: OFF)
-    uv run python -m phenotypic pipeline.json ./images --save-overlays
-
     # Rerun measurements on a previous forward run without re-detecting
     # (reads HDFs from <previous-output-dir>/results/*/hdf/, rewrites
     # parquet measurements + master CSV, skips detection, does NOT
@@ -69,8 +66,9 @@ Outputs:
     Forward runs write a single HDF5 per input image under
     `<output>/results/<dataset>/hdf/<stem>.h5` (layers + metadata + grid
     state, reloadable via `Image.load_hdf5` / `GridImage.load_hdf5`).
-    Overlay PNGs under `<output>/results/<dataset>/overlays/<stem>.png`
-    are opt-in and only written when `--save-overlays` is set.
+    Overlay PNGs are always written under
+    `<output>/results/<dataset>/overlays/<stem>.png` for forward runs;
+    `--measure` reruns reuse existing overlays and do not regenerate them.
 
 SLURM Execution (Autonomous HPC Cluster Processing):
     Use --slurm to submit jobs to an HPC cluster via SLURM. The CLI will:
@@ -525,12 +523,6 @@ def _display_execution_config(config: ExecutionConfig, datasets: list) -> None:
     "consults this value.",
 )
 @click.option(
-    "--save-overlays",
-    is_flag=True,
-    default=False,
-    help="Save PNG overlay per image (default: off).",
-)
-@click.option(
     "--measure",
     "measure_only",
     is_flag=True,
@@ -631,7 +623,6 @@ def phenotypic_cli(
     force_local: bool,
     wait: bool,
     ext: str,
-    save_overlays: bool,
     measure_only: bool,
     overlay_alpha: float,
     include_dataset_column: bool,
@@ -865,7 +856,6 @@ def phenotypic_cli(
             skip_validation=skip_validation,
             metadata_csv=metadata_csv,
             checkpoint_interval=checkpoint_interval,
-            save_overlays=save_overlays,
             measure_only=measure_only,
         )
 
@@ -1127,8 +1117,8 @@ def phenotypic_cli(
                 }
             else:
                 state = create_initial_state(config, datasets, output_dir)
-                # Forward runs: persist save_overlays alongside the other
-                # resume-compat keys so a later --resume can pick it up.
+                # Recorded for diagnostic transparency; no longer drives
+                # resume compatibility (overlays are always-on).
                 state.config["save_overlays"] = config.save_overlays
             save_processing_state(state, output_dir)
 

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -385,7 +385,13 @@ def _display_execution_config(config: ExecutionConfig, datasets: list) -> None:
     # Image settings
     table.add_row("Image Type", config.image_type)
     if config.image_type == "GridImage":
-        table.add_row("Grid Dimensions", f"{config.nrows} × {config.ncols}")
+        if config.nrows is None and config.ncols is None:
+            grid_str = "auto (from pipeline preset, default 8 × 12)"
+        else:
+            nr = "auto" if config.nrows is None else str(config.nrows)
+            nc = "auto" if config.ncols is None else str(config.ncols)
+            grid_str = f"{nr} × {nc}"
+        table.add_row("Grid Dimensions", grid_str)
     if config.bit_depth:
         table.add_row("Bit Depth", str(config.bit_depth))
     if config.detect_mode != "gray":
@@ -459,16 +465,16 @@ def _display_execution_config(config: ExecutionConfig, datasets: list) -> None:
 @click.option(
     "--nrows",
     type=click.IntRange(min=1),
-    default=8,
-    show_default=True,
-    help="Number of rows for GridImage (must be positive)",
+    default=None,
+    help="Number of rows for GridImage. Overrides any pipeline-level "
+    "preset; when omitted, the pipeline preset is used, falling back to 8.",
 )
 @click.option(
     "--ncols",
     type=click.IntRange(min=1),
-    default=12,
-    show_default=True,
-    help="Number of columns for GridImage (must be positive)",
+    default=None,
+    help="Number of columns for GridImage. Overrides any pipeline-level "
+    "preset; when omitted, the pipeline preset is used, falling back to 12.",
 )
 @click.option(
     "--bit-depth",
@@ -616,8 +622,8 @@ def phenotypic_cli(
     input_path: Optional[Path],
     output_dir: Optional[Path],
     image_type: str,
-    nrows: int,
-    ncols: int,
+    nrows: Optional[int],
+    ncols: Optional[int],
     bit_depth: Optional[int],
     detect_mode: str,
     n_jobs: int,

--- a/src/phenotypic/sweep/_sweep_cli/_sweep_cli.py
+++ b/src/phenotypic/sweep/_sweep_cli/_sweep_cli.py
@@ -147,8 +147,8 @@ def _display_sweep_config(
         num_images: int,
         num_pipelines: int,
         image_type: str,
-        nrows: int,
-        ncols: int,
+        nrows: Optional[int],
+        ncols: Optional[int],
         n_jobs: int,
         slurm_args: Dict[str, Any],
         is_slurm: bool,
@@ -181,7 +181,13 @@ def _display_sweep_config(
     table.add_row("", "")
     table.add_row("Image Type", image_type)
     if image_type == "GridImage":
-        table.add_row("Grid", f"{nrows} x {ncols}")
+        if nrows is None and ncols is None:
+            grid_str = "auto (per-pipeline preset, default 8 x 12)"
+        else:
+            nr = "auto" if nrows is None else str(nrows)
+            nc = "auto" if ncols is None else str(ncols)
+            grid_str = f"{nr} x {nc}"
+        table.add_row("Grid", grid_str)
 
     if not is_slurm:
         n_str = "All cores" if n_jobs == -1 else str(n_jobs)
@@ -228,16 +234,16 @@ def _format_duration(seconds: float) -> str:
 @click.option(
         "--nrows",
         type=click.IntRange(min=1),
-        default=8,
-        show_default=True,
-        help="Grid rows (for GridImage).",
+        default=None,
+        help="Grid rows (for GridImage). Overrides any per-pipeline preset; "
+             "falls back to each pipeline's preset or 8 when omitted.",
 )
 @click.option(
         "--ncols",
         type=click.IntRange(min=1),
-        default=12,
-        show_default=True,
-        help="Grid columns (for GridImage).",
+        default=None,
+        help="Grid columns (for GridImage). Overrides any per-pipeline preset; "
+             "falls back to each pipeline's preset or 12 when omitted.",
 )
 @click.option(
         "--bit-depth",
@@ -276,8 +282,8 @@ def sweep_cli(
         input_dir: Path,
         output_dir: Optional[Path],
         image_type: str,
-        nrows: int,
-        ncols: int,
+        nrows: Optional[int],
+        ncols: Optional[int],
         bit_depth: Optional[int],
         detect_mode: str,
         n_jobs: int,
@@ -350,11 +356,8 @@ def sweep_cli(
         pipeline_names = list(pipeline_json_strs.keys())
         click.echo(f"Loaded {len(pipeline_names)} pipeline configurations")
 
-        # Build read kwargs
+        # Build read kwargs.
         read_kwargs: Dict[str, Any] = {}
-        if image_type == "GridImage":
-            read_kwargs["nrows"] = nrows
-            read_kwargs["ncols"] = ncols
         if bit_depth is not None:
             read_kwargs["bit_depth"] = bit_depth
         if detect_mode != "gray":
@@ -463,6 +466,8 @@ def sweep_cli(
                     wait=wait,
                     verbose=verbose,
                     save_intermediates=save_intermediates,
+                    cli_nrows=nrows,
+                    cli_ncols=ncols,
             )
         else:
             strategy = LocalSweepStrategy(
@@ -473,6 +478,8 @@ def sweep_cli(
                     n_jobs=n_jobs,
                     event_log=event_log,
                     save_intermediates=save_intermediates,
+                    cli_nrows=nrows,
+                    cli_ncols=ncols,
             )
 
         results = strategy.execute(image_paths, output_dir)

--- a/src/phenotypic/sweep/_sweep_cli/_sweep_execution.py
+++ b/src/phenotypic/sweep/_sweep_cli/_sweep_execution.py
@@ -32,11 +32,15 @@ class SweepExecutionStrategy(ABC):
         image_type: Literal["Image", "GridImage"],
         read_kwargs: Dict[str, Any],
         output_manager: SweepOutputManager,
+        cli_nrows: Optional[int] = None,
+        cli_ncols: Optional[int] = None,
     ):
         self.pipeline_json_strs = pipeline_json_strs
         self.image_type = image_type
         self.read_kwargs = read_kwargs
         self.output_manager = output_manager
+        self.cli_nrows = cli_nrows
+        self.cli_ncols = cli_ncols
 
     @abstractmethod
     def execute(
@@ -68,8 +72,17 @@ class LocalSweepStrategy(SweepExecutionStrategy):
         n_jobs: int = -1,
         event_log: Optional[Path] = None,
         save_intermediates: bool = False,
+        cli_nrows: Optional[int] = None,
+        cli_ncols: Optional[int] = None,
     ):
-        super().__init__(pipeline_json_strs, image_type, read_kwargs, output_manager)
+        super().__init__(
+            pipeline_json_strs,
+            image_type,
+            read_kwargs,
+            output_manager,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
+        )
         self.n_jobs = n_jobs
         self.event_log = event_log
         self.save_intermediates = save_intermediates
@@ -109,6 +122,8 @@ class LocalSweepStrategy(SweepExecutionStrategy):
                 output_manager=self.output_manager,
                 n_jobs=self.n_jobs,
                 save_intermediates=self.save_intermediates,
+                cli_nrows=self.cli_nrows,
+                cli_ncols=self.cli_ncols,
             )
 
             img_ok = sum(1 for _, ok, _ in results if ok)
@@ -179,8 +194,17 @@ class SLURMSweepStrategy(SweepExecutionStrategy):
         wait: bool = False,
         verbose: bool = False,
         save_intermediates: bool = False,
+        cli_nrows: Optional[int] = None,
+        cli_ncols: Optional[int] = None,
     ):
-        super().__init__(pipeline_json_strs, image_type, read_kwargs, output_manager)
+        super().__init__(
+            pipeline_json_strs,
+            image_type,
+            read_kwargs,
+            output_manager,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
+        )
         self.manifest_path = manifest_path
         self.slurm_args = slurm_args
         self.wait = wait
@@ -236,6 +260,8 @@ class SLURMSweepStrategy(SweepExecutionStrategy):
             array_limit=array_limit,
             verbose=self.verbose,
             save_intermediates=self.save_intermediates,
+            cli_nrows=self.cli_nrows,
+            cli_ncols=self.cli_ncols,
         )
 
         # Generate dispatcher chain for drip-feed submission

--- a/src/phenotypic/sweep/_sweep_cli/_sweep_process_image.py
+++ b/src/phenotypic/sweep/_sweep_cli/_sweep_process_image.py
@@ -38,6 +38,8 @@ def _run_single_pipeline(
     read_kwargs: Dict[str, Any],
     output_manager: SweepOutputManager,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> Tuple[str, bool, str]:
     """Run a single pipeline on an image.
 
@@ -50,10 +52,15 @@ def _run_single_pipeline(
         pipeline_name: Human-readable pipeline name.
         image_path: Path to the input image.
         image_type: ``"Image"`` or ``"GridImage"``.
-        read_kwargs: Kwargs for ``imread`` (nrows, ncols, etc.).
+        read_kwargs: Kwargs for ``imread`` (bit_depth, detect_mode). Should
+            NOT contain ``nrows``/``ncols``; those are resolved per-pipeline
+            from ``cli_nrows``/``cli_ncols`` and the deserialized pipeline's
+            soft preset.
         output_manager: Sweep output manager instance.
         save_intermediates: When True, save intermediate image state
             after each pipeline operation as HDF5.
+        cli_nrows: Explicit CLI ``--nrows`` override, or ``None``.
+        cli_ncols: Explicit CLI ``--ncols`` override, or ``None``.
 
     Returns:
         Tuple of ``(pipeline_name, success, error_message)``.
@@ -67,9 +74,20 @@ def _run_single_pipeline(
         # Deserialize pipeline
         pipeline = ImagePipeline.from_json(pipeline_json_str)
 
-        # Load image from disk
+        # Resolve nrows/ncols per-pipeline so each carries its own preset.
         image_cls = GridImage if image_type == "GridImage" else Image
         rk = dict(read_kwargs)  # shallow copy
+        if image_type == "GridImage":
+            from phenotypic._cli._cli_utils import resolve_grid_shape
+
+            nrows, ncols = resolve_grid_shape(
+                cli_nrows=cli_nrows,
+                cli_ncols=cli_ncols,
+                pipeline_nrows=pipeline.nrows,
+                pipeline_ncols=pipeline.ncols,
+            )
+            rk["nrows"] = nrows
+            rk["ncols"] = ncols
         detect_mode = rk.pop("detect_mode", "gray")
         image = image_cls.imread(image_path, **rk)
 
@@ -142,6 +160,8 @@ def process_image_all_pipelines(
     output_manager: SweepOutputManager,
     n_jobs: int = -1,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> List[Tuple[str, bool, str]]:
     """Process a single image through all pipelines in parallel.
 
@@ -152,11 +172,13 @@ def process_image_all_pipelines(
         image_path: Path to the input image.
         pipeline_json_strs: Mapping of pipeline_name to JSON string.
         image_type: ``"Image"`` or ``"GridImage"``.
-        read_kwargs: Kwargs for ``imread``.
+        read_kwargs: Kwargs for ``imread`` (bit_depth, detect_mode).
         output_manager: Sweep output manager instance.
         n_jobs: Number of parallel jobs (``-1`` = all cores).
         save_intermediates: When True, save intermediate image state
             after each pipeline operation as HDF5.
+        cli_nrows: Explicit CLI ``--nrows`` override, or ``None``.
+        cli_ncols: Explicit CLI ``--ncols`` override, or ``None``.
 
     Returns:
         List of ``(pipeline_name, success, error_message)`` tuples.
@@ -172,6 +194,8 @@ def process_image_all_pipelines(
             read_kwargs=read_kwargs,
             output_manager=output_manager,
             save_intermediates=save_intermediates,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
         )
         for pipe_name, json_str in pipeline_json_strs.items()
     )
@@ -186,6 +210,8 @@ def process_image_all_pipelines_sequential(
     read_kwargs: Dict[str, Any],
     output_manager: SweepOutputManager,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> List[Tuple[str, bool, str]]:
     """Process a single image through all pipelines sequentially.
 
@@ -196,10 +222,12 @@ def process_image_all_pipelines_sequential(
         image_path: Path to the input image.
         pipeline_json_strs: Mapping of pipeline_name to JSON string.
         image_type: ``"Image"`` or ``"GridImage"``.
-        read_kwargs: Kwargs for ``imread``.
+        read_kwargs: Kwargs for ``imread`` (bit_depth, detect_mode).
         output_manager: Sweep output manager instance.
         save_intermediates: When True, save intermediate image state
             after each pipeline operation as HDF5.
+        cli_nrows: Explicit CLI ``--nrows`` override, or ``None``.
+        cli_ncols: Explicit CLI ``--ncols`` override, or ``None``.
 
     Returns:
         List of ``(pipeline_name, success, error_message)`` tuples.
@@ -217,6 +245,8 @@ def process_image_all_pipelines_sequential(
             read_kwargs=read_kwargs,
             output_manager=output_manager,
             save_intermediates=save_intermediates,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
         )
         elapsed = time.monotonic() - t0
         status = "OK" if result[1] else "FAILED"
@@ -247,8 +277,20 @@ def process_image_all_pipelines_sequential(
     "--image-type", type=click.Choice(["Image", "GridImage"]),
     default="GridImage", help="Image class to use.",
 )
-@click.option("--nrows", type=int, default=8, help="Grid rows (for GridImage).")
-@click.option("--ncols", type=int, default=12, help="Grid columns (for GridImage).")
+@click.option(
+    "--nrows",
+    type=int,
+    default=None,
+    help="Grid rows (for GridImage). Overrides any pipeline preset; "
+    "falls back to the pipeline preset or 8 when omitted.",
+)
+@click.option(
+    "--ncols",
+    type=int,
+    default=None,
+    help="Grid columns (for GridImage). Overrides any pipeline preset; "
+    "falls back to the pipeline preset or 12 when omitted.",
+)
 @click.option("--bit-depth", type=int, default=None, help="Bit depth (8 or 16).")
 @click.option("--detect-mode", default="gray", help="Detection channel.")
 @click.option(
@@ -272,8 +314,8 @@ def sweep_worker_cli(
     image: Path,
     output_dir: Path,
     image_type: str,
-    nrows: int,
-    ncols: int,
+    nrows: Optional[int],
+    ncols: Optional[int],
     bit_depth: Optional[int],
     detect_mode: str,
     event_log: Optional[Path],
@@ -291,11 +333,8 @@ def sweep_worker_cli(
     from ._sweep_output import SweepOutputManager
 
     try:
-        # Build read kwargs
+        # Build read kwargs.
         read_kwargs: Dict[str, Any] = {}
-        if image_type == "GridImage":
-            read_kwargs["nrows"] = nrows
-            read_kwargs["ncols"] = ncols
         if bit_depth is not None:
             read_kwargs["bit_depth"] = bit_depth
         if detect_mode != "gray":
@@ -337,6 +376,8 @@ def sweep_worker_cli(
             read_kwargs=read_kwargs,
             output_manager=output_manager,
             save_intermediates=save_intermediates,
+            cli_nrows=nrows,
+            cli_ncols=ncols,
         )
 
         # Log results

--- a/src/phenotypic/sweep/_sweep_cli/_sweep_slurm_scripts.py
+++ b/src/phenotypic/sweep/_sweep_cli/_sweep_slurm_scripts.py
@@ -24,6 +24,8 @@ def _build_worker_command(
     read_kwargs: Dict[str, Any],
     verbose: bool = False,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> str:
     """Build the worker CLI command string (without image/pipeline args).
 
@@ -31,11 +33,18 @@ def _build_worker_command(
         manifest_path: Path to the sweep manifest JSON.
         output_dir: Base output directory.
         image_type: ``"Image"`` or ``"GridImage"``.
-        read_kwargs: Image read kwargs (nrows, ncols, etc.).
+        read_kwargs: Image read kwargs (bit_depth, detect_mode). ``nrows``
+            and ``ncols`` are NOT read from this dict — pass them via
+            ``cli_nrows``/``cli_ncols`` so per-pipeline preset resolution
+            happens inside the worker.
         verbose: When True, append ``--verbose`` to enable per-operation
             debug logging in the worker process.
         save_intermediates: When True, append ``--save-intermediates``
             to save intermediate image state after each pipeline operation.
+        cli_nrows: Explicit CLI ``--nrows`` override, or ``None`` to leave
+            the flag off (worker falls back to pipeline preset).
+        cli_ncols: Explicit CLI ``--ncols`` override, or ``None`` to leave
+            the flag off (worker falls back to pipeline preset).
 
     Returns:
         Command string with ``${CURRENT_IMAGE}`` and ``${CURRENT_PIPELINE}``
@@ -58,12 +67,13 @@ def _build_worker_command(
         image_type,
     ]
 
-    # Grid params
-    nrows = read_kwargs.get("nrows")
-    ncols = read_kwargs.get("ncols")
+    # Grid params: only emit when the user explicitly supplied a CLI value.
+    # Otherwise the worker falls back to each pipeline's soft preset.
     if image_type == "GridImage":
-        cmd_parts.extend(["--nrows", str(nrows or 8)])
-        cmd_parts.extend(["--ncols", str(ncols or 12)])
+        if cli_nrows is not None:
+            cmd_parts.extend(["--nrows", str(cli_nrows)])
+        if cli_ncols is not None:
+            cmd_parts.extend(["--ncols", str(cli_ncols)])
 
     bit_depth = read_kwargs.get("bit_depth")
     if bit_depth is not None:
@@ -99,6 +109,8 @@ def generate_sweep_array_script(
     verbose: bool = False,
     batch_size: int = 1,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> Path:
     """Generate a SLURM array job script for sweep processing.
 
@@ -180,6 +192,8 @@ def generate_sweep_array_script(
         read_kwargs=read_kwargs,
         verbose=verbose,
         save_intermediates=save_intermediates,
+        cli_nrows=cli_nrows,
+        cli_ncols=cli_ncols,
     )
 
     # Offset section (only included for chunked scripts)
@@ -348,6 +362,8 @@ def generate_sweep_array_scripts_chunked(
     verbose: bool = False,
     batch_size: int = 1,
     save_intermediates: bool = False,
+    cli_nrows: Optional[int] = None,
+    cli_ncols: Optional[int] = None,
 ) -> List[Path]:
     """Generate chunked SLURM array scripts for large sweeps.
 
@@ -395,6 +411,8 @@ def generate_sweep_array_scripts_chunked(
             verbose=verbose,
             batch_size=batch_size,
             save_intermediates=save_intermediates,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
         )
         return [path]
 
@@ -416,6 +434,8 @@ def generate_sweep_array_scripts_chunked(
             verbose=verbose,
             batch_size=batch_size,
             save_intermediates=save_intermediates,
+            cli_nrows=cli_nrows,
+            cli_ncols=cli_ncols,
         )
         script_paths.append(path)
 

--- a/tests/integration/cli/test_cli_hdf_output.py
+++ b/tests/integration/cli/test_cli_hdf_output.py
@@ -8,7 +8,7 @@ the behaviour promised by Phase 7 of the HDF-centric CLI plan:
   ``results/<dataset>/hdf/<stem>.h5`` and a parquet measurements file under
   ``results/<dataset>/measurements/<stem>.parquet`` — and nothing else
   (no per-layer ``rgb/`` / ``gray/`` / ``detect_mat/`` / ``objmap/`` folders).
-* Overlays are gated behind ``--save-overlays`` and default OFF.
+* Forward runs always write a PNG overlay per image alongside the HDF.
 * ``--measure`` reruns :meth:`ImagePipeline.measure` on existing HDFs
   without touching the HDF files on disk and without regenerating overlays.
 * ``--measure`` rejects incompatible flags with a clear error message.
@@ -124,6 +124,7 @@ class TestForwardRunHdfLayout:
         dataset_dir = output_dir / "results" / "plates"
         hdf_file = dataset_dir / "hdf" / "plate_001.h5"
         parquet_file = dataset_dir / "measurements" / "plate_001.parquet"
+        overlay_file = dataset_dir / "overlays" / "plate_001.png"
 
         assert hdf_file.exists(), (
             f"Expected HDF output at {hdf_file} (got contents: "
@@ -132,9 +133,13 @@ class TestForwardRunHdfLayout:
         assert parquet_file.exists(), (
             f"Expected parquet measurements at {parquet_file}"
         )
+        assert overlay_file.exists(), (
+            f"Expected overlay PNG at {overlay_file} (overlays are always "
+            f"written for forward runs)"
+        )
 
         # None of the legacy per-layer directories must be created.
-        for legacy_folder in ("rgb", "gray", "detect_mat", "objmap", "overlays"):
+        for legacy_folder in ("rgb", "gray", "detect_mat", "objmap"):
             legacy_path = dataset_dir / legacy_folder
             assert not legacy_path.exists(), (
                 f"Legacy per-layer folder {legacy_path} should NOT exist "
@@ -142,88 +147,52 @@ class TestForwardRunHdfLayout:
             )
 
         # Whitelist check: after a default forward run the dataset directory
-        # must contain ONLY `hdf/` and `measurements/`. Any other subdir
-        # (e.g. a renamed or new per-layer folder) would regress the layout.
+        # must contain exactly `hdf/`, `measurements/`, and `overlays/`. Any
+        # other subdir (e.g. a renamed or new per-layer folder) would regress
+        # the layout.
         actual_children = {p.name for p in dataset_dir.iterdir() if p.is_dir()}
-        assert actual_children == {"hdf", "measurements"}, (
+        assert actual_children == {"hdf", "measurements", "overlays"}, (
             f"Unexpected dataset-level folders after forward run. "
-            f"Got {sorted(actual_children)}; expected {{'hdf', 'measurements'}}."
-        )
-
-        # No stray PNGs should have landed anywhere under the dataset dir
-        # on a default run (they would indicate an overlay regression).
-        stray_pngs = list(dataset_dir.rglob("*.png"))
-        assert not stray_pngs, (
-            f"No PNG files should exist under {dataset_dir} on a default "
-            f"forward run, but found: {stray_pngs}"
+            f"Got {sorted(actual_children)}; expected "
+            f"{{'hdf', 'measurements', 'overlays'}}."
         )
 
 
 # ---------------------------------------------------------------------------
-# Overlay gating — default OFF, enabled by --save-overlays
+# Overlays — always-on for forward runs
 # ---------------------------------------------------------------------------
 
 
-class TestOverlayGating:
-    """Overlays are opt-in: off by default, on with --save-overlays."""
+class TestOverlayAlwaysOn:
+    """Forward runs always write an overlay PNG per image."""
 
-    def test_forward_run_overlays_gated(
+    def test_forward_run_writes_overlay(
         self, runner, temp_pipeline, plates_input_dir, tmp_path
     ):
-        """Two separate runs: default has no overlays/, --save-overlays does."""
-        # --- Run 1: default (no --save-overlays). No overlays/ dir. ---
-        output_dir_default = tmp_path / "out_default"
-        result_default = runner.invoke(
+        """A default forward run produces an overlay PNG without any flag."""
+        output_dir = tmp_path / "out"
+        result = runner.invoke(
             phenotypic_cli,
             [
                 str(temp_pipeline),
                 str(plates_input_dir),
                 "-o",
-                str(output_dir_default),
+                str(output_dir),
                 "--n-jobs",
                 "1",
                 "--skip-validation",
                 "--force-local",
             ],
         )
-        assert result_default.exit_code == 0, (
-            f"Default forward run failed:\n{result_default.output}"
-        )
-
-        default_overlays_dir = (
-            output_dir_default / "results" / "plates" / "overlays"
-        )
-        assert not default_overlays_dir.exists(), (
-            f"Default run should NOT create overlays/ directory, "
-            f"but found {default_overlays_dir}."
-        )
-
-        # --- Run 2: --save-overlays. PNG must exist. ---
-        output_dir_ov = tmp_path / "out_overlays"
-        result_ov = runner.invoke(
-            phenotypic_cli,
-            [
-                str(temp_pipeline),
-                str(plates_input_dir),
-                "-o",
-                str(output_dir_ov),
-                "--n-jobs",
-                "1",
-                "--skip-validation",
-                "--force-local",
-                "--save-overlays",
-            ],
-        )
-        assert result_ov.exit_code == 0, (
-            f"--save-overlays forward run failed:\n{result_ov.output}"
+        assert result.exit_code == 0, (
+            f"Default forward run failed:\n{result.output}"
         )
 
         overlay_png = (
-            output_dir_ov / "results" / "plates" / "overlays" / "plate_001.png"
+            output_dir / "results" / "plates" / "overlays" / "plate_001.png"
         )
         assert overlay_png.exists(), (
-            f"Expected overlay PNG at {overlay_png} when --save-overlays "
-            f"was passed."
+            f"Expected overlay PNG at {overlay_png} on a default forward run."
         )
 
 
@@ -262,12 +231,17 @@ class TestMeasureRerun:
         dataset_dir = output_dir / "results" / "plates"
         hdf_path = dataset_dir / "hdf" / "plate_001.h5"
         parquet_path = dataset_dir / "measurements" / "plate_001.parquet"
+        overlay_path = dataset_dir / "overlays" / "plate_001.png"
 
         assert hdf_path.exists()
         assert parquet_path.exists()
+        assert overlay_path.exists(), (
+            "Forward run should always write overlay PNG."
+        )
 
         hdf_mtime_before = hdf_path.stat().st_mtime_ns
         parquet_mtime_before = parquet_path.stat().st_mtime_ns
+        overlay_mtime_before = overlay_path.stat().st_mtime_ns
 
         # Sleep so mtimes actually differ on filesystems that round to seconds.
         time.sleep(0.1)
@@ -308,9 +282,12 @@ class TestMeasureRerun:
             f"--measure must not rewrite HDF files."
         )
 
-        # No overlays should be created on a measure rerun.
-        assert not (dataset_dir / "overlays").exists(), (
-            "--measure must not regenerate or create overlays/."
+        # Existing overlay must NOT be rewritten by a measure rerun.
+        overlay_mtime_after = overlay_path.stat().st_mtime_ns
+        assert overlay_mtime_after == overlay_mtime_before, (
+            f"Overlay mtime changed after --measure rerun "
+            f"(before={overlay_mtime_before}, after={overlay_mtime_after}). "
+            f"--measure must not regenerate overlays."
         )
 
     def test_measure_rerun_grid_image_hdf(

--- a/tests/unit/cli/test_cli_slurm_array.py
+++ b/tests/unit/cli/test_cli_slurm_array.py
@@ -321,8 +321,48 @@ class TestArrayJobScriptGeneration:
             array_limit=1000,
         )
 
-        # Should have 3 chunks (0-1000, 1000-2000, 2000-2500)
+        # Each chunk reserves slots for inserted checkpoint/manifest/finalizer
+        # sentinels, so the per-chunk image count is slightly below array_limit;
+        # 2500 images at limit=1000 still splits into 3 chunks.
         assert len(all_scripts["large_dataset"]) == 3
+
+    def test_generate_all_array_job_scripts_array_directive_within_limit(
+        self, tmp_path, config
+    ):
+        """Generated #SBATCH --array=0-N must satisfy N+1 <= array_limit
+        even after sentinel insertion. Regression for the
+        'Invalid job array specification' sbatch failure when chunk size
+        equaled array_limit and sentinels pushed len(entries) past MaxArraySize.
+        """
+        import re
+
+        images = [tmp_path / f"image_{i:05d}.tif" for i in range(3663)]
+        for img in images:
+            img.touch()
+        ds = Dataset(
+            name="big",
+            images=images,
+            input_dir=tmp_path,
+            output_dir=tmp_path / "output",
+        )
+
+        array_limit = 2500
+        all_scripts = generate_all_array_job_scripts(
+            datasets=[ds],
+            config=config,
+            output_dir=tmp_path / "output",
+            array_limit=array_limit,
+        )
+
+        for script_path in all_scripts["big"]:
+            content = script_path.read_text()
+            match = re.search(r"#SBATCH --array=0-(\d+)", content)
+            assert match is not None, f"No array directive in {script_path}"
+            top_index = int(match.group(1))
+            assert top_index + 1 <= array_limit, (
+                f"Array directive 0-{top_index} ({top_index + 1} entries) "
+                f"exceeds array_limit={array_limit} in {script_path.name}"
+            )
 
     def test_generate_array_job_script_empty_chunk_raises(
         self, dataset, config, tmp_path

--- a/tests/unit/cli/test_cli_v2.py
+++ b/tests/unit/cli/test_cli_v2.py
@@ -425,19 +425,19 @@ class TestOutputManager:
         assert manager.extensions == {"hdf": ".h5"}
         assert manager.overlay_alpha == 0.5
         assert manager.include_dataset_column is True
-        # Overlays default to OFF (opt-in via --save-overlays).
-        assert manager.save_overlays is False
+        # Overlays are always-on by default for forward runs.
+        assert manager.save_overlays is True
 
-    def test_from_config_factory_with_overlays(self, temp_output_dir):
-        """from_config(save_overlays=True) enables overlay output."""
+    def test_from_config_factory_overlays_disabled(self, temp_output_dir):
+        """from_config(save_overlays=False) disables overlay output (e.g. --measure)."""
         manager = OutputManager.from_config(
             base_dir=temp_output_dir,
             ext=".tiff",
             overlay_alpha=0.5,
-            save_overlays=True,
+            save_overlays=False,
         )
 
-        assert manager.save_overlays is True
+        assert manager.save_overlays is False
 
     def test_pipeline_json_copied_to_output(self, temp_output_dir):
         """Test pipeline JSON is copied to output directory for reproducibility."""
@@ -1088,7 +1088,6 @@ class TestEdgeCases:
                 "--n-jobs",
                 "1",
                 "--skip-validation",
-                "--save-overlays",
             ],
         )
 
@@ -1106,7 +1105,7 @@ class TestEdgeCases:
 
         assert measurements_file.exists(), f"Expected {measurements_file} to exist"
         assert hdf_file.exists(), f"Expected {hdf_file} to exist"
-        # Overlay only produced because --save-overlays was passed
+        # Overlays are always written for forward runs.
         assert overlay_file.exists(), f"Expected {overlay_file} to exist"
 
         # Verify results and dataset folder is created

--- a/tests/unit/core/test_image_pipeline.py
+++ b/tests/unit/core/test_image_pipeline.py
@@ -340,3 +340,72 @@ def test_benchmark_no_memory_when_disabled(plate_12hr_grid_image):
 
     assert len(pipe._operation_memory) == 0
     assert len(pipe._operation_rss) == 0
+
+
+# ---------------------------------------------------------------------------
+# Soft grid-shape preset (nrows/ncols)
+# ---------------------------------------------------------------------------
+
+
+@timeit
+def test_grid_preset_auto_injects_grid_finder(synth_plate_detected):
+    """measure() auto-injects AutoGridFinder when preset set and none configured."""
+    from phenotypic.grid import AutoGridFinder
+
+    pipe = ImagePipeline(meas=[MeasureShape()], nrows=8, ncols=12)
+    assert "AutoGridFinder" not in pipe._meas  # not persisted
+
+    df = pipe.measure(synth_plate_detected.copy())
+
+    # AutoGridFinder ran first, so the result has grid columns.
+    assert "Grid_RowNum" in df.columns and "Grid_ColNum" in df.columns
+    # _meas itself was not mutated.
+    assert "AutoGridFinder" not in pipe._meas
+    # Sanity: the preset is reachable on the pipeline instance.
+    assert pipe.nrows == 8 and pipe.ncols == 12
+    # Auto-injected step uses the preset values: build a fresh run order and
+    # confirm the injected instance carries them.
+    run_order = pipe._build_measurement_run_order()
+    injected = run_order["AutoGridFinder"]
+    assert isinstance(injected, AutoGridFinder)
+    assert injected.nrows == 8 and injected.ncols == 12
+
+
+@timeit
+def test_grid_preset_does_not_override_existing_grid_finder(synth_plate_detected):
+    """An existing GridFinder step wins; the preset does not auto-inject."""
+    from phenotypic.grid import AutoGridFinder
+
+    explicit = AutoGridFinder(nrows=4, ncols=6)
+    # Preset says 16x24 but explicit says 4x6 — explicit must win.
+    pipe = ImagePipeline(meas=[explicit], nrows=16, ncols=24)
+
+    run_order = pipe._build_measurement_run_order()
+    finders = [m for m in run_order.values() if isinstance(m, AutoGridFinder)]
+    assert len(finders) == 1
+    assert finders[0] is explicit
+    assert finders[0].nrows == 4 and finders[0].ncols == 6
+
+
+@timeit
+def test_grid_preset_no_op_when_unset():
+    """Without the preset, measure() does not auto-inject anything."""
+    from phenotypic.grid import AutoGridFinder
+
+    pipe = ImagePipeline(meas=[MeasureShape()])
+    run_order = pipe._build_measurement_run_order()
+
+    assert all(not isinstance(m, AutoGridFinder) for m in run_order.values())
+    assert list(run_order.keys()) == list(pipe._meas.keys())
+
+
+@timeit
+def test_grid_preset_idempotent_repeated_measure(synth_plate_detected):
+    """Repeat measure() calls neither accumulate nor mutate _meas."""
+    pipe = ImagePipeline(meas=[MeasureShape()], nrows=8, ncols=12)
+
+    pipe.measure(synth_plate_detected.copy())
+    pipe.measure(synth_plate_detected.copy())
+
+    # _meas was never touched, regardless of how many measure() calls ran.
+    assert list(pipe._meas.keys()) == ["MeasureShape"]

--- a/tests/unit/core/test_pipeline_serialization.py
+++ b/tests/unit/core/test_pipeline_serialization.py
@@ -317,6 +317,47 @@ class TestEdgeCases:
         assert "GaussianBlur_1" in op_names
         assert "GaussianBlur_2" in op_names
 
+    def test_grid_preset_roundtrip(self):
+        """nrows/ncols soft preset survives to_json / from_json."""
+        pipe = ImagePipeline(nrows=16, ncols=24)
+        json_str = pipe.to_json()
+
+        config = json.loads(json_str)
+        assert config["nrows"] == 16
+        assert config["ncols"] == 24
+
+        loaded = ImagePipeline.from_json(json_str)
+        assert loaded.nrows == 16
+        assert loaded.ncols == 24
+
+    def test_grid_preset_omitted_when_unset(self):
+        """When nrows/ncols are unset, JSON contains no such keys."""
+        pipe = ImagePipeline(ops=[OtsuDetector()])
+        json_str = pipe.to_json()
+
+        config = json.loads(json_str)
+        assert "nrows" not in config
+        assert "ncols" not in config
+
+        loaded = ImagePipeline.from_json(json_str)
+        assert loaded.nrows is None
+        assert loaded.ncols is None
+
+    def test_legacy_json_without_grid_preset_loads(self):
+        """Old JSON without nrows/ncols keys still loads cleanly."""
+        legacy_json = json.dumps({
+            "pipe_cfgs": {},
+            "meas": {},
+            "post": {},
+            "name": "legacy",
+            "desc": None,
+            "reset": False,
+        })
+
+        loaded = ImagePipeline.from_json(legacy_json)
+        assert loaded.nrows is None
+        assert loaded.ncols is None
+
     def test_benchmark_and_verbose_flags_not_serialized(self):
         """Test that benchmark and verbose flags are not serialized but can be passed as params."""
         pipe = ImagePipeline(ops=[OtsuDetector()], benchmark=True, verbose=True)

--- a/tests/unit/grid/test_auto_grid_finder.py
+++ b/tests/unit/grid/test_auto_grid_finder.py
@@ -392,7 +392,9 @@ class TestRobustPitchEstimate:
 
     def test_uniform_centers(self):
         centers = np.array([10.0, 30.0, 50.0, 70.0, 90.0])
-        pitch = AutoGridFinder._robust_pitch_estimate(centers, n_expected=5)
+        pitch = AutoGridFinder._robust_pitch_estimate(
+            centers, n_expected=5, image_dim=100,
+        )
         assert 15.0 < pitch < 25.0
 
     def test_outlier_at_extreme(self):
@@ -401,25 +403,31 @@ class TestRobustPitchEstimate:
             10.0, 30.0, 50.0, 70.0, 90.0,  # true grid, pitch=20
             300.0,  # far outlier
         ]))
-        pitch = AutoGridFinder._robust_pitch_estimate(centers, n_expected=5)
-        # Mode of diffs is still ~20, but span pitch is (300-10)/4=72.5
-        # Mode (~20) is < 0.5 * 72.5 = 36.25, so falls back to span pitch
-        # Either way, should return a positive value
+        pitch = AutoGridFinder._robust_pitch_estimate(
+            centers, n_expected=5, image_dim=100,
+        )
+        # span_pitch=(300-10)/4=72.5, image_pitch=100/5=20. Mode (~20) is
+        # within [0.5x, 2.0x] of image_pitch, so dual-reference accepts
+        # the mode and the span outlier no longer corrupts the result.
         assert pitch > 0
 
     def test_half_pitch_contamination_triggers_fallback(self):
-        """Objects at half-pitch intervals should trigger sanity check fallback."""
+        """Objects at half-pitch intervals — mode lies at the boundary."""
         # True pitch = 20, but objects at every 10px
         centers = np.arange(10.0, 100.0, 10.0)  # 9 points at pitch 10
-        pitch = AutoGridFinder._robust_pitch_estimate(centers, n_expected=5)
-        # mode of diffs = 10, span pitch = (90-10)/4 = 20
-        # 10 == 0.5 * 20 → borderline, should fall back to span pitch
+        pitch = AutoGridFinder._robust_pitch_estimate(
+            centers, n_expected=5, image_dim=100,
+        )
+        # mode=10, span_pitch=20, image_pitch=20. ref_low=10, ref_high=40
+        # → mode=10 is at the inclusive lower bound, so accepted.
         assert pitch >= 10.0
 
     def test_few_diffs_falls_back(self):
         centers = np.array([10.0, 30.0])
-        pitch = AutoGridFinder._robust_pitch_estimate(centers, n_expected=5)
-        # Only 1 diff → falls back to span pitch
+        pitch = AutoGridFinder._robust_pitch_estimate(
+            centers, n_expected=5, image_dim=40,
+        )
+        # Only 1 diff → falls back to span pitch (early-return branch)
         expected_span = (30.0 - 10.0) / 4
         assert pitch == pytest.approx(expected_span)
 
@@ -504,16 +512,6 @@ class TestAssignGridIndicesWithAnchor:
 
 class TestHighObjectCountRobustness:
 
-    @pytest.mark.xfail(
-        reason=(
-            "Mode-vs-span ratio guard in _robust_pitch_estimate is "
-            "temporarily disabled (see TODO there). With many detections "
-            "per cell, mode_pitch now reflects within-cluster spacing "
-            "rather than inter-cell pitch. Re-enable when Option 2 "
-            "(image_dim/n_expected reference) is implemented."
-        ),
-        strict=True,
-    )
     def test_many_objects_per_cell(self):
         """Simulate ~50 objects per grid cell + noise, verify edges are sane."""
         rng = np.random.default_rng(123)

--- a/tests/unit/grid/test_auto_grid_finder.py
+++ b/tests/unit/grid/test_auto_grid_finder.py
@@ -504,6 +504,16 @@ class TestAssignGridIndicesWithAnchor:
 
 class TestHighObjectCountRobustness:
 
+    @pytest.mark.xfail(
+        reason=(
+            "Mode-vs-span ratio guard in _robust_pitch_estimate is "
+            "temporarily disabled (see TODO there). With many detections "
+            "per cell, mode_pitch now reflects within-cluster spacing "
+            "rather than inter-cell pitch. Re-enable when Option 2 "
+            "(image_dim/n_expected reference) is implemented."
+        ),
+        strict=True,
+    )
     def test_many_objects_per_cell(self):
         """Simulate ~50 objects per grid cell + noise, verify edges are sane."""
         rng = np.random.default_rng(123)

--- a/tests/unit/grid/test_auto_grid_finder.py
+++ b/tests/unit/grid/test_auto_grid_finder.py
@@ -384,55 +384,6 @@ class TestAutoGridFinderIntegration:
 
 
 # ===========================================================================
-# _robust_pitch_estimate
-# ===========================================================================
-
-
-class TestRobustPitchEstimate:
-
-    def test_uniform_centers(self):
-        centers = np.array([10.0, 30.0, 50.0, 70.0, 90.0])
-        pitch = AutoGridFinder._robust_pitch_estimate(
-            centers, n_expected=5, image_dim=100,
-        )
-        assert 15.0 < pitch < 25.0
-
-    def test_outlier_at_extreme(self):
-        """Outlier at the far end should not corrupt the estimate."""
-        centers = np.sort(np.array([
-            10.0, 30.0, 50.0, 70.0, 90.0,  # true grid, pitch=20
-            300.0,  # far outlier
-        ]))
-        pitch = AutoGridFinder._robust_pitch_estimate(
-            centers, n_expected=5, image_dim=100,
-        )
-        # span_pitch=(300-10)/4=72.5, image_pitch=100/5=20. Mode (~20) is
-        # within [0.5x, 2.0x] of image_pitch, so dual-reference accepts
-        # the mode and the span outlier no longer corrupts the result.
-        assert pitch > 0
-
-    def test_half_pitch_contamination_triggers_fallback(self):
-        """Objects at half-pitch intervals — mode lies at the boundary."""
-        # True pitch = 20, but objects at every 10px
-        centers = np.arange(10.0, 100.0, 10.0)  # 9 points at pitch 10
-        pitch = AutoGridFinder._robust_pitch_estimate(
-            centers, n_expected=5, image_dim=100,
-        )
-        # mode=10, span_pitch=20, image_pitch=20. ref_low=10, ref_high=40
-        # → mode=10 is at the inclusive lower bound, so accepted.
-        assert pitch >= 10.0
-
-    def test_few_diffs_falls_back(self):
-        centers = np.array([10.0, 30.0])
-        pitch = AutoGridFinder._robust_pitch_estimate(
-            centers, n_expected=5, image_dim=40,
-        )
-        # Only 1 diff → falls back to span pitch (early-return branch)
-        expected_span = (30.0 - 10.0) / 4
-        assert pitch == pytest.approx(expected_span)
-
-
-# ===========================================================================
 # _aggregate_to_cell_medians
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

- **Pipeline grid-shape preset**: `ImagePipeline` now carries optional `nrows`/`ncols`; when both are set and no `GridFinder` is configured, `measure()` auto-injects an `AutoGridFinder` for that call without mutating the persisted `_meas` mapping. The preset round-trips through `to_json`/`from_json` and is omitted when unset so legacy pipeline JSONs load unchanged.
- **CLI grid flags optional**: Main CLI and sweep CLI `--nrows`/`--ncols` default to `None`. A new `resolve_grid_shape()` helper picks effective values with precedence explicit-CLI > pipeline preset > built-in default, resolved per-pipeline in the worker so each sweep variant can carry its own preset. SLURM scripts omit unset flags.
- **AutoGridFinder rewrite**: Replaces the brittle mode-of-successive-diffs robust pitch pipeline with k-means style iterative refinement seeded from image-pitch indices, plus a dual-reference pitch guard (span_pitch vs image_dim/n_expected), per-axis sparsity gate, filterable fallback warnings, and dashboard diagnostic panels. Converges on index stability with single-cell boundary flicker tolerance for dense (~1500-center) plates.
- **Serialization fix**: `ImagePipeline.to_json()` now returns `None` when `filepath` is provided (previously wrote to disk *and* returned the JSON string, contradicting the documented contract). CLI validation accepts `None` for `nrows`/`ncols` on `GridImage`; only explicit non-positive values are rejected.
- **SLURM array sentinel reservation**: `generate_all_array_job_scripts` now caps per-chunk image count at `(L-3)*K/(K+2)` so checkpoint/manifest sentinels and the finalizer trio fit under `MaxArraySize` (previously sbatch rejected jobs with `image_count == array_limit`).
- **Overlay PNGs always-on**: `--save-overlays` flag removed from the main CLI; defaults flipped to `True` in `ExecutionConfig` and `OutputManager`. SLURM unconditionally passes the flag to the worker for non-measure runs; `--measure` reruns still skip overlays.
- **Docs notebook plotly rendering**: Sets `pio.renderers.default = \"notebook_connected\"` inside `phenotypic` when `PHENOTYPIC_DOCS_BUILD=1`, and exports the var from the docs Makefile and both Sphinx CI workflows so nbsphinx preserves Plotly's JSON-mimetype bundle on the static site.

## Test plan

- [ ] `uv run pytest tests/unit/core/test_image_pipeline.py tests/unit/core/test_pipeline_serialization.py`
- [ ] `uv run pytest tests/unit/grid/test_auto_grid_finder.py`
- [ ] `uv run pytest tests/unit/cli/test_cli_v2.py tests/unit/cli/test_cli_slurm_array.py tests/integration/cli/test_cli_hdf_output.py`
- [ ] Verify `to_json(filepath=...)` writes the file and returns `None`; `to_json()` with no filepath still returns the JSON string
- [ ] Run a SLURM array job near `MaxArraySize` to confirm sbatch accepts the chunked submission
- [ ] Build docs locally with `PHENOTYPIC_DOCS_BUILD=1` and confirm Plotly figures render in `01_your_first_plate_image.ipynb`
- [ ] Run a sweep CLI invocation without `--nrows`/`--ncols` and confirm each pipeline uses its own preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)