### PR TITLE
gui(builder): add Dash + dash-cytoscape pipeline builder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,9 @@ dependencies = [
     "ruptures>=1.1.9",
     "typing_extensions>=4.0.0",
     "pooch>=1.8",
+    "dash>=4.1.0",
+    "dash-cytoscape>=1.0.2",
+    "dash-bootstrap-components>=2.0.4",
 ]
 
 [project.urls]

--- a/src/phenotypic/_core/_pipeline_parts/_image_pipeline_core.py
+++ b/src/phenotypic/_core/_pipeline_parts/_image_pipeline_core.py
@@ -315,6 +315,17 @@ class ImagePipelineCore(BaseOperation, LazyWidgetMixin):
         """
         return dict(self._meas)
 
+    def get_post(self) -> Dict[str, PostMeasurement]:
+        """Get a copy of the post-measurement transforms dictionary.
+
+        Returns a shallow copy to prevent accidental mutation of internal state.
+
+        Returns:
+            Dict[str, PostMeasurement]: Dictionary mapping post-measurement
+                names to ``PostMeasurement`` instances.
+        """
+        return dict(self._post)
+
     @staticmethod
     def __make_unique(class_names):
         """

--- a/src/phenotypic/gui/__init__.py
+++ b/src/phenotypic/gui/__init__.py
@@ -108,6 +108,17 @@ def __getattr__(name: str):
 
             return launch_sweep_viewer
 
+    # Dash node-graph builder (requires dash + dash-cytoscape, lazy)
+    if name in ("create_builder_app", "BuilderState"):
+        if name == "create_builder_app":
+            from .builder import create_app
+
+            return create_app
+        elif name == "BuilderState":
+            from .builder import BuilderState
+
+            return BuilderState
+
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -122,4 +133,7 @@ __all__ = [
     # Napari sweep viewer
     "NapariSweepViewer",
     "launch_sweep_viewer",
+    # Dash node-graph builder
+    "create_builder_app",
+    "BuilderState",
 ]

--- a/src/phenotypic/gui/_operation_registry.py
+++ b/src/phenotypic/gui/_operation_registry.py
@@ -114,6 +114,7 @@ class OperationRegistry:
         import phenotypic.correction as correction_module
         import phenotypic.measure as measure_module
         import phenotypic.grid as grid_module
+        import phenotypic.post as post_module
 
         from phenotypic.abc_ import (
             ImageEnhancer,
@@ -122,6 +123,7 @@ class OperationRegistry:
             ImageCorrector,
             MeasureFeatures,
             GridOperation,
+            PostMeasurement,
         )
 
         # Map modules to categories
@@ -132,6 +134,7 @@ class OperationRegistry:
             (correction_module, "Corrector", ImageCorrector),
             (measure_module, "Measure", MeasureFeatures),
             (grid_module, "Grid", GridOperation),
+            (post_module, "Post", PostMeasurement),
         ]
 
         for module, category, base_class in module_category_map:

--- a/src/phenotypic/gui/builder/__init__.py
+++ b/src/phenotypic/gui/builder/__init__.py
@@ -1,0 +1,26 @@
+"""Dash + dash-cytoscape interactive ImagePipeline builder.
+
+This subpackage provides a web-based node-graph editor for constructing
+:class:`phenotypic.ImagePipeline` objects interactively. It is intended to
+run on an HPCC head node and be reached from a workstation via SSH port
+forwarding (``ssh -L 8050:localhost:8050 user@hpcc``).
+
+Public API will be filled in by Phase 4 once :func:`create_app` exists.
+"""
+
+from __future__ import annotations
+
+__all__ = ["create_app", "BuilderState"]
+
+
+def __getattr__(name: str):  # noqa: D401 - lazy re-export
+    """Lazily import builder objects to keep Dash off the import-time hot path."""
+    if name == "create_app":
+        from phenotypic.gui.builder._app import create_app
+
+        return create_app
+    if name == "BuilderState":
+        from phenotypic.gui.builder._state import BuilderState
+
+        return BuilderState
+    raise AttributeError(f"module 'phenotypic.gui.builder' has no attribute {name!r}")

--- a/src/phenotypic/gui/builder/__main__.py
+++ b/src/phenotypic/gui/builder/__main__.py
@@ -1,0 +1,100 @@
+"""CLI entry point for the Dash + dash-cytoscape pipeline builder.
+
+Boots a Dash server hosting an interactive node-graph editor for
+constructing :class:`phenotypic.ImagePipeline` objects. Designed to run on
+an HPCC head node and be reached from a workstation via SSH port
+forwarding (``ssh -L 8050:localhost:8050 user@hpcc``).
+
+Examples:
+    Default port + bind to all interfaces (so an SSH tunnel to a
+    cluster login node sees the server on the forwarded port)::
+
+        uv run python -m phenotypic.gui.builder
+
+    Serve from a project scratch directory so the in-app file picker
+    can browse the user's images::
+
+        uv run python -m phenotypic.gui.builder \\
+            --image-root /scratch/$USER/images \\
+            --port 8050
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Optional, Sequence
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser used by :func:`main`."""
+    parser = argparse.ArgumentParser(
+        prog="python -m phenotypic.gui.builder",
+        description=(
+            "Launch the Dash + dash-cytoscape ImagePipeline builder. "
+            "Reach the UI by SSH-tunneling the chosen port "
+            "('ssh -L 8050:localhost:8050 user@hpcc')."
+        ),
+    )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Interface to bind. Default 127.0.0.1 keeps the server "
+            "loopback-only — pair with SSH port forwarding for remote "
+            "access. Use 0.0.0.0 to expose on the network (not "
+            "recommended without authentication)."
+        ),
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8050,
+        help="TCP port to bind. Default 8050.",
+    )
+    parser.add_argument(
+        "--image-root",
+        type=Path,
+        default=None,
+        help=(
+            "Directory rooting the in-app file picker. Omit to disable "
+            "the tree (the user can still type a path or use the "
+            "synthetic plate fallback)."
+        ),
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Run Dash in debug mode (auto-reload, verbose tracebacks).",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    """Parse CLI arguments and run the builder Dash server.
+
+    Args:
+        argv: Optional argument vector for testing. ``None`` uses
+            ``sys.argv[1:]``.
+    """
+    args = _build_parser().parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.image_root is not None and not args.image_root.is_dir():
+        raise SystemExit(
+            f"--image-root {args.image_root} is not an existing directory"
+        )
+
+    from phenotypic.gui.builder._app import create_app
+
+    app = create_app(image_root=args.image_root)
+    app.run(host=args.host, port=args.port, debug=args.debug)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/phenotypic/gui/builder/_app.py
+++ b/src/phenotypic/gui/builder/_app.py
@@ -1,0 +1,86 @@
+"""Dash app factory for the pipeline builder.
+
+Phase 2 deliverable: build a fully-laid-out Dash application without any
+``@callback`` registration. Phase 3 imports :func:`create_app`, mutates the
+returned instance to add callbacks via the IDs exported from
+:mod:`phenotypic.gui.builder._ids`, and wires preview/save/load logic.
+
+The app is ready to ``run(host=..., port=...)`` for visual inspection — the
+canvas, palette, and footer all render — but no buttons are functional until
+Phase 3 lands.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import dash
+import dash_bootstrap_components as dbc  # type: ignore[import-untyped]
+
+from phenotypic.gui._operation_registry import OperationRegistry
+from phenotypic.gui.builder._callbacks import register_callbacks
+from phenotypic.gui.builder._layout import build_app_layout
+from phenotypic.gui.builder._state import BuilderState
+
+
+def create_app(
+    image_root: Optional[Path] = None,
+    *,
+    registry: Optional[OperationRegistry] = None,
+) -> dash.Dash:
+    """Build a Dash application instance for the pipeline builder.
+
+    Constructs (or reuses) an :class:`OperationRegistry`, builds an empty
+    :class:`BuilderState`, instantiates a :class:`dash.Dash` with Bootstrap
+    styling, sets ``app.layout`` from :func:`build_app_layout`, and stashes
+    *image_root* and *registry* on ``app.server.config`` so Phase 3 callbacks
+    can retrieve them via ``flask.current_app``.
+
+    Args:
+        image_root: Optional server-side directory used as the root of the
+            directory-tree picker. ``None`` disables the tree (the user can
+            still type a path or fall back to the synthetic plate).
+        registry: Pre-populated :class:`OperationRegistry` to share across
+            requests. When ``None``, a fresh registry is constructed and
+            :meth:`OperationRegistry.discover` is called immediately so the
+            palette renders on the first paint.
+
+    Returns:
+        A configured :class:`dash.Dash` instance whose ``app.run(...)`` is
+        the responsibility of the caller (typically the Phase-4 CLI).
+
+    Examples:
+        >>> from phenotypic.gui.builder._app import create_app
+        >>> app = create_app(image_root=None)
+        >>> app.title
+        'PhenoTypic Pipeline Builder'
+    """
+
+    if registry is None:
+        registry = OperationRegistry()
+        registry.discover()
+
+    state = BuilderState()
+
+    app = dash.Dash(
+        __name__,
+        external_stylesheets=[dbc.themes.BOOTSTRAP],
+        suppress_callback_exceptions=True,
+        title="PhenoTypic Pipeline Builder",
+    )
+
+    app.layout = build_app_layout(state, registry, image_root)
+
+    # Stash dependencies on the underlying Flask server so Phase 3 callbacks
+    # can fetch them via ``flask.current_app.config[...]`` without rebuilding
+    # the registry per request.
+    app.server.config["pheno_image_root"] = image_root
+    app.server.config["pheno_registry"] = registry
+
+    register_callbacks(app)
+
+    return app
+
+
+__all__ = ["create_app"]

--- a/src/phenotypic/gui/builder/_callbacks.py
+++ b/src/phenotypic/gui/builder/_callbacks.py
@@ -1,0 +1,1545 @@
+"""Dash ``@callback`` registrations for the pipeline builder.
+
+Phase 3 owns every callback that reads or writes
+:data:`phenotypic.gui.builder._ids.STORE_BUILDER_STATE` plus the few helper
+callbacks that drive the directory picker, preview, and inspector preview
+panel.
+
+Architecture notes:
+
+* **Single fan-in mutation callback** — every trigger that mutates the
+  builder state (palette adds, deletes, drill-in/out, breadcrumb jumps,
+  reorders, drag, parameter edits, label edits) feeds one callback that
+  resolves the trigger via :data:`dash.callback_context.triggered_id` and
+  returns a fresh ``STORE_BUILDER_STATE`` plus a re-rendered canvas /
+  inspector / breadcrumb.  This keeps ``allow_duplicate=True`` out of the
+  store contract.
+* **Stateless helpers** — :func:`_dispatch_state_update` is a pure function
+  taking a serialized state dict + a kind tag + a payload and returning the
+  new dict.  Tests can exercise the full mutation surface without booting
+  Dash.
+* **Drill-in surface** — the inspector reuses :data:`BTN_DRILL_OUT` as the
+  drill-in button when a pipeline node is selected (set by Phase 2).  The
+  fan-in handler distinguishes "drill-in" from "drill-out" by inspecting the
+  selected node's class at trigger time, so the same component id maps to
+  two semantic actions.
+* **Cytoscape reorder** — we listen to ``Input(CANVAS_CYTOSCAPE, "elements")``
+  and, when the visible node-id sequence (filtered to non-edge entries and
+  sorted by ``position.x``) differs from the state-derived order, reorder
+  ``current_scope(state).nodes`` to match.  Reorder is a no-op while no node
+  has a ``position`` (cytoscape's grid layout fills positions on the second
+  render).
+
+Every state-mutating callback uses ``prevent_initial_call=True`` and wraps
+its body in ``try / except`` so a callback can never crash the running app
+— errors flip the toast to the failure variant instead.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import dash
+from dash import ALL, Input, Output, State, ctx, html, no_update
+from flask import current_app
+
+from phenotypic.gui.builder import _ids as ids
+from phenotypic.gui.builder._directory_browser import (
+    DIR_PICKER_PATH_INPUT,
+    DIR_PICKER_SYNTH_BTN,
+    DIR_PICKER_TREE_CONTAINER,
+    DIR_PICKER_USE_PATH_BTN,
+    SYNTHETIC_SENTINEL,
+    directory_tree,
+    find_synthetic_plate_path,
+)
+from phenotypic.gui.builder._image_renderer import dataframe_to_table, to_data_uri
+from phenotypic.gui.builder._layout import (
+    build_breadcrumb,
+    build_canvas,
+    build_inspector,
+)
+from phenotypic.gui.builder._param_form import parse_widget_value
+from phenotypic.gui.builder._session import get_cache
+from phenotypic.gui.builder._state import (
+    PIPELINE_CLASS_NAME,
+    BuilderState,
+    StepNode,
+    _PARAM_SCOPE_KEY,
+    _new_node_id,
+    current_scope,
+    from_pipeline,
+    stage_of,
+    state_from_json,
+    state_to_json,
+    to_pipeline,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ``STORE_IMAGE_PATH`` lives on :mod:`._ids` now; alias here for backwards
+# compatibility with callers that imported it from this module.
+STORE_IMAGE_PATH = ids.STORE_IMAGE_PATH
+
+
+# ---------------------------------------------------------------------------
+# Pure mutation helpers (testable without Dash)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_segment(seg: Any) -> Dict[str, Any]:
+    """Return *seg* as a ``{"node_id": ..., "param": ...}`` dict.
+
+    Accepts both legacy plain-string entries (older saved state) and the
+    new dict form so dispatch logic can be agnostic to the storage format.
+    """
+
+    if isinstance(seg, str):
+        return {"node_id": seg, "param": None}
+    return {"node_id": seg["node_id"], "param": seg.get("param")}
+
+
+def _scope_at_breadcrumb(
+    state_dict: Dict[str, Any], breadcrumb: List[Any]
+) -> Dict[str, Any]:
+    """Walk *state_dict* ``root`` → ``breadcrumb`` and return that scope dict.
+
+    For pipeline drill segments the walker descends into ``node["nested"]``;
+    for op-typed-parameter segments it descends into the synthesised scope
+    dict stored under ``node["params"]["__op_param_scope__"][param_name]``,
+    seeding it from any existing operation marker dict if absent.
+
+    Args:
+        state_dict: ``state_to_json`` output.
+        breadcrumb: List of breadcrumb segments (string ids or
+            ``{"node_id", "param"}`` dicts).
+
+    Returns:
+        The nested scope dict (``{"nodes": [...], ...}``).  Returns the root
+        scope when ``breadcrumb`` is empty.
+    """
+
+    scope = state_dict["root"]
+    for raw in breadcrumb:
+        seg = _normalize_segment(raw)
+        node = next(
+            (n for n in scope["nodes"] if n["node_id"] == seg["node_id"]),
+            None,
+        )
+        if node is None:
+            return scope
+        if seg["param"] is None:
+            if node.get("nested") is None:
+                return scope
+            scope = node["nested"]
+        else:
+            params = node.setdefault("params", {})
+            scopes = params.setdefault(_PARAM_SCOPE_KEY, {})
+            param_scope = scopes.get(seg["param"])
+            if param_scope is None:
+                param_scope = _seed_param_scope_from_marker(
+                    params.get(seg["param"]), seg["param"], node
+                )
+                scopes[seg["param"]] = param_scope
+            scope = param_scope
+    return scope
+
+
+def _seed_param_scope_from_marker(
+    existing: Any, param_name: str, parent_node: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Build a fresh scope dict, optionally seeding a single node from *existing*.
+
+    Mirrors :func:`phenotypic.gui.builder._state._ensure_param_scope` at the
+    JSON-dict level so dispatch can stay schema-agnostic.
+    """
+
+    seed_nodes: List[Dict[str, Any]] = []
+    if isinstance(existing, dict):
+        marker_type = existing.get("__type__")
+        if marker_type == "operation":
+            class_name = existing.get("class_name") or existing.get("class")
+            seed_nodes.append(
+                {
+                    "node_id": _new_node_id(),
+                    "class_name": str(class_name),
+                    "params": dict(existing.get("params") or {}),
+                    "label": str(class_name),
+                    "nested": None,
+                }
+            )
+        elif marker_type in {"pipeline", "pipeline_operation"}:
+            inner = existing.get("scope") or existing.get("config") or {}
+            seed_nodes.append(
+                {
+                    "node_id": _new_node_id(),
+                    "class_name": PIPELINE_CLASS_NAME,
+                    "params": {},
+                    "label": PIPELINE_CLASS_NAME,
+                    "nested": inner if isinstance(inner, dict) else {"nodes": []},
+                }
+            )
+
+    label = parent_node.get("label") or parent_node.get("class_name") or "node"
+    return {
+        "nodes": seed_nodes,
+        "name": f"{label}.{param_name}",
+        "desc": "",
+        "nrows": None,
+        "ncols": None,
+    }
+
+
+def _commit_param_segments(
+    state_dict: Dict[str, Any], dropped: List[Dict[str, Any]]
+) -> None:
+    """Mirror any popped param-scope segments back into their parent params.
+
+    ``dropped`` is the suffix of ``breadcrumb`` that's about to be removed
+    (innermost first does *not* matter — we re-walk from root each time).
+    For each segment whose ``param`` is set we collapse its synthesized
+    singleton scope into a normal operation marker stored at
+    ``parent.params[param_name]``.
+
+    The scope dict under ``__op_param_scope__`` is preserved so re-entering
+    the slot keeps the same node ids and incidental UI state.
+    """
+
+    for raw in dropped:
+        seg = _normalize_segment(raw)
+        if seg["param"] is None:
+            continue
+        # Walk fresh from root to find the parent node.
+        scope = state_dict["root"]
+        # Path leading up to (but not including) this segment is everything
+        # before ``seg`` in the breadcrumb.  We don't have that path here,
+        # so we instead search the whole tree depth-first for the matching
+        # node id.  Param scopes attach uniquely by id; collisions would be
+        # a state-model bug not addressed here.
+        target = _find_node_by_id(scope, seg["node_id"])
+        if target is None:
+            continue
+        scopes = target.get("params", {}).get(_PARAM_SCOPE_KEY) or {}
+        param_scope = scopes.get(seg["param"])
+        if param_scope is None:
+            continue
+        nodes = param_scope.get("nodes") or []
+        if not nodes:
+            target["params"][seg["param"]] = None
+            continue
+        first = nodes[0]
+        if first.get("class_name") == PIPELINE_CLASS_NAME:
+            target["params"][seg["param"]] = {
+                "__type__": "pipeline",
+                "class_name": PIPELINE_CLASS_NAME,
+                "scope": first.get("nested") or {"nodes": []},
+            }
+        else:
+            inner_params = {
+                k: v
+                for k, v in (first.get("params") or {}).items()
+                if k != _PARAM_SCOPE_KEY
+            }
+            target["params"][seg["param"]] = {
+                "__type__": "operation",
+                "class_name": first.get("class_name"),
+                "params": inner_params,
+            }
+
+
+def _find_node_by_id(scope: Dict[str, Any], node_id: str) -> Optional[Dict[str, Any]]:
+    """Depth-first search for a node by id across all nested scopes."""
+
+    for n in scope.get("nodes", []) or []:
+        if n.get("node_id") == node_id:
+            return n
+        nested = n.get("nested")
+        if isinstance(nested, dict):
+            hit = _find_node_by_id(nested, node_id)
+            if hit is not None:
+                return hit
+        param_scopes = (n.get("params") or {}).get(_PARAM_SCOPE_KEY) or {}
+        for inner in param_scopes.values():
+            if isinstance(inner, dict):
+                hit = _find_node_by_id(inner, node_id)
+                if hit is not None:
+                    return hit
+    return None
+
+
+def _default_params_for(class_name: str) -> Dict[str, Any]:
+    """Return a JSON-friendly default-param dict for *class_name*.
+
+    The registry's :class:`ParamInfo.default` is used directly when it is JSON
+    serialisable; non-trivial defaults (e.g. nested ops) are skipped because
+    they need a follow-up "Edit ▸" interaction.
+
+    Args:
+        class_name: Registry key.
+
+    Returns:
+        A dict mapping parameter name → default value.  Empty when the class
+        is not registered (the caller will simply emit an empty params dict).
+    """
+
+    from phenotypic.gui._operation_registry import get_registry
+
+    info = get_registry().get(class_name)
+    if info is None:
+        return {}
+
+    out: Dict[str, Any] = {}
+    for name, p in info.parameters.items():
+        if not p.has_default:
+            continue
+        if p.is_operation or p.is_pipeline:
+            # Skip nested-op defaults; the user will fill them via "Edit ▸".
+            continue
+        try:
+            json.dumps(p.default)
+        except (TypeError, ValueError):
+            continue
+        out[name] = p.default
+    return out
+
+
+def _dispatch_state_update(
+    state_dict: Dict[str, Any], kind: str, payload: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Apply a named mutation to a serialized state dict.
+
+    The pipeline builder funnels every state-mutating event through this
+    function so callbacks stay thin and the mutation surface stays unit-
+    testable.  Unknown *kind* values pass through unchanged.
+
+    Args:
+        state_dict: Output of :func:`state_to_json` (a plain ``dict``).
+        kind: One of:
+
+            ``"add_node"`` (payload: ``class_name``)
+                Append a fresh :class:`StepNode` for *class_name* to the
+                current scope.  Selects the new node.
+            ``"add_pipeline"``
+                Append a :class:`StepNode` carrying an empty nested scope.
+            ``"select_node"`` (payload: ``node_id``)
+                Set ``selected_node_id``.
+            ``"delete_node"``
+                Remove ``selected_node_id`` from the current scope.
+            ``"drill_in"``
+                Push ``selected_node_id`` onto the breadcrumb (only if that
+                node has a nested scope).
+            ``"drill_out"``
+                Pop the breadcrumb tail.
+            ``"breadcrumb_to"`` (payload: ``depth``)
+                Truncate breadcrumb to ``depth`` entries.
+            ``"reorder"`` (payload: ``order`` list of node-ids)
+                Reorder the current scope's nodes by node-id sequence.
+            ``"edit_param"`` (payload: ``node_id``, ``name``, ``value``,
+            ``omit``)
+                Set or delete ``params[name]`` on a specific node.
+            ``"edit_label"`` (payload: ``node_id``, ``label``)
+                Update the node label.
+
+        payload: kind-specific data (see above).
+
+    Returns:
+        A *new* state dict reflecting the mutation; the input dict is not
+        modified in place.
+
+    Raises:
+        ValueError: If a payload is missing a required key or refers to a
+            node that does not exist in the relevant scope.
+    """
+
+    out = deepcopy(state_dict)
+    breadcrumb = list(out.get("breadcrumb", []) or [])
+    scope = _scope_at_breadcrumb(out, breadcrumb)
+
+    if kind == "add_node":
+        class_name = payload["class_name"]
+        node_id = _new_node_id()
+        scope["nodes"].append(
+            {
+                "node_id": node_id,
+                "class_name": class_name,
+                "params": _default_params_for(class_name),
+                "label": None,
+                "nested": None,
+            }
+        )
+        out["selected_node_id"] = node_id
+        return out
+
+    if kind == "add_pipeline":
+        node_id = _new_node_id()
+        scope["nodes"].append(
+            {
+                "node_id": node_id,
+                "class_name": PIPELINE_CLASS_NAME,
+                "params": {},
+                "label": None,
+                "nested": {
+                    "nodes": [],
+                    "name": "Subpipeline",
+                    "desc": "",
+                    "nrows": None,
+                    "ncols": None,
+                },
+            }
+        )
+        out["selected_node_id"] = node_id
+        return out
+
+    if kind == "select_node":
+        out["selected_node_id"] = payload.get("node_id")
+        return out
+
+    if kind == "delete_node":
+        sel = out.get("selected_node_id")
+        if sel is None:
+            return out
+        scope["nodes"] = [n for n in scope["nodes"] if n["node_id"] != sel]
+        out["selected_node_id"] = None
+        return out
+
+    if kind == "drill_in":
+        sel = out.get("selected_node_id")
+        if sel is None:
+            return out
+        node = next((n for n in scope["nodes"] if n["node_id"] == sel), None)
+        if node is None or node.get("nested") is None:
+            return out
+        breadcrumb.append({"node_id": sel, "param": None})
+        out["breadcrumb"] = breadcrumb
+        out["selected_node_id"] = None
+        return out
+
+    if kind == "drill_out":
+        if breadcrumb:
+            dropped = [breadcrumb.pop()]
+            _commit_param_segments(out, dropped)
+        out["breadcrumb"] = breadcrumb
+        out["selected_node_id"] = None
+        return out
+
+    if kind == "breadcrumb_to":
+        depth = int(payload.get("depth", 0))
+        dropped = breadcrumb[depth:]
+        _commit_param_segments(out, dropped)
+        out["breadcrumb"] = breadcrumb[:depth]
+        out["selected_node_id"] = None
+        return out
+
+    if kind == "drill_in_param":
+        node_id = payload["node_id"]
+        param_name = payload["param_name"]
+        node = next((n for n in scope["nodes"] if n["node_id"] == node_id), None)
+        if node is None:
+            return out
+        params = node.setdefault("params", {})
+        scopes = params.setdefault(_PARAM_SCOPE_KEY, {})
+        if scopes.get(param_name) is None:
+            scopes[param_name] = _seed_param_scope_from_marker(
+                params.get(param_name), param_name, node
+            )
+        breadcrumb.append({"node_id": node_id, "param": param_name})
+        out["breadcrumb"] = breadcrumb
+        out["selected_node_id"] = None
+        return out
+
+    if kind == "reorder":
+        new_order: List[str] = list(payload.get("order", []) or [])
+        if not new_order:
+            return out
+        by_id = {n["node_id"]: n for n in scope["nodes"]}
+        # Drop unknown ids and append any nodes missing from new_order at the
+        # end so we can never accidentally lose data on a partial drag event.
+        reordered = [by_id[nid] for nid in new_order if nid in by_id]
+        leftover = [n for n in scope["nodes"] if n["node_id"] not in set(new_order)]
+        scope["nodes"] = reordered + leftover
+        return out
+
+    if kind == "edit_param":
+        node_id = payload["node_id"]
+        node = next((n for n in scope["nodes"] if n["node_id"] == node_id), None)
+        if node is None:
+            return out
+        if payload.get("omit"):
+            node.get("params", {}).pop(payload["name"], None)
+        else:
+            params = node.setdefault("params", {})
+            params[payload["name"]] = payload.get("value")
+        return out
+
+    if kind == "edit_label":
+        node_id = payload["node_id"]
+        node = next((n for n in scope["nodes"] if n["node_id"] == node_id), None)
+        if node is None:
+            return out
+        node["label"] = payload.get("label") or None
+        return out
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Toast helpers
+# ---------------------------------------------------------------------------
+
+
+def _toast(
+    message: str, *, ok: bool = True, header: Optional[str] = None
+) -> Tuple[bool, str, str, str]:
+    """Build the four toast outputs (``is_open``, ``children``, ``icon``, ``header``).
+
+    Args:
+        message: Text shown inside the toast body.
+        ok: ``True`` for success styling (primary), ``False`` for error
+            (danger).
+        header: Optional header override; defaults to "Pipeline builder" for
+            success or "Error" for failure.
+
+    Returns:
+        Tuple matching ``Output(TOAST_NOTIFICATION, "is_open" / "children" /
+        "icon" / "header")``.
+    """
+
+    icon = "primary" if ok else "danger"
+    h = header if header is not None else ("Pipeline builder" if ok else "Error")
+    return True, message, icon, h
+
+
+def _format_exception(exc: BaseException) -> str:
+    """Pretty short single-line summary of an exception for toast display."""
+
+    return f"{type(exc).__name__}: {exc}"
+
+
+# ---------------------------------------------------------------------------
+# Layout-render helpers (re-render canvas/inspector/breadcrumb after a state
+# mutation)
+# ---------------------------------------------------------------------------
+
+
+def _registry() -> Any:
+    """Return the registry stashed on ``app.server.config`` by ``create_app``."""
+
+    return current_app.config.get("pheno_registry")
+
+
+def _render_views(state: BuilderState) -> Tuple[Any, Any, Any]:
+    """Re-render breadcrumb, canvas, and inspector for a given state.
+
+    Args:
+        state: Live :class:`BuilderState` object.
+
+    Returns:
+        Tuple of ``(breadcrumb, canvas, inspector)`` Dash component subtrees.
+    """
+
+    registry = _registry()
+    try:
+        scope = current_scope(state)
+    except KeyError:
+        # Stale breadcrumb — fall back to the root.
+        state = BuilderState(
+            root=state.root, breadcrumb=[], selected_node_id=None
+        )
+        scope = state.root
+
+    canvas = build_canvas(scope, state.selected_node_id)
+    inspector = build_inspector(state, registry)
+    breadcrumb = build_breadcrumb(state)
+    return breadcrumb, canvas, inspector
+
+
+# ---------------------------------------------------------------------------
+# register_callbacks
+# ---------------------------------------------------------------------------
+
+
+def register_callbacks(app: dash.Dash) -> None:
+    """Register every Phase-3 callback on *app*.
+
+    Idempotent: callers that build the app should invoke this exactly once
+    after the layout is set so the patterns / store ids resolve.
+
+    Args:
+        app: The :class:`dash.Dash` instance returned by ``create_app``.
+    """
+
+    # --- Hidden store for the active image path ---------------------------
+    # Mounted after the fact so layout doesn't need editing.  We slot it into
+    # the layout via a dedicated callback that injects the store on first
+    # paint (see init_session_id below).
+
+    # ----------------------------------------------------------------------
+    # 1. Initialize STORE_SESSION_ID on first paint
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(ids.STORE_SESSION_ID, "data"),
+        Input(ids.STORE_BUILDER_STATE, "data"),
+        State(ids.STORE_SESSION_ID, "data"),
+        prevent_initial_call=False,
+    )
+    def init_session_id(_state_data: Any, current_id: Any) -> Any:
+        """Populate ``STORE_SESSION_ID`` with a fresh uuid on first paint.
+
+        Args:
+            _state_data: Builder state payload (only used as a trigger).
+            current_id: Current value of ``STORE_SESSION_ID``.
+
+        Returns:
+            The existing id when one exists, otherwise a new ``uuid.uuid4().hex``.
+        """
+
+        if current_id:
+            return no_update
+        return uuid.uuid4().hex
+
+    # ----------------------------------------------------------------------
+    # 2. Single fan-in mutation callback
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(ids.STORE_BUILDER_STATE, "data"),
+        Output(ids.BREADCRUMB_CONTAINER, "children"),
+        Output("canvas-cytoscape-wrapper", "children"),  # set below
+        Output(ids.INSPECTOR_CONTAINER, "children"),
+        # Toast outputs surface mutation errors to the user; success path leaves
+        # them as ``no_update`` so they don't clobber other callbacks' toasts.
+        Output(ids.TOAST_NOTIFICATION, "is_open", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "icon", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "header", allow_duplicate=True),
+        # palette
+        Input({"type": "palette-add", "class_name": ALL}, "n_clicks"),
+        Input(ids.BTN_NEW_PIPELINE_NODE, "n_clicks"),
+        # selection
+        Input(ids.CANVAS_CYTOSCAPE, "tapNodeData"),
+        # drill in (visible button on pipeline-node inspector); drill-out is
+        # done via breadcrumb-link clicks, not a dedicated button.
+        Input(ids.BTN_DRILL_IN, "n_clicks"),
+        Input({"type": "breadcrumb-link", "depth": ALL}, "n_clicks"),
+        # delete
+        Input(ids.BTN_DELETE_NODE, "n_clicks"),
+        # reorder via canvas elements
+        Input(ids.CANVAS_CYTOSCAPE, "elements"),
+        # parameter edits (one input per widget kind)
+        Input({"type": "param-bool", "prefix": ALL, "name": ALL}, "value"),
+        Input({"type": "param-num", "prefix": ALL, "name": ALL}, "n_blur"),
+        Input({"type": "param-str", "prefix": ALL, "name": ALL}, "n_blur"),
+        Input({"type": "param-enum", "prefix": ALL, "name": ALL}, "value"),
+        Input({"type": "param-list", "prefix": ALL, "name": ALL}, "n_blur"),
+        Input({"type": "param-tuple", "prefix": ALL, "name": ALL}, "n_blur"),
+        Input(
+            {"type": "param-optional-toggle", "prefix": ALL, "name": ALL},
+            "value",
+        ),
+        # operation-typed param drill-in
+        Input(
+            {"type": "param-edit-nested", "prefix": ALL, "name": ALL},
+            "n_clicks",
+        ),
+        # label
+        Input(ids.INPUT_NODE_LABEL, "n_blur"),
+        # values for parameter widgets (so we can resolve raw values on blur)
+        State({"type": "param-num", "prefix": ALL, "name": ALL}, "value"),
+        State({"type": "param-num", "prefix": ALL, "name": ALL}, "id"),
+        State({"type": "param-str", "prefix": ALL, "name": ALL}, "value"),
+        State({"type": "param-str", "prefix": ALL, "name": ALL}, "id"),
+        State({"type": "param-list", "prefix": ALL, "name": ALL}, "value"),
+        State({"type": "param-list", "prefix": ALL, "name": ALL}, "id"),
+        State({"type": "param-tuple", "prefix": ALL, "name": ALL}, "value"),
+        State({"type": "param-tuple", "prefix": ALL, "name": ALL}, "id"),
+        State(ids.INPUT_NODE_LABEL, "value"),
+        State(ids.STORE_BUILDER_STATE, "data"),
+        prevent_initial_call=True,
+    )
+    def fan_in_state_mutation(  # noqa: C901, PLR0912, PLR0913, PLR0915
+        _palette_clicks: List[int],
+        _new_pipe_clicks: Optional[int],
+        tap_node_data: Optional[Dict[str, Any]],
+        _drill_out_clicks: Optional[int],
+        _crumb_clicks: List[int],
+        _delete_clicks: Optional[int],
+        elements: Optional[List[Dict[str, Any]]],
+        bool_vals: List[Any],
+        _num_blurs: List[Any],
+        _str_blurs: List[Any],
+        enum_vals: List[Any],
+        _list_blurs: List[Any],
+        _tuple_blurs: List[Any],
+        toggle_vals: List[Any],
+        _edit_nested_clicks: List[Any],
+        _label_blur: Any,
+        num_values: List[Any],
+        num_ids: List[Dict[str, Any]],
+        str_values: List[Any],
+        str_ids: List[Dict[str, Any]],
+        list_values: List[Any],
+        list_ids: List[Dict[str, Any]],
+        tuple_values: List[Any],
+        tuple_ids: List[Dict[str, Any]],
+        label_value: Optional[str],
+        state_data: Dict[str, Any],
+    ) -> Tuple[Any, ...]:
+        """Resolve the trigger and return updated state + redrawn views.
+
+        See module docstring for the dispatch table.
+        """
+
+        if state_data is None:
+            return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+
+        triggered = ctx.triggered_id
+        if triggered is None:
+            return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+
+        new_state_dict = state_data
+
+        try:
+            # --- Pattern-matching ids ---------------------------------
+            if isinstance(triggered, dict):
+                t_type = triggered.get("type")
+                if t_type == "palette-add":
+                    # Some clicks may be zero (initial render of a button
+                    # group with shared n_clicks=0).  Skip those.
+                    nclicks_list = ctx.triggered[0]["value"]
+                    if not nclicks_list:
+                        return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+                    new_state_dict = _dispatch_state_update(
+                        state_data,
+                        "add_node",
+                        {"class_name": triggered["class_name"]},
+                    )
+                elif t_type == "breadcrumb-link":
+                    new_state_dict = _dispatch_state_update(
+                        state_data,
+                        "breadcrumb_to",
+                        {"depth": triggered["depth"]},
+                    )
+                elif t_type in {
+                    "param-bool",
+                    "param-num",
+                    "param-str",
+                    "param-enum",
+                    "param-list",
+                    "param-tuple",
+                }:
+                    new_state_dict = _handle_param_edit(
+                        state_data,
+                        triggered=triggered,
+                        bool_vals=bool_vals,
+                        enum_vals=enum_vals,
+                        num_values=num_values,
+                        num_ids=num_ids,
+                        str_values=str_values,
+                        str_ids=str_ids,
+                        list_values=list_values,
+                        list_ids=list_ids,
+                        tuple_values=tuple_values,
+                        tuple_ids=tuple_ids,
+                    )
+                elif t_type == "param-edit-nested":
+                    nclicks_val = ctx.triggered[0].get("value")
+                    if not nclicks_val:
+                        return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+                    new_state_dict = _dispatch_state_update(
+                        state_data,
+                        "drill_in_param",
+                        {
+                            "node_id": triggered["prefix"],
+                            "param_name": triggered["name"],
+                        },
+                    )
+                elif t_type == "param-optional-toggle":
+                    new_state_dict = _handle_optional_toggle(
+                        state_data,
+                        triggered=triggered,
+                        toggle_vals=toggle_vals,
+                        num_values=num_values,
+                        num_ids=num_ids,
+                        str_values=str_values,
+                        str_ids=str_ids,
+                        list_values=list_values,
+                        list_ids=list_ids,
+                        tuple_values=tuple_values,
+                        tuple_ids=tuple_ids,
+                    )
+                else:
+                    return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+
+            # --- Plain string ids -------------------------------------
+            elif triggered == ids.BTN_NEW_PIPELINE_NODE:
+                new_state_dict = _dispatch_state_update(
+                    state_data, "add_pipeline", {}
+                )
+            elif triggered == ids.CANVAS_CYTOSCAPE:
+                # Disambiguate tap (selection) vs elements (reorder).
+                trigger_prop = ctx.triggered[0]["prop_id"].split(".")[-1]
+                if trigger_prop == "tapNodeData":
+                    if not tap_node_data:
+                        return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+                    new_state_dict = _dispatch_state_update(
+                        state_data,
+                        "select_node",
+                        {"node_id": tap_node_data.get("id")},
+                    )
+                elif trigger_prop == "elements":
+                    new_state_dict = _maybe_reorder_from_elements(
+                        state_data, elements
+                    )
+                    if new_state_dict is state_data:
+                        return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+                else:
+                    return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+            elif triggered == ids.BTN_DRILL_IN:
+                # The inspector renders a visible "Drill in ▸" button only on
+                # ImagePipeline nodes; for any other selection the button is a
+                # hidden placeholder that the user can't trigger. Either way,
+                # the canonical action here is drill-in.
+                new_state_dict = _dispatch_state_update(
+                    state_data, "drill_in", {}
+                )
+            elif triggered == ids.BTN_DELETE_NODE:
+                new_state_dict = _dispatch_state_update(
+                    state_data, "delete_node", {}
+                )
+            elif triggered == ids.INPUT_NODE_LABEL:
+                state = state_from_json(state_data)
+                if state.selected_node_id is None:
+                    return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+                new_state_dict = _dispatch_state_update(
+                    state_data,
+                    "edit_label",
+                    {
+                        "node_id": state.selected_node_id,
+                        "label": label_value,
+                    },
+                )
+            else:
+                return (
+                no_update, no_update, no_update, no_update,
+                no_update, no_update, no_update, no_update,
+            )
+
+            # --- Render ----------------------------------------------
+            new_state = state_from_json(new_state_dict)
+            breadcrumb, canvas, inspector = _render_views(new_state)
+            return (
+                new_state_dict, breadcrumb, canvas, inspector,
+                no_update, no_update, no_update, no_update,
+            )
+
+        except Exception as exc:
+            # Never crash the UI on a bad mutation — log full traceback and
+            # surface the message via the toast instead of silently dropping
+            # the user's interaction.
+            logger.exception("fan_in_state_mutation failed")
+            return (
+                no_update, no_update, no_update, no_update,
+                True,
+                f"{type(exc).__name__}: {exc}",
+                "danger",
+                "Update failed",
+            )
+
+    # ----------------------------------------------------------------------
+    # 3. Run preview
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(ids.STORE_INTERMEDIATE_KEYS, "data"),
+        Output(ids.TOAST_NOTIFICATION, "is_open", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "icon", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "header", allow_duplicate=True),
+        Input(ids.BTN_RUN_PREVIEW, "n_clicks"),
+        State(ids.STORE_BUILDER_STATE, "data"),
+        State(ids.STORE_SESSION_ID, "data"),
+        State(STORE_IMAGE_PATH, "data"),
+        State(ids.INPUT_NROWS, "value"),
+        State(ids.INPUT_NCOLS, "value"),
+        prevent_initial_call=True,
+    )
+    def run_preview(
+        n_clicks: Optional[int],
+        state_data: Dict[str, Any],
+        session_id: Optional[str],
+        image_path: Optional[str],
+        nrows: Optional[Any],
+        ncols: Optional[Any],
+    ) -> Tuple[Any, bool, str, str, str]:
+        """Build the pipeline, run preview, cache intermediates."""
+
+        if not n_clicks or state_data is None:
+            return no_update, *_toast("No state to preview", ok=False)
+
+        if not session_id:
+            session_id = uuid.uuid4().hex
+
+        try:
+            t0 = time.time()
+
+            from phenotypic import GridImage, Image
+            from phenotypic.abc_ import GridOperation
+
+            state = state_from_json(state_data)
+            pipeline = to_pipeline(state.root)
+
+            uses_grid = _pipeline_uses_grid(pipeline, GridOperation)
+
+            if not image_path or image_path == SYNTHETIC_SENTINEL:
+                from phenotypic.data._synthetic_data import load_synth_yeast_plate
+
+                image = load_synth_yeast_plate()
+            else:
+                p = Path(image_path)
+                if uses_grid:
+                    image = GridImage.imread(
+                        p,
+                        nrows=int(nrows) if nrows else 8,
+                        ncols=int(ncols) if ncols else 12,
+                    )
+                else:
+                    image = Image.imread(p)
+
+            cache = get_cache()
+            cache.set_image(session_id, image, str(image_path) if image_path else None)
+
+            result = pipeline.apply_with_intermediates(image)
+
+            # Map intermediate keys (op-keys e.g. "GaussianBlur",
+            # "GaussianBlur_2") back to BuilderState node-ids by walking ops
+            # in declaration order.
+            ops_keys: List[str] = list(pipeline.get_ops().keys())
+            ops_nodes: List[StepNode] = [
+                n
+                for n in state.root.nodes
+                if stage_of(n.class_name) == "ops" or n.class_name == PIPELINE_CLASS_NAME
+            ]
+            for op_key, node in zip(ops_keys, ops_nodes):
+                inter = result.intermediates.get(op_key)
+                if inter is not None:
+                    cache.set_intermediate(session_id, node.node_id, inter)
+
+            # Run measurements if any are configured.  Their output is a
+            # single DataFrame; we attach it to every measurement node so
+            # the inspector can show it for whichever the user selects.
+            # `measure()` needs the *processed* image (objmap populated by
+            # the detector chain), not the raw input.
+            if pipeline.get_meas() or pipeline.get_post():
+                try:
+                    df = pipeline.measure(result.image)
+                    meas_nodes = [
+                        n
+                        for n in state.root.nodes
+                        if stage_of(n.class_name) in {"meas", "post"}
+                    ]
+                    for node in meas_nodes:
+                        cache.set_intermediate(session_id, node.node_id, df)
+                except Exception as meas_exc:  # noqa: BLE001
+                    logger.warning("measure() failed: %s", meas_exc)
+
+            duration = time.time() - t0
+            keys = cache.known_intermediate_keys(session_id)
+            return (
+                keys,
+                *_toast(f"Preview ran in {duration:.2f}s", ok=True),
+            )
+
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Run preview failed")
+            return (
+                no_update,
+                *_toast(_format_exception(exc), ok=False),
+            )
+
+    # ----------------------------------------------------------------------
+    # 4. Inspector preview rendering
+    # ----------------------------------------------------------------------
+
+    # Tracks the last (session_id, node_id, intermediate-id) tuple this
+    # callback rendered for. State changes that don't shift selection or
+    # intermediate identity short-circuit to ``no_update`` so the inspector
+    # doesn't re-encode the image / rebuild the DataTable on every keystroke
+    # or drag. Plain dict (single-process Dash dev server); under multi-
+    # worker deployment this would just degrade to "always render", same as
+    # before.
+    _preview_render_keys: Dict[str, Tuple[Optional[str], int]] = {}
+
+    @app.callback(
+        Output(ids.INSPECTOR_PREVIEW, "children"),
+        Input(ids.STORE_BUILDER_STATE, "data"),
+        Input(ids.STORE_INTERMEDIATE_KEYS, "data"),
+        State(ids.STORE_SESSION_ID, "data"),
+    )
+    def render_inspector_preview(
+        state_data: Optional[Dict[str, Any]],
+        _keys: Optional[List[str]],
+        session_id: Optional[str],
+    ) -> Any:
+        """Show the cached intermediate (image / DataTable) for the selection."""
+
+        if state_data is None or not session_id:
+            _preview_render_keys.pop(session_id or "", None)
+            return html.Div(
+                "No preview yet — click Run preview.",
+                className="text-muted",
+            )
+
+        try:
+            state = state_from_json(state_data)
+        except Exception:  # noqa: BLE001
+            return no_update
+
+        if state.selected_node_id is None:
+            last = _preview_render_keys.get(session_id)
+            if last is not None and last[0] is None:
+                return no_update
+            _preview_render_keys[session_id] = (None, 0)
+            return html.Div(
+                "Select a node to view its preview.",
+                className="text-muted",
+            )
+
+        try:
+            scope = current_scope(state)
+        except KeyError:
+            return no_update
+        node = next(
+            (n for n in scope.nodes if n.node_id == state.selected_node_id),
+            None,
+        )
+        if node is None:
+            return no_update
+
+        cached = get_cache().get_intermediate(session_id, state.selected_node_id)
+        cache_token = id(cached) if cached is not None else 0
+        last = _preview_render_keys.get(session_id)
+        if last == (state.selected_node_id, cache_token):
+            return no_update
+        _preview_render_keys[session_id] = (state.selected_node_id, cache_token)
+        if cached is None:
+            return html.Div(
+                "No preview yet — click Run preview.",
+                className="text-muted",
+            )
+
+        # DataFrame preview for measurement / post nodes.
+        try:
+            import pandas as pd  # type: ignore[import-untyped]
+        except Exception:  # pragma: no cover - pandas always present in env
+            pd = None  # type: ignore[assignment]
+
+        if pd is not None and isinstance(cached, pd.DataFrame):
+            return dataframe_to_table(cached)
+
+        # Otherwise treat as Image — pick channel by stage.
+        try:
+            stage = stage_of(node.class_name)
+        except KeyError:
+            stage = "ops"
+        channel = "rgb"
+        if stage == "ops":
+            try:
+                from phenotypic.gui._operation_registry import get_registry
+
+                info = get_registry().get(node.class_name)
+                if info is not None and info.category == "Enhancer":
+                    channel = "detect_mat"
+                elif info is not None and info.category in {"Detector", "Refiner"}:
+                    channel = "objmap"
+            except Exception:  # noqa: BLE001
+                pass
+
+        try:
+            uri = to_data_uri(cached, channel=channel)  # type: ignore[arg-type]
+        except Exception as exc:  # noqa: BLE001
+            return html.Div(
+                f"(Could not render preview: {_format_exception(exc)})",
+                className="text-warning",
+            )
+        return html.Img(src=uri, style={"maxWidth": "100%"})
+
+    # ----------------------------------------------------------------------
+    # 5. Save
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(ids.TOAST_NOTIFICATION, "is_open", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "icon", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "header", allow_duplicate=True),
+        Input(ids.BTN_SAVE, "n_clicks"),
+        State(ids.STORE_BUILDER_STATE, "data"),
+        State(ids.INPUT_SAVE_PATH, "value"),
+        prevent_initial_call=True,
+    )
+    def save_pipeline(
+        n_clicks: Optional[int], state_data: Dict[str, Any], path_value: Optional[str]
+    ) -> Tuple[bool, str, str, str]:
+        if not n_clicks:
+            return _toast("Nothing to save", ok=False)
+        if not path_value:
+            return _toast("Provide a save path first", ok=False)
+
+        try:
+            state = state_from_json(state_data)
+            pipeline = to_pipeline(state.root)
+            payload = pipeline.to_json()
+            target = Path(path_value).expanduser()
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with open(target, "w", encoding="utf-8") as fh:
+                fh.write(payload if isinstance(payload, str) else json.dumps(payload))
+
+            image_root = current_app.config.get("pheno_image_root")
+            if image_root is not None:
+                try:
+                    target.resolve().relative_to(Path(image_root).resolve())
+                except ValueError:
+                    return _toast(
+                        f"Saved to {target} (warning: outside --image-root)",
+                        ok=True,
+                    )
+            return _toast(f"Saved to {target}", ok=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Save failed")
+            return _toast(_format_exception(exc), ok=False)
+
+    # ----------------------------------------------------------------------
+    # 6. Load
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(ids.STORE_BUILDER_STATE, "data", allow_duplicate=True),
+        Output(ids.BREADCRUMB_CONTAINER, "children", allow_duplicate=True),
+        Output("canvas-cytoscape-wrapper", "children", allow_duplicate=True),
+        Output(ids.INSPECTOR_CONTAINER, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "is_open", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "icon", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "header", allow_duplicate=True),
+        Input(ids.BTN_LOAD, "n_clicks"),
+        State(ids.INPUT_LOAD_PATH, "value"),
+        prevent_initial_call=True,
+    )
+    def load_pipeline(
+        n_clicks: Optional[int], path_value: Optional[str]
+    ) -> Tuple[Any, ...]:
+        if not n_clicks:
+            return (no_update,) * 4 + _toast("Nothing to load", ok=False)
+        if not path_value:
+            return (no_update,) * 4 + _toast("Provide a load path first", ok=False)
+        try:
+            from phenotypic import ImagePipeline
+
+            with open(Path(path_value).expanduser(), encoding="utf-8") as fh:
+                content = fh.read()
+            pipeline = ImagePipeline.from_json(content)
+            scope = from_pipeline(pipeline)
+            new_state = BuilderState(
+                root=scope, breadcrumb=[], selected_node_id=None
+            )
+            new_state_dict = state_to_json(new_state)
+            breadcrumb, canvas, inspector = _render_views(new_state)
+            return (
+                new_state_dict,
+                breadcrumb,
+                canvas,
+                inspector,
+                *_toast(f"Loaded {path_value}", ok=True),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Load failed")
+            return (no_update,) * 4 + _toast(_format_exception(exc), ok=False)
+
+    # ----------------------------------------------------------------------
+    # 7. Directory picker
+    # ----------------------------------------------------------------------
+
+    @app.callback(
+        Output(STORE_IMAGE_PATH, "data"),
+        Output(DIR_PICKER_PATH_INPUT, "value"),
+        Output(DIR_PICKER_TREE_CONTAINER, "children"),
+        Output(ids.TOAST_NOTIFICATION, "is_open", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "children", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "icon", allow_duplicate=True),
+        Output(ids.TOAST_NOTIFICATION, "header", allow_duplicate=True),
+        Input({"type": "dir-entry", "kind": ALL, "path": ALL}, "n_clicks"),
+        Input(DIR_PICKER_USE_PATH_BTN, "n_clicks"),
+        Input(DIR_PICKER_SYNTH_BTN, "n_clicks"),
+        State(DIR_PICKER_PATH_INPUT, "value"),
+        prevent_initial_call=True,
+    )
+    def directory_picker_actions(
+        _entry_clicks: List[int],
+        _use_clicks: Optional[int],
+        _synth_clicks: Optional[int],
+        path_value: Optional[str],
+    ) -> Tuple[Any, ...]:
+        triggered = ctx.triggered_id
+        if triggered is None:
+            return (no_update,) * 7
+        image_root: Optional[Path] = current_app.config.get("pheno_image_root")
+
+        try:
+            if isinstance(triggered, dict) and triggered.get("type") == "dir-entry":
+                # Skip noisy zero-click events (Dash fires once per registered
+                # entry on first paint).
+                value = ctx.triggered[0].get("value")
+                if not value:
+                    return (no_update,) * 7
+                kind = triggered["kind"]
+                clicked_path = Path(triggered["path"])
+                if kind == "file":
+                    return (
+                        str(clicked_path),
+                        str(clicked_path),
+                        no_update,
+                        *_toast(f"Image set: {clicked_path.name}", ok=True),
+                    )
+                # dir or parent
+                if image_root is not None:
+                    tree = directory_tree(image_root, clicked_path)
+                    return (
+                        no_update,
+                        no_update,
+                        tree,
+                        False,
+                        no_update,
+                        no_update,
+                        no_update,
+                    )
+                return (no_update,) * 7
+
+            if triggered == DIR_PICKER_USE_PATH_BTN:
+                if not path_value:
+                    return (no_update,) * 4 + _toast(
+                        "Type a path first", ok=False
+                    )
+                p = Path(path_value).expanduser()
+                if not p.exists():
+                    return (no_update,) * 4 + _toast(
+                        f"Path does not exist: {p}", ok=False
+                    )
+                return (
+                    str(p),
+                    str(p),
+                    no_update,
+                    *_toast(f"Image path set: {p}", ok=True),
+                )
+
+            if triggered == DIR_PICKER_SYNTH_BTN:
+                synth = find_synthetic_plate_path()
+                return (
+                    str(synth),
+                    str(synth),
+                    no_update,
+                    *_toast("Using synthetic yeast plate", ok=True),
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Directory picker failed")
+            return (no_update,) * 4 + _toast(_format_exception(exc), ok=False)
+
+        return (no_update,) * 7
+
+    # ----------------------------------------------------------------------
+    # 8. Canvas zoom / fit — clientside (calls cytoscape.js directly)
+    # ----------------------------------------------------------------------
+    # We previously tried to refit by re-emitting the ``layout`` prop with
+    # ``fit: True`` from a server callback, but dash-cytoscape sometimes
+    # ignored identical-shaped layout dicts. Calling ``cy.fit()`` /
+    # ``cy.zoom()`` directly via clientside JS sidesteps that and gives a
+    # snappier, animation-free response.
+    #
+    # ``window.phenoGetCy()`` is defined in ``assets/builder.js``.
+
+    app.clientside_callback(
+        """
+        function(n_clicks, prev) {
+            if (!n_clicks) return window.dash_clientside.no_update;
+            const cy = window.phenoGetCy && window.phenoGetCy();
+            if (cy) cy.animate({fit: {padding: 24}}, {duration: 200});
+            return (prev || 0) + 1;
+        }
+        """,
+        Output(ids.STORE_CANVAS_CONTROL, "data", allow_duplicate=True),
+        Input(ids.BTN_CANVAS_FIT, "n_clicks"),
+        State(ids.STORE_CANVAS_CONTROL, "data"),
+        prevent_initial_call=True,
+    )
+
+    app.clientside_callback(
+        """
+        function(n_clicks, prev) {
+            if (!n_clicks) return window.dash_clientside.no_update;
+            const cy = window.phenoGetCy && window.phenoGetCy();
+            if (cy) {
+                const z = cy.zoom() * 1.25;
+                const center = {x: cy.width() / 2, y: cy.height() / 2};
+                cy.zoom({level: z, renderedPosition: center});
+            }
+            return (prev || 0) + 1;
+        }
+        """,
+        Output(ids.STORE_CANVAS_CONTROL, "data", allow_duplicate=True),
+        Input(ids.BTN_CANVAS_ZOOM_IN, "n_clicks"),
+        State(ids.STORE_CANVAS_CONTROL, "data"),
+        prevent_initial_call=True,
+    )
+
+    app.clientside_callback(
+        """
+        function(n_clicks, prev) {
+            if (!n_clicks) return window.dash_clientside.no_update;
+            const cy = window.phenoGetCy && window.phenoGetCy();
+            if (cy) {
+                const z = cy.zoom() / 1.25;
+                const center = {x: cy.width() / 2, y: cy.height() / 2};
+                cy.zoom({level: z, renderedPosition: center});
+            }
+            return (prev || 0) + 1;
+        }
+        """,
+        Output(ids.STORE_CANVAS_CONTROL, "data", allow_duplicate=True),
+        Input(ids.BTN_CANVAS_ZOOM_OUT, "n_clicks"),
+        State(ids.STORE_CANVAS_CONTROL, "data"),
+        prevent_initial_call=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers (private to this module)
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_uses_grid(pipeline: Any, grid_op_cls: type) -> bool:
+    """True if any step of *pipeline* (recursively) is a :class:`GridOperation`."""
+
+    for collection in (
+        pipeline.get_ops().values(),
+        pipeline.get_meas().values(),
+        pipeline.get_post().values() if hasattr(pipeline, "get_post") else [],
+    ):
+        for op in collection:
+            if isinstance(op, grid_op_cls):
+                return True
+            # Recurse into nested ImagePipeline.
+            if hasattr(op, "get_ops"):
+                if _pipeline_uses_grid(op, grid_op_cls):
+                    return True
+    return False
+
+
+def _maybe_reorder_from_elements(
+    state_data: Dict[str, Any], elements: Optional[List[Dict[str, Any]]]
+) -> Dict[str, Any]:
+    """Compute a reorder mutation from a cytoscape ``elements`` payload.
+
+    Returns *state_data* unchanged when no positional change is detectable;
+    otherwise returns a new state dict with the current scope's nodes
+    re-ordered to match the visual left-to-right sequence.
+    """
+
+    if not elements:
+        return state_data
+
+    # Filter to node entries with positions.
+    node_entries = [
+        e for e in elements if "data" in e and "source" not in e.get("data", {})
+    ]
+    positioned = [e for e in node_entries if "position" in e]
+    if len(positioned) < 2:
+        return state_data
+
+    positioned.sort(key=lambda e: e["position"].get("x", 0.0))
+    new_order = [e["data"]["id"] for e in positioned]
+
+    breadcrumb = list(state_data.get("breadcrumb", []) or [])
+    scope = _scope_at_breadcrumb(state_data, breadcrumb)
+    existing_order = [n["node_id"] for n in scope["nodes"]]
+    if new_order == existing_order:
+        return state_data
+
+    # Only reorder if the *set* matches — guards against transient cytoscape
+    # element pruning.
+    if set(new_order) != set(existing_order):
+        return state_data
+
+    return _dispatch_state_update(state_data, "reorder", {"order": new_order})
+
+
+def _handle_param_edit(
+    state_data: Dict[str, Any],
+    *,
+    triggered: Dict[str, Any],
+    bool_vals: List[Any],
+    enum_vals: List[Any],
+    num_values: List[Any],
+    num_ids: List[Dict[str, Any]],
+    str_values: List[Any],
+    str_ids: List[Dict[str, Any]],
+    list_values: List[Any],
+    list_ids: List[Dict[str, Any]],
+    tuple_values: List[Any],
+    tuple_ids: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Handle a single param-widget edit by writing into the matching node."""
+
+    from phenotypic.gui._operation_registry import get_registry
+
+    t_type = triggered["type"]
+    prefix = triggered["prefix"]
+    name = triggered["name"]
+
+    raw: Any
+    if t_type == "param-bool":
+        raw = ctx.triggered[0]["value"]
+    elif t_type == "param-enum":
+        raw = ctx.triggered[0]["value"]
+    elif t_type == "param-num":
+        raw = _lookup_in_state(num_ids, num_values, prefix=prefix, name=name)
+    elif t_type == "param-str":
+        raw = _lookup_in_state(str_ids, str_values, prefix=prefix, name=name)
+    elif t_type == "param-list":
+        raw = _lookup_in_state(list_ids, list_values, prefix=prefix, name=name)
+    elif t_type == "param-tuple":
+        raw = _lookup_in_state(tuple_ids, tuple_values, prefix=prefix, name=name)
+    else:
+        return state_data
+
+    # Resolve ParamInfo to coerce the raw value back to a Python type.
+    state = state_from_json(state_data)
+    try:
+        scope = current_scope(state)
+    except KeyError:
+        return state_data
+    node = next((n for n in scope.nodes if n.node_id == prefix), None)
+    if node is None:
+        return state_data
+    info = get_registry().get(node.class_name)
+    if info is None:
+        return state_data
+    p = info.parameters.get(name)
+    if p is None:
+        return state_data
+
+    try:
+        coerced = parse_widget_value(raw, p)
+    except Exception:  # noqa: BLE001
+        return state_data
+
+    return _dispatch_state_update(
+        state_data,
+        "edit_param",
+        {"node_id": prefix, "name": name, "value": coerced, "omit": False},
+    )
+
+
+def _handle_optional_toggle(
+    state_data: Dict[str, Any],
+    *,
+    triggered: Dict[str, Any],
+    toggle_vals: List[Any],
+    num_values: List[Any],
+    num_ids: List[Dict[str, Any]],
+    str_values: List[Any],
+    str_ids: List[Dict[str, Any]],
+    list_values: List[Any],
+    list_ids: List[Dict[str, Any]],
+    tuple_values: List[Any],
+    tuple_ids: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Apply a "Use default" toggle change to the parameter node."""
+
+    prefix = triggered["prefix"]
+    name = triggered["name"]
+    value = ctx.triggered[0]["value"]
+    if value:
+        # Toggle ON -> remove the param so the operation default takes over.
+        return _dispatch_state_update(
+            state_data,
+            "edit_param",
+            {"node_id": prefix, "name": name, "omit": True},
+        )
+
+    # Toggle OFF -> read the current widget value (search across all kinds).
+    raw = None
+    for ids_list, vals in (
+        (num_ids, num_values),
+        (str_ids, str_values),
+        (list_ids, list_values),
+        (tuple_ids, tuple_values),
+    ):
+        candidate = _lookup_in_state(ids_list, vals, prefix=prefix, name=name)
+        if candidate is not None:
+            raw = candidate
+            break
+
+    return _dispatch_state_update(
+        state_data,
+        "edit_param",
+        {"node_id": prefix, "name": name, "value": raw, "omit": False},
+    )
+
+
+def _lookup_in_state(
+    ids_list: List[Dict[str, Any]],
+    values: List[Any],
+    *,
+    prefix: str,
+    name: str,
+) -> Any:
+    """Return the value matching ``{prefix, name}`` in a parallel id/value pair."""
+
+    for component_id, val in zip(ids_list, values):
+        if (
+            component_id.get("prefix") == prefix
+            and component_id.get("name") == name
+        ):
+            return val
+    return None
+
+
+__all__ = [
+    "register_callbacks",
+    "_dispatch_state_update",
+    "STORE_IMAGE_PATH",
+]

--- a/src/phenotypic/gui/builder/_directory_browser.py
+++ b/src/phenotypic/gui/builder/_directory_browser.py
@@ -1,0 +1,364 @@
+"""Server-side directory tree component for picking test images on the HPCC.
+
+This module provides the layout-only Dash components used by the pipeline
+builder's image-source picker. It walks one directory level at a time so that
+remote filesystems (e.g. HPCC scratch) stay responsive, and never traverses
+through symlinks that escape the configured root.
+
+Callbacks are wired up in ``_callbacks.py``; nothing here registers callbacks
+or imports the builder state model.
+
+Component IDs are exposed as module-level constants so that the callback
+module has a single source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional
+
+import dash_bootstrap_components as dbc  # type: ignore[import-untyped]
+from dash import dcc, html
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+#: Image file extensions surfaced by the directory tree (case-insensitive).
+IMAGE_EXTS = {
+    ".png",
+    ".tif",
+    ".tiff",
+    ".jpg",
+    ".jpeg",
+    ".raw",
+    ".nef",
+    ".cr2",
+    ".arw",
+    ".dng",
+}
+
+#: Sentinel path injected into the path input when the user clicks
+#: "Use synthetic plate" and the bundled synthetic plate cannot be located on
+#: disk. Callbacks should detect this and fall back to
+#: ``phenotypic.data.load_synth_yeast_plate()`` rather than treating it as a
+#: real path.
+SYNTHETIC_SENTINEL = "<synthetic>"
+
+# Component IDs (single source of truth for callbacks in Phase 3).
+DIR_PICKER_PATH_INPUT = "dir-picker-path"
+DIR_PICKER_USE_PATH_BTN = "dir-picker-use-path"
+DIR_PICKER_SYNTH_BTN = "dir-picker-synth"
+DIR_PICKER_TREE_CONTAINER = "dir-picker-tree"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def find_synthetic_plate_path() -> Path:
+    """Locate the on-disk path of the bundled synthetic yeast plate image.
+
+    The builder needs a concrete file path to populate the path input when the
+    user clicks "Use synthetic plate". We resolve the same RGB PNG that
+    :func:`phenotypic.data.load_synth_yeast_plate` reads.
+
+    Returns:
+        The absolute path of ``synthetic_test_plate/yeast_plate_rgb.png`` if
+        it exists on disk, otherwise the sentinel
+        :data:`SYNTHETIC_SENTINEL` (wrapped in :class:`pathlib.Path`). The
+        sentinel is returned as a ``Path`` so the return type stays
+        consistent; callers should check via ``str(path) ==
+        SYNTHETIC_SENTINEL`` before treating the value as a filesystem path.
+
+    Notes:
+        We import ``phenotypic.data._sample_image_data`` lazily to avoid
+        pulling the whole image-IO stack at module import time (this layout
+        module is imported during Dash app construction).
+    """
+    try:
+        from phenotypic.data import _sample_image_data
+    except Exception:
+        return Path(SYNTHETIC_SENTINEL)
+
+    candidate = (
+        Path(_sample_image_data.__current_file_dir)
+        / "synthetic_test_plate"
+        / "yeast_plate_rgb.png"
+    )
+    if candidate.is_file():
+        return candidate.resolve()
+    return Path(SYNTHETIC_SENTINEL)
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if ``path`` resolves under ``root`` (inclusive).
+
+    Used to keep symlink traversal contained to the configured root so a
+    rogue symlink in the browsed tree cannot expose the wider filesystem.
+    """
+    try:
+        resolved = path.resolve()
+        root_resolved = root.resolve()
+    except OSError:
+        return False
+    if resolved == root_resolved:
+        return True
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError:
+        return False
+    return True
+
+
+def _safe_iterdir(path: Path) -> List[Path]:
+    """Iterate ``path`` defensively, returning ``[]`` on any OS error.
+
+    Permission errors, broken symlinks, and missing directories all collapse
+    to an empty list so the UI can still render an empty list-group instead
+    of crashing the callback.
+    """
+    try:
+        return list(path.iterdir())
+    except (OSError, PermissionError):
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Layout builders
+# ---------------------------------------------------------------------------
+
+def directory_tree(root: Path, current: Path | None = None) -> html.Div:
+    """Render a depth-1 directory tree rooted at ``root``.
+
+    The tree shows the absolute path of ``current or root`` as a header,
+    optionally followed by a "↑ Parent directory" entry (when navigation
+    upward stays within ``root``), then all immediate subdirectories
+    (alphabetical), then all immediate image files (alphabetical) whose
+    extension is in :data:`IMAGE_EXTS` (case-insensitive).
+
+    Hidden entries (names starting with ``.``) are skipped. Symlinks whose
+    target resolves outside ``root`` are skipped to prevent the user from
+    navigating off the configured root.
+
+    Args:
+        root: Configured image root. Used as both the security boundary and
+            the fallback location when ``current`` is not supplied.
+        current: Directory currently being viewed. If ``None``, defaults to
+            ``root``. If outside ``root``, falls back to ``root``.
+
+    Returns:
+        A :class:`dash.html.Div` containing the header and the listing as a
+        :class:`dash_bootstrap_components.ListGroup`. Each list item carries a
+        pattern-matching id of the form
+        ``{"type": "dir-entry", "kind": "dir" | "file" | "parent", "path":
+        str(path)}`` so the callbacks module can wire one handler for the
+        whole tree.
+    """
+    here = current if current is not None else root
+    if not _is_within(here, root):
+        here = root
+
+    children: List = [
+        html.Div(
+            str(here.resolve() if here.exists() else here),
+            className="text-monospace small text-muted mb-2",
+            style={"wordBreak": "break-all"},
+        ),
+    ]
+
+    list_items: List = []
+
+    # Parent entry (only when current is set, distinct from root, and stays
+    # within the configured root after going up one level).
+    if current is not None:
+        try:
+            current_resolved = here.resolve()
+            root_resolved = root.resolve()
+        except OSError:
+            current_resolved = here
+            root_resolved = root
+        if current_resolved != root_resolved:
+            parent = here.parent
+            if _is_within(parent, root):
+                list_items.append(
+                    dbc.ListGroupItem(
+                        [html.Span("↑ "), html.Span("Parent directory")],
+                        id={
+                            "type": "dir-entry",
+                            "kind": "parent",
+                            "path": str(parent),
+                        },
+                        action=True,
+                        n_clicks=0,
+                    )
+                )
+
+    # Walk depth-1 of `here`, filtering hidden entries and out-of-root symlinks.
+    entries = _safe_iterdir(here)
+
+    subdirs: List[Path] = []
+    files: List[Path] = []
+    for entry in entries:
+        if entry.name.startswith("."):
+            continue
+        try:
+            is_dir = entry.is_dir()
+        except OSError:
+            continue
+        if entry.is_symlink() and not _is_within(entry, root):
+            # Don't expose anything beyond the configured root via symlinks.
+            continue
+        if is_dir:
+            subdirs.append(entry)
+        else:
+            if entry.suffix.lower() in IMAGE_EXTS:
+                files.append(entry)
+
+    subdirs.sort(key=lambda p: p.name.lower())
+    files.sort(key=lambda p: p.name.lower())
+
+    for d in subdirs:
+        list_items.append(
+            dbc.ListGroupItem(
+                [html.Span("\U0001F4C1 "), html.Span(d.name + "/")],
+                id={
+                    "type": "dir-entry",
+                    "kind": "dir",
+                    "path": str(d),
+                },
+                action=True,
+                n_clicks=0,
+            )
+        )
+    for f in files:
+        list_items.append(
+            dbc.ListGroupItem(
+                [html.Span("\U0001F5BC️ "), html.Span(f.name)],
+                id={
+                    "type": "dir-entry",
+                    "kind": "file",
+                    "path": str(f),
+                },
+                action=True,
+                n_clicks=0,
+            )
+        )
+
+    if list_items:
+        children.append(dbc.ListGroup(list_items, flush=True))
+    else:
+        children.append(
+            html.Div(
+                "(no subdirectories or images)",
+                className="text-muted small fst-italic",
+            )
+        )
+
+    return html.Div(children)
+
+
+def directory_picker(
+    root: Path | None,
+    current: Path | None = None,
+    *,
+    component_id: str = "dir-picker",
+) -> html.Div:
+    """Build the full image-source picker.
+
+    Sections rendered top to bottom:
+
+    1. **Path input row** — a free-form ``dcc.Input`` for typing or pasting
+       an absolute path, alongside a "Use this path" button that the
+       callback layer wires to commit the input value to the builder state.
+    2. **Synthetic-plate button** — clicking populates the path input with
+       the resolved disk path of the bundled synthetic yeast plate. If the
+       file cannot be located, the input is populated with the
+       :data:`SYNTHETIC_SENTINEL` string so the callback can fall back to
+       :func:`phenotypic.data.load_synth_yeast_plate` programmatically.
+    3. **Tree section** — only rendered when ``root`` is provided. Shows the
+       depth-1 :func:`directory_tree` for ``current or root``.
+
+    Args:
+        root: Configured image-root directory (from the CLI's
+            ``--image-root``). When ``None``, the directory tree section is
+            omitted; the user can still type a path manually or pick the
+            synthetic plate.
+        current: Directory currently being viewed inside the tree. Ignored
+            when ``root`` is ``None``.
+        component_id: Reserved for future use; not currently consumed by
+            this layout because the inner widgets use the module-level
+            ``DIR_PICKER_*`` constants for their ids. Kept in the signature
+            so callers can pass a namespace if multiple pickers ever need to
+            coexist on the same page.
+
+    Returns:
+        A :class:`dash.html.Div` containing the three sections described
+        above.
+    """
+    del component_id  # currently unused; reserved for future namespacing
+
+    sections: List = []
+
+    # 1. Path input row.
+    path_row = dbc.Row(
+        [
+            dbc.Col(
+                dcc.Input(
+                    id=DIR_PICKER_PATH_INPUT,
+                    type="text",
+                    placeholder="/abs/path/to/image.tif",
+                    debounce=True,
+                    style={"width": "100%"},
+                ),
+                width=9,
+            ),
+            dbc.Col(
+                dbc.Button(
+                    "Use this path",
+                    id=DIR_PICKER_USE_PATH_BTN,
+                    color="primary",
+                    n_clicks=0,
+                ),
+                width=3,
+            ),
+        ],
+        className="g-2 mb-2",
+    )
+    sections.append(path_row)
+
+    # 2. Synthetic-plate button.
+    synth_button = dbc.Button(
+        "Use synthetic plate",
+        id=DIR_PICKER_SYNTH_BTN,
+        color="secondary",
+        outline=True,
+        n_clicks=0,
+        className="mb-2",
+    )
+    sections.append(synth_button)
+
+    # 3. Tree section (only when a root is configured).
+    if root is not None:
+        tree: Optional[html.Div] = directory_tree(root, current)
+        sections.append(
+            html.Div(
+                tree,
+                id=DIR_PICKER_TREE_CONTAINER,
+                className="border rounded p-2",
+            )
+        )
+    else:
+        sections.append(
+            html.Div(
+                id=DIR_PICKER_TREE_CONTAINER,
+                children=html.Div(
+                    "(no --image-root configured; type a path above"
+                    " or use the synthetic plate)",
+                    className="text-muted small fst-italic",
+                ),
+                className="border rounded p-2",
+            )
+        )
+
+    return html.Div(sections)

--- a/src/phenotypic/gui/builder/_ids.py
+++ b/src/phenotypic/gui/builder/_ids.py
@@ -1,0 +1,208 @@
+"""Single source of truth for component IDs in the Dash pipeline builder.
+
+This module exposes plain string constants for static (non-pattern-matching)
+component ids, plus small helpers for the pattern-matching ids used by the
+palette and breadcrumb. Both layout (Phase 2) and callbacks (Phase 3) import
+from here so the contract between them is stable and grep-able.
+
+Notes:
+    - Pattern-matching ids returned by helpers are plain dicts; Dash hashes
+      them at registration time, so Phase 3 can use ``MATCH`` / ``ALL`` against
+      the ``type`` key documented on each helper.
+    - Constants intentionally use kebab-case strings to match Dash convention
+      and the existing ``DIR_PICKER_*`` ids in ``_directory_browser.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# ---------------------------------------------------------------------------
+# Stores
+# ---------------------------------------------------------------------------
+
+#: Holds the JSON dump of :class:`BuilderState` (see ``state_to_json``).
+STORE_BUILDER_STATE = "store-builder-state"
+
+#: Per-tab uuid (storage_type='session') used as the IntermediatesCache key.
+STORE_SESSION_ID = "store-session-id"
+
+#: List of ``node_id`` values that have a cached intermediate this session.
+STORE_INTERMEDIATE_KEYS = "store-intermediate-keys"
+
+
+# ---------------------------------------------------------------------------
+# Top-level layout regions
+# ---------------------------------------------------------------------------
+
+#: Container for the breadcrumb nav at the top of the page.
+BREADCRUMB_CONTAINER = "breadcrumb"
+
+#: Container for the operation palette accordion (left column).
+PALETTE_CONTAINER = "palette"
+
+#: Cytoscape canvas in the centre column. Phase 3 will read tap/select events
+#: and write nodes/edges/elements as state changes.
+CANVAS_CYTOSCAPE = "canvas-cytoscape"
+
+#: Right-column inspector wrapper — Phase 3 swaps its children when the
+#: selected node changes.
+INSPECTOR_CONTAINER = "inspector"
+
+#: Mount point for ``param_form`` output. Lives inside ``INSPECTOR_CONTAINER``.
+INSPECTOR_PARAM_FORM = "inspector-param-form"
+
+#: Mount point for the per-step preview (image thumbnail or DataTable).
+INSPECTOR_PREVIEW = "inspector-preview"
+
+#: Footer row holding image-source + run/save/load buttons.
+FOOTER_CONTAINER = "footer"
+
+
+# ---------------------------------------------------------------------------
+# Buttons
+# ---------------------------------------------------------------------------
+
+#: Triggers ``apply_with_intermediates`` against the current pipeline.
+BTN_RUN_PREVIEW = "btn-run-preview"
+
+#: Writes ``pipeline.to_json()`` to the path in INPUT_SAVE_PATH.
+BTN_SAVE = "btn-save"
+
+#: Reads JSON from INPUT_LOAD_PATH and replaces the current state.
+BTN_LOAD = "btn-load"
+
+#: Adds a fresh ``ImagePipeline`` step to the current scope.
+BTN_NEW_PIPELINE_NODE = "btn-new-pipeline-node"
+
+#: Removes the currently selected node from the visible scope.
+BTN_DELETE_NODE = "btn-delete-node"
+
+#: Pops the breadcrumb (returns to the parent scope).
+BTN_DRILL_OUT = "btn-drill-out"
+
+#: Drills into the currently selected pipeline-typed node. The inspector's
+#: visible "Drill in ▸" button uses this id when a pipeline node is selected;
+#: a hidden placeholder with the same id is rendered in every other inspector
+#: branch so the fan-in callback's ``Input`` always resolves.
+BTN_DRILL_IN = "btn-drill-in"
+
+#: Recenters / refits the cytoscape canvas on the current pipeline. Useful
+#: after a drag has scrolled nodes off-screen.
+BTN_CANVAS_FIT = "btn-canvas-fit"
+
+#: Zoom the cytoscape canvas in by a fixed factor.
+BTN_CANVAS_ZOOM_IN = "btn-canvas-zoom-in"
+
+#: Zoom the cytoscape canvas out by a fixed factor.
+BTN_CANVAS_ZOOM_OUT = "btn-canvas-zoom-out"
+
+#: Hidden ``dcc.Store`` whose data is bumped by clientside callbacks that
+#: drive the cytoscape canvas (zoom / fit). Only exists to satisfy Dash's
+#: "every callback needs an Output" rule for action-style buttons.
+STORE_CANVAS_CONTROL = "store-canvas-control"
+
+#: Active image path. The directory browser writes it on "Use this path" /
+#: "Use synthetic plate"; Run preview reads it as State.
+STORE_IMAGE_PATH = "store-image-path"
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+
+#: Server-side path to write the current pipeline JSON to.
+INPUT_SAVE_PATH = "input-save-path"
+
+#: Server-side path to read pipeline JSON from.
+INPUT_LOAD_PATH = "input-load-path"
+
+#: Optional ``nrows`` override for grid pipelines (root scope only).
+INPUT_NROWS = "input-nrows"
+
+#: Optional ``ncols`` override for grid pipelines (root scope only).
+INPUT_NCOLS = "input-ncols"
+
+#: Inspector text input for editing the selected node's display label.
+INPUT_NODE_LABEL = "input-node-label"
+
+
+# ---------------------------------------------------------------------------
+# Toast / status
+# ---------------------------------------------------------------------------
+
+#: Floating toast used for save/load/preview success and error messages.
+TOAST_NOTIFICATION = "toast-notification"
+
+#: ``dcc.Loading`` wrapper around the preview button + canvas / inspector
+#: previews so the spinner appears while ``apply_with_intermediates`` runs.
+PREVIEW_LOADING = "preview-loading"
+
+
+# ---------------------------------------------------------------------------
+# Pattern-matching id-builders
+# ---------------------------------------------------------------------------
+
+
+def palette_button_id(class_name: str) -> Dict[str, Any]:
+    """Build the pattern-matching id for an operation-palette button.
+
+    Args:
+        class_name: Registry key (e.g. ``"GaussianBlur"``) the button adds.
+
+    Returns:
+        Dict of shape ``{"type": "palette-add", "class_name": class_name}``.
+        Phase 3 callbacks should match ``Input({"type": "palette-add",
+        "class_name": ALL}, "n_clicks")``.
+    """
+
+    return {"type": "palette-add", "class_name": class_name}
+
+
+def breadcrumb_link_id(depth: int) -> Dict[str, Any]:
+    """Build the pattern-matching id for a clickable breadcrumb segment.
+
+    Args:
+        depth: Position in the breadcrumb (0 = root, 1 = first child, ...).
+
+    Returns:
+        Dict of shape ``{"type": "breadcrumb-link", "depth": depth}``.
+    """
+
+    return {"type": "breadcrumb-link", "depth": depth}
+
+
+__all__ = [
+    "STORE_BUILDER_STATE",
+    "STORE_SESSION_ID",
+    "STORE_INTERMEDIATE_KEYS",
+    "BREADCRUMB_CONTAINER",
+    "PALETTE_CONTAINER",
+    "CANVAS_CYTOSCAPE",
+    "INSPECTOR_CONTAINER",
+    "INSPECTOR_PARAM_FORM",
+    "INSPECTOR_PREVIEW",
+    "FOOTER_CONTAINER",
+    "BTN_RUN_PREVIEW",
+    "BTN_SAVE",
+    "BTN_LOAD",
+    "BTN_NEW_PIPELINE_NODE",
+    "BTN_DELETE_NODE",
+    "BTN_DRILL_OUT",
+    "BTN_DRILL_IN",
+    "BTN_CANVAS_FIT",
+    "BTN_CANVAS_ZOOM_IN",
+    "BTN_CANVAS_ZOOM_OUT",
+    "STORE_CANVAS_CONTROL",
+    "STORE_IMAGE_PATH",
+    "INPUT_SAVE_PATH",
+    "INPUT_LOAD_PATH",
+    "INPUT_NROWS",
+    "INPUT_NCOLS",
+    "INPUT_NODE_LABEL",
+    "TOAST_NOTIFICATION",
+    "PREVIEW_LOADING",
+    "palette_button_id",
+    "breadcrumb_link_id",
+]

--- a/src/phenotypic/gui/builder/_image_renderer.py
+++ b/src/phenotypic/gui/builder/_image_renderer.py
@@ -1,0 +1,288 @@
+"""Render :class:`phenotypic.Image` channels as base64 PNG data URIs for Dash.
+
+The pipeline-builder inspector pane embeds previews via plain ``<img src=...>``
+tags rather than streaming endpoints — base64-encoded PNGs avoid spinning up a
+per-session asset route. Channels supported: ``rgb``, ``gray``, ``detect_mat``,
+and ``objmap``.
+
+Large source arrays are downscaled with ``cv2.resize(INTER_AREA)`` *before*
+encoding so a 4000×6000 uint16 plate doesn't pay PIL's slow per-pixel thumbnail
+cost.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+from typing import TYPE_CHECKING, Any, Literal
+
+import cv2
+import numpy as np
+from dash import dash_table
+from PIL import Image as PILImage
+
+if TYPE_CHECKING:  # pragma: no cover - import only used for type hints
+    import pandas as pd  # type: ignore[import-untyped]
+    import phenotypic
+
+
+ChannelName = Literal["rgb", "gray", "detect_mat", "objmap"]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_channel(image: "phenotypic.Image", channel: ChannelName) -> np.ndarray:
+    """Pull the requested channel from an :class:`Image` via the accessor API.
+
+    Args:
+        image: PhenoTypic :class:`Image` (or :class:`GridImage`).
+        channel: One of ``rgb``, ``gray``, ``detect_mat``, ``objmap``.
+
+    Returns:
+        A NumPy array (the accessor's ``[:]`` slice).
+
+    Raises:
+        ValueError: If ``channel`` is not a supported name.
+    """
+    if channel == "rgb":
+        return np.asarray(image.rgb[:])
+    if channel == "gray":
+        return np.asarray(image.gray[:])
+    if channel == "detect_mat":
+        return np.asarray(image.detect_mat[:])
+    if channel == "objmap":
+        return np.asarray(image.objmap[:])
+    raise ValueError(
+        f"Unknown channel {channel!r}; expected one of "
+        "'rgb', 'gray', 'detect_mat', 'objmap'."
+    )
+
+
+def _downscale(arr: np.ndarray, max_dim: int) -> np.ndarray:
+    """Resize ``arr`` so its longest spatial side ≤ ``max_dim`` pixels.
+
+    Uses ``cv2.resize`` with ``INTER_AREA`` (best for shrinking). Handles
+    integer-label maps by coercing to a cv2-supported dtype before resizing
+    and casting back so label IDs survive the resampling pass.
+
+    Args:
+        arr: 2-D or 3-D NumPy array.
+        max_dim: Maximum allowed length of the longer spatial side.
+
+    Returns:
+        Either ``arr`` unchanged (when already small enough) or a resized copy.
+    """
+    if arr.ndim < 2:
+        return arr
+    h, w = arr.shape[:2]
+    longer = max(h, w)
+    if longer <= max_dim:
+        return arr
+    scale = max_dim / float(longer)
+    new_w = max(1, int(round(w * scale)))
+    new_h = max(1, int(round(h * scale)))
+
+    src = arr
+    cast_back: np.dtype | None = None
+    interp = cv2.INTER_AREA
+
+    # cv2.resize doesn't accept uint16 multi-channel directly in all builds;
+    # the safe path is to widen integer label maps to int32 then restore.
+    if np.issubdtype(arr.dtype, np.integer) and arr.dtype not in (
+        np.uint8, np.uint16, np.int16, np.int32,
+    ):
+        cast_back = arr.dtype
+        src = arr.astype(np.int32)
+
+    resized = cv2.resize(src, (new_w, new_h), interpolation=interp)
+    if cast_back is not None:
+        resized = resized.astype(cast_back)
+    return resized
+
+
+def _normalize_to_uint8(arr: np.ndarray) -> np.ndarray:
+    """Scale an arbitrary-range array to uint8 in [0, 255].
+
+    Floats are clipped to [0, 1] when their max ≤ 1, otherwise rescaled by
+    their global max. Integer dtypes are rescaled by their global max so that
+    e.g. uint16 RGB lands in 0..255 with full dynamic range preserved.
+    """
+    if arr.dtype == np.uint8:
+        return arr
+
+    a = arr.astype(np.float64, copy=False)
+    finite = a[np.isfinite(a)]
+    if finite.size == 0:
+        return np.zeros(arr.shape, dtype=np.uint8)
+
+    amax = float(finite.max())
+    amin = float(finite.min())
+
+    if amax <= 1.0 and amin >= 0.0:
+        scaled = a * 255.0
+    elif amax > 0:
+        # Min-max stretch keeps low-contrast detect_mat readable.
+        denom = amax - amin if amax > amin else amax
+        scaled = (a - amin) / denom * 255.0
+    else:
+        scaled = np.zeros_like(a)
+
+    return np.clip(scaled, 0, 255).astype(np.uint8)
+
+
+def _label_map_to_rgb(arr: np.ndarray) -> np.ndarray:
+    """Convert an integer label map to an 8-bit RGB visualisation.
+
+    Tries :func:`skimage.color.label2rgb` first (perceptually distinct colours,
+    background preserved). Falls back to a tab20 colormap on the
+    ``(label % 20)`` index when scikit-image is unavailable.
+    """
+    try:
+        from skimage.color import label2rgb
+
+        rgb = label2rgb(arr, bg_label=0)
+        return np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
+    except Exception:
+        try:
+            import matplotlib.cm as cm
+
+            cmap = cm.get_cmap("tab20", 20)
+            idx = (arr.astype(np.int64) % 20).astype(np.int64)
+            rgba = cmap(idx)
+            rgba[arr == 0] = (0.0, 0.0, 0.0, 1.0)
+            return (rgba[..., :3] * 255.0).astype(np.uint8)
+        except Exception:
+            # Last-ditch fallback: greyscale modulus.
+            return np.stack([(arr % 256).astype(np.uint8)] * 3, axis=-1)
+
+
+def _channel_to_rgb_uint8(arr: np.ndarray, channel: ChannelName) -> np.ndarray:
+    """Project an arbitrary channel onto a displayable HxWx3 uint8 array.
+
+    Args:
+        arr: Source array straight from the channel accessor.
+        channel: Channel name driving the projection rule.
+
+    Returns:
+        ``(H, W, 3)`` uint8 array suitable for ``PIL.Image.fromarray(..., 'RGB')``.
+    """
+    if channel == "objmap":
+        return _label_map_to_rgb(arr)
+
+    if channel == "rgb":
+        u8 = _normalize_to_uint8(arr)
+        if u8.ndim == 2:
+            return np.stack([u8] * 3, axis=-1)
+        if u8.shape[-1] == 4:
+            return u8[..., :3]
+        return u8
+
+    # gray / detect_mat → grey-as-RGB.
+    u8 = _normalize_to_uint8(arr)
+    if u8.ndim == 3:
+        # Already multi-channel — drop alpha if present.
+        return u8[..., :3]
+    return np.stack([u8] * 3, axis=-1)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def to_data_uri(
+    image: "phenotypic.Image",
+    channel: ChannelName = "rgb",
+    *,
+    max_dim: int = 512,
+) -> str:
+    """Render an :class:`Image` channel as a base64 PNG data URI.
+
+    The image is downscaled with ``cv2.resize(INTER_AREA)`` before PNG encoding
+    so multi-megapixel raw scans encode in a fraction of a second. The output
+    is suitable for direct use as the ``src`` of an HTML ``<img>`` element.
+
+    Args:
+        image: PhenoTypic :class:`Image` (or :class:`GridImage`) instance.
+        channel: One of ``"rgb"``, ``"gray"``, ``"detect_mat"``, ``"objmap"``.
+            Defaults to ``"rgb"``.
+        max_dim: Maximum length of the longer spatial side after resizing,
+            in pixels. Defaults to ``512``.
+
+    Returns:
+        A string of the form ``"data:image/png;base64,<...>"``.
+
+    Raises:
+        ValueError: If ``channel`` is not one of the supported names.
+
+    Examples:
+        >>> from phenotypic.data._synthetic_data import load_synth_yeast_plate
+        >>> img = load_synth_yeast_plate()
+        >>> uri = to_data_uri(img, channel="rgb")
+        >>> uri.startswith("data:image/png;base64,")
+        True
+    """
+    arr = _read_channel(image, channel)
+    arr = _downscale(arr, max_dim=max_dim)
+    rgb_uint8 = _channel_to_rgb_uint8(arr, channel)
+
+    pil = PILImage.fromarray(rgb_uint8, mode="RGB")
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG", optimize=False)
+    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def dataframe_to_table(
+    df: "pd.DataFrame",
+    max_rows: int = 50,
+    *,
+    table_id: str | dict[str, Any] | None = None,
+) -> Any:
+    """Render the head of a DataFrame as a Dash ``DataTable`` for the inspector.
+
+    The table is sortable, has horizontal overflow scrolling, and renders no
+    pagination controls — callers slice to ``max_rows`` rows up front to keep
+    payloads small.
+
+    Args:
+        df: Source DataFrame. ``None`` / empty frames render an empty table.
+        max_rows: Maximum number of rows to include. Defaults to 50.
+        table_id: Optional component id (string or pattern-match dict). When
+            omitted, Dash assigns an auto id.
+
+    Returns:
+        A configured :class:`dash_table.DataTable` ready to drop into a layout.
+    """
+    if df is None or len(df) == 0:
+        rows: list[dict[str, Any]] = []
+        columns: list[dict[str, Any]] = []
+    else:
+        head = df.head(max_rows)
+        rows = head.to_dict("records")
+        columns = [{"name": str(c), "id": str(c)} for c in head.columns]
+
+    kwargs: dict[str, Any] = {
+        "data": rows,
+        "columns": columns,
+        "sort_action": "native",
+        "page_action": "none",
+        "style_table": {"overflowX": "auto"},
+        "style_cell": {
+            "fontFamily": "monospace",
+            "fontSize": "0.85rem",
+            "padding": "4px 8px",
+            "textAlign": "left",
+        },
+        "style_header": {"fontWeight": "bold"},
+    }
+    if table_id is not None:
+        kwargs["id"] = table_id
+
+    return dash_table.DataTable(**kwargs)  # type: ignore[attr-defined]
+
+
+__all__ = ["to_data_uri", "dataframe_to_table"]

--- a/src/phenotypic/gui/builder/_layout.py
+++ b/src/phenotypic/gui/builder/_layout.py
@@ -1,0 +1,1193 @@
+"""Pure layout builders for the Dash pipeline builder.
+
+This module is intentionally side-effect-free: every public function returns a
+Dash component tree given some immutable inputs. Phase 3 owns all
+``@callback`` registration and is the only place where ids declared here are
+read or written.
+
+Layout is composed top-to-bottom as:
+
+* :func:`build_breadcrumb` — drill-down indicator + clickable parent links.
+* Three-column body:
+    - :func:`build_palette` (left) — categorised operation buttons.
+    - :func:`build_canvas` (center) — the cytoscape chain.
+    - :func:`build_inspector` (right) — node label + param form + preview.
+* :func:`build_footer` — image source picker, run/save/load controls.
+
+:func:`build_app_layout` stitches the pieces together and mounts the
+``dcc.Store`` instances callbacks read from in Phase 3.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, List, Optional
+
+import dash_bootstrap_components as dbc  # type: ignore[import-untyped]
+import dash_cytoscape as cyto  # type: ignore[import-untyped]
+from dash import dcc, html
+
+from phenotypic.gui.builder import _ids as ids
+from phenotypic.gui.builder._directory_browser import directory_picker
+from phenotypic.gui.builder._param_form import param_form
+from phenotypic.gui.builder._state import (
+    PIPELINE_CLASS_NAME,
+    BuilderScope,
+    BuilderState,
+    current_scope,
+    stage_of,
+    state_to_json,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - type-only imports
+    from phenotypic.gui._operation_registry import (
+        OperationRegistry,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage colour palette
+# ---------------------------------------------------------------------------
+
+#: Background colour for canvas nodes by inferred stage (or pipeline sentinel).
+_STAGE_COLORS = {
+    "ops": "#c5e3ff",
+    "meas": "#fff3c5",
+    "post": "#d5f5d5",
+    "pipeline": "#e0d5ff",
+}
+
+#: Text colour for palette buttons by stage. Matches canvas backgrounds in
+#: spirit but uses outline styling so the accordion stays readable.
+_STAGE_BUTTON_OUTLINE_COLOR = {
+    "ops": "primary",
+    "meas": "warning",
+    "post": "success",
+    "pipeline": "secondary",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_stage(class_name: str) -> str:
+    """Return a stage label for *class_name*, falling back to ``"ops"``.
+
+    :func:`stage_of` raises ``KeyError`` for unknown classes (and we can't
+    pretend a class we don't know is a measurement op). Layout code should
+    degrade gracefully on stale state, so we collapse the error to ``"ops"``.
+    """
+
+    if class_name == PIPELINE_CLASS_NAME:
+        return "pipeline"
+    try:
+        return stage_of(class_name)
+    except KeyError:
+        return "ops"
+
+
+def _scope_path_labels(state: BuilderState) -> List[str]:
+    """Return display labels for each level the breadcrumb walks through.
+
+    Args:
+        state: Full builder state.
+
+    Returns:
+        Labels: ``["Pipeline", <node label>, <inner node label>, ...]``.
+    """
+
+    labels: List[str] = [state.root.name or "Pipeline"]
+    scope: BuilderScope = state.root
+    for raw in state.breadcrumb:
+        if isinstance(raw, str):
+            node_id, param = raw, None
+        else:
+            node_id = raw.get("node_id")
+            param = raw.get("param")
+        node = next((n for n in scope.nodes if n.node_id == node_id), None)
+        if node is None:
+            # Stale breadcrumb: bail gracefully.
+            labels.append("?")
+            break
+        if param is None:
+            labels.append(node.label or node.class_name)
+            if node.nested is None:
+                break
+            scope = node.nested
+        else:
+            # Param drill: synthesize a label like "GaussianBlur.sub_op" so
+            # the user can see where they are without exposing internal
+            # storage details.
+            base = node.label or node.class_name
+            labels.append(f"{base}.{param}")
+            from phenotypic.gui.builder._state import _ensure_param_scope
+
+            scope = _ensure_param_scope(node, str(param))
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Palette
+# ---------------------------------------------------------------------------
+
+
+#: Categories that map to the ``_ops`` chain (image-domain operations).
+_OPS_STAGE_CATEGORIES = {"Corrector", "Detector", "Enhancer", "Refiner"}
+
+#: Category that maps to the ``_meas`` chain.
+_MEAS_STAGE_CATEGORIES = {"Measure"}
+
+#: Category that maps to the ``_post`` chain.
+_POST_STAGE_CATEGORIES = {"Post"}
+
+
+def _palette_for_categories(
+    registry: "OperationRegistry",
+    *,
+    accordion_id: str,
+    category_filter: set[str],
+) -> dbc.Accordion:
+    """Build a categorised palette accordion filtered to *category_filter*.
+
+    Args:
+        registry: A pre-populated :class:`OperationRegistry`.
+        accordion_id: DOM id assigned to the resulting :class:`dbc.Accordion`.
+        category_filter: Subset of registry category names to include.
+
+    Returns:
+        A :class:`dbc.Accordion`. When no categories survive the filter the
+        accordion is empty (callers can detect this via ``not items``).
+    """
+
+    items: List[dbc.AccordionItem] = []
+    for category in registry.get_categories():
+        if category not in category_filter:
+            continue
+        ops = sorted(
+            registry.get_by_category(category),
+            key=lambda info: info.name.lower(),
+        )
+        if not ops:
+            continue
+
+        buttons: List[Any] = []
+        for op_info in ops:
+            stage = _safe_stage(op_info.name)
+            buttons.append(
+                dbc.Button(
+                    op_info.name,
+                    id=ids.palette_button_id(op_info.name),
+                    color=_STAGE_BUTTON_OUTLINE_COLOR.get(stage, "primary"),
+                    outline=True,
+                    size="sm",
+                    n_clicks=0,
+                    className="text-start w-100 mb-1",
+                )
+            )
+
+        items.append(
+            dbc.AccordionItem(
+                buttons,
+                title=f"{category} ({len(ops)})",
+                item_id=f"palette-cat-{category.lower()}",
+            )
+        )
+
+    return dbc.Accordion(
+        items,
+        id=accordion_id,
+        always_open=True,
+        flush=True,
+        active_item=[items[0].item_id] if items else None,
+    )
+
+
+def build_palette(registry: "OperationRegistry") -> dbc.Accordion:
+    """Build the image-stage palette (Corrector / Detector / Enhancer / Refiner).
+
+    The Measure and Post stages have their own palettes — see
+    :func:`build_measure_palette` and :func:`build_post_palette` — so the user
+    can tell at a glance which sections of the pipeline (image ops vs.
+    measurements vs. post-measurement transforms) a node will land in.
+
+    Args:
+        registry: A pre-populated :class:`OperationRegistry`.
+
+    Returns:
+        A :class:`dbc.Accordion` ready to drop into the page layout. Always
+        carries id :data:`PALETTE_CONTAINER` for the existing tests / callbacks
+        that target the canonical palette container.
+    """
+
+    return _palette_for_categories(
+        registry,
+        accordion_id=ids.PALETTE_CONTAINER,
+        category_filter=_OPS_STAGE_CATEGORIES,
+    )
+
+
+def build_measure_palette(registry: "OperationRegistry") -> dbc.Accordion:
+    """Build the Measurements palette (the ``Measure`` category)."""
+
+    return _palette_for_categories(
+        registry,
+        accordion_id="palette-meas",
+        category_filter=_MEAS_STAGE_CATEGORIES,
+    )
+
+
+def build_post_palette(registry: "OperationRegistry") -> dbc.Accordion:
+    """Build the Post-measurements palette (the ``Post`` category)."""
+
+    return _palette_for_categories(
+        registry,
+        accordion_id="palette-post",
+        category_filter=_POST_STAGE_CATEGORIES,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canvas
+# ---------------------------------------------------------------------------
+
+
+def _canvas_stylesheet() -> List[dict]:
+    """Cytoscape stylesheet used by :func:`build_canvas`.
+
+    Phase 3 may extend this list (e.g. to highlight nodes with hot
+    intermediates), so we keep it as a function for easy reuse.
+    """
+
+    return [
+        {
+            "selector": "node",
+            "style": {
+                "shape": "round-rectangle",
+                "label": "data(label)",
+                "text-valign": "center",
+                "text-halign": "center",
+                "background-color": "data(bg)",
+                "border-color": "#666",
+                "border-width": 1,
+                "padding": "12px",
+                "font-size": "12px",
+                "width": "label",
+                "height": 36,
+                "min-width": 80,
+                "color": "#222",
+            },
+        },
+        {
+            "selector": "node.selected",
+            "style": {
+                "border-color": "#0d6efd",
+                "border-width": 3,
+            },
+        },
+        {
+            "selector": "edge",
+            "style": {
+                "curve-style": "bezier",
+                "target-arrow-shape": "triangle",
+                "target-arrow-color": "#888",
+                "line-color": "#888",
+                "width": 1.5,
+            },
+        },
+    ]
+
+
+def build_canvas(
+    scope: BuilderScope,
+    selected_node_id: Optional[str],
+) -> cyto.Cytoscape:
+    """Render the linear chain for *scope* as a cytoscape canvas.
+
+    Each :class:`StepNode` becomes one cytoscape node; consecutive nodes are
+    joined by directed edges. Nested ``ImagePipeline`` nodes get a folder
+    glyph in their label so the user can tell drillable nodes apart.
+
+    Args:
+        scope: The :class:`BuilderScope` currently in view.
+        selected_node_id: If set, the matching node gets the ``"selected"``
+            class so the stylesheet highlights it.
+
+    Returns:
+        A :class:`dash_cytoscape.Cytoscape` component populated with elements
+        for *scope*. Layout is ``"grid"`` with one row to keep the chain
+        horizontal.
+    """
+
+    elements: List[dict] = []
+    prev_id: Optional[str] = None
+
+    for node in scope.nodes:
+        stage = _safe_stage(node.class_name)
+        label = node.label or node.class_name
+        if node.class_name == PIPELINE_CLASS_NAME:
+            label = f"\U0001F4C1 {label}"
+
+        node_classes = "selected" if node.node_id == selected_node_id else ""
+        elements.append(
+            {
+                "data": {
+                    "id": node.node_id,
+                    "label": label,
+                    "bg": _STAGE_COLORS.get(stage, _STAGE_COLORS["ops"]),
+                    "stage": stage,
+                    "class_name": node.class_name,
+                },
+                "classes": node_classes,
+                "selectable": True,
+                "grabbable": True,
+            }
+        )
+        if prev_id is not None:
+            elements.append(
+                {
+                    "data": {
+                        "id": f"{prev_id}__{node.node_id}",
+                        "source": prev_id,
+                        "target": node.node_id,
+                    },
+                }
+            )
+        prev_id = node.node_id
+
+    return cyto.Cytoscape(
+        id=ids.CANVAS_CYTOSCAPE,
+        elements=elements,
+        layout={
+            "name": "grid",
+            "rows": 1,
+            "cols": max(len(scope.nodes), 1),
+            "fit": True,
+            "padding": 24,
+        },
+        # Absolutely position the cytoscape inside its (relative-positioned)
+        # ``cytoscape_slot`` parent so it fills the slot regardless of
+        # whether intermediate containers use flex, block, or grid layout.
+        # Plain ``height: 100%`` was unreliable because percentage heights
+        # don't resolve through ``display: block`` parents whose height was
+        # set by flex.
+        style={
+            "position": "absolute",
+            "top": 0,
+            "left": 0,
+            "right": 0,
+            "bottom": 0,
+        },
+        stylesheet=_canvas_stylesheet(),
+        autoungrabify=False,
+        userPanningEnabled=True,
+        userZoomingEnabled=True,
+        boxSelectionEnabled=False,
+    )
+
+
+def build_canvas_section(
+    scope: BuilderScope, selected_node_id: Optional[str]
+) -> html.Div:
+    """Wrap :func:`build_canvas` with a header and zoom / reset controls.
+
+    The three controls (Zoom out, Zoom in, Reset view) are wired by
+    clientside callbacks registered in :mod:`_callbacks`. They call the
+    underlying cytoscape.js API directly via ``window.phenoGetCy()`` —
+    ``cy.zoom()`` / ``cy.fit()`` — rather than going through dash-
+    cytoscape's prop change detection, which can ignore identical
+    layout dicts.
+    """
+
+    controls = dbc.ButtonGroup(
+        [
+            dbc.Button(
+                "−",
+                id=ids.BTN_CANVAS_ZOOM_OUT,
+                color="secondary",
+                outline=True,
+                size="sm",
+                n_clicks=0,
+                title="Zoom out",
+            ),
+            dbc.Button(
+                "+",
+                id=ids.BTN_CANVAS_ZOOM_IN,
+                color="secondary",
+                outline=True,
+                size="sm",
+                n_clicks=0,
+                title="Zoom in",
+            ),
+            dbc.Button(
+                "Reset view",
+                id=ids.BTN_CANVAS_FIT,
+                color="secondary",
+                outline=True,
+                size="sm",
+                n_clicks=0,
+                title="Recenter and zoom-to-fit",
+            ),
+        ],
+        size="sm",
+    )
+
+    header = html.Div(
+        [
+            html.H6("Canvas", className="mb-0"),
+            controls,
+        ],
+        className="d-flex justify-content-between align-items-center mb-2",
+    )
+    # Cytoscape (``height: 100%``) needs a flex-grown sibling slot so the
+    # browser can resolve its percentage height. The header has natural
+    # height; the cytoscape wrapper takes the remaining flex space via
+    # ``flex: 1 1 0; min-height: 0``. We deliberately leave the slot as a
+    # plain block (no inner ``display: flex``) — making it a row-flex
+    # container would force its child's width to its content size, which
+    # is 0 for a cytoscape (no intrinsic content), collapsing the canvas to
+    # zero width.
+    # The slot doubles as the swappable ``canvas-cytoscape-wrapper`` whose
+    # ``children`` callbacks rewrite to mount a fresh cytoscape after a state
+    # mutation (avoids fighting dash-cytoscape's prop diffing). The id also
+    # gives ``window.phenoGetCy()`` a reliable anchor for the React fiber walk.
+    cytoscape_slot = html.Div(
+        build_canvas(scope, selected_node_id),
+        id="canvas-cytoscape-wrapper",
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "position": "relative",
+        },
+    )
+    return html.Div(
+        [header, cytoscape_slot],
+        style={
+            "display": "flex",
+            "flexDirection": "column",
+            "height": "100%",
+            "minHeight": 0,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inspector
+# ---------------------------------------------------------------------------
+
+
+_HIDDEN_STYLE = {"display": "none"}
+
+
+def _hidden_inspector_widgets() -> List[Any]:
+    """Always-rendered hidden placeholders for conditionally-visible inspector
+    widgets.
+
+    The fan-in callback in :mod:`phenotypic.gui.builder._callbacks` declares
+    ``Input(BTN_DRILL_IN, ...)`` and ``Input(INPUT_NODE_LABEL, ...)``. Dash's
+    client-side renderer raises ``ReferenceError`` when a callback fires and
+    one of its referenced ids is missing from the live layout, even with
+    ``suppress_callback_exceptions=True`` (which only skips server-side
+    validation at registration time). To keep the inputs always resolvable,
+    every branch of :func:`build_inspector` emits these hidden widgets so the
+    ids stay in the DOM whether or not a pipeline node happens to be
+    selected.
+    """
+
+    return [
+        dbc.Input(id=ids.INPUT_NODE_LABEL, type="text", style=_HIDDEN_STYLE),
+        dbc.Button(id=ids.BTN_DRILL_IN, n_clicks=0, style=_HIDDEN_STYLE),
+    ]
+
+
+def _empty_inspector_card() -> dbc.Card:
+    """Friendly placeholder shown when no canvas node is selected."""
+
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H5("Inspector", className="card-title"),
+                html.P(
+                    "Click a node on the canvas to edit its parameters, "
+                    "or drag an operation from the palette.",
+                    className="text-muted mb-0",
+                ),
+            ]
+        ),
+        className="h-100",
+    )
+
+
+def build_inspector(
+    state: BuilderState,
+    registry: "OperationRegistry",
+) -> html.Div:
+    """Render the inspector pane for the current selection.
+
+    When ``state.selected_node_id`` matches a node in
+    :func:`current_scope`, the inspector renders:
+
+    1. A label-text input (id :data:`INPUT_NODE_LABEL`) for renaming.
+    2. The auto-generated :func:`param_form` from
+       :mod:`phenotypic.gui.builder._param_form` — except for the
+       ``ImagePipeline`` sentinel, where a "Drill in" button is shown
+       instead so Phase 3 can push the breadcrumb.
+    3. A placeholder :data:`INSPECTOR_PREVIEW` div — Phase 3 fills it with a
+       channel thumbnail (via :func:`to_data_uri`) for image-stage nodes or a
+       :class:`dash_table.DataTable` for measurement steps.
+
+    Args:
+        state: The full builder state (used to resolve the active scope and
+            selection via :func:`current_scope`).
+        registry: Operation registry consulted for parameter metadata.
+
+    Returns:
+        A :class:`dash.html.Div` wrapping the inspector card. Always carries
+        the :data:`INSPECTOR_CONTAINER` id so callbacks can swap children.
+    """
+
+    if state.selected_node_id is None:
+        return html.Div(
+            [_empty_inspector_card(), *_hidden_inspector_widgets()],
+            id=ids.INSPECTOR_CONTAINER,
+        )
+
+    try:
+        scope = current_scope(state)
+    except KeyError:
+        return html.Div(
+            [_empty_inspector_card(), *_hidden_inspector_widgets()],
+            id=ids.INSPECTOR_CONTAINER,
+        )
+
+    node = next(
+        (n for n in scope.nodes if n.node_id == state.selected_node_id),
+        None,
+    )
+    if node is None:
+        return html.Div(
+            [_empty_inspector_card(), *_hidden_inspector_widgets()],
+            id=ids.INSPECTOR_CONTAINER,
+        )
+
+    label_value = node.label or node.class_name
+    header_children: List[Any] = [
+        html.H5(node.class_name, className="card-title mb-3"),
+        dbc.InputGroup(
+            [
+                dbc.InputGroupText("Label"),
+                dbc.Input(
+                    id=ids.INPUT_NODE_LABEL,
+                    type="text",
+                    value=label_value,
+                    debounce=True,
+                ),
+            ],
+            className="mb-3",
+        ),
+    ]
+
+    if node.class_name == PIPELINE_CLASS_NAME:
+        body_children: List[Any] = [
+            *header_children,
+            html.Div(
+                [
+                    html.P(
+                        "This step is a nested pipeline. Drill in to edit "
+                        "its operations.",
+                        className="text-muted",
+                    ),
+                    dbc.Button(
+                        "Drill in ▸",
+                        id=ids.BTN_DRILL_IN,
+                        color="primary",
+                        outline=True,
+                        n_clicks=0,
+                    ),
+                ]
+            ),
+            html.Hr(),
+            html.Div(id=ids.INSPECTOR_PARAM_FORM),
+            html.Div(
+                id=ids.INSPECTOR_PREVIEW,
+                className="mt-3",
+            ),
+        ]
+        return html.Div(
+            dbc.Card(dbc.CardBody(body_children), className="h-100"),
+            id=ids.INSPECTOR_CONTAINER,
+        )
+
+    op_info = registry.get(node.class_name)
+    if op_info is None:
+        form: Any = html.Div(
+            f"Unknown operation '{node.class_name}'. "
+            "It may have been removed from the registry.",
+            className="text-warning",
+        )
+    else:
+        form = html.Div(
+            param_form(
+                op_info,
+                current_values=node.params,
+                form_id_prefix=node.node_id,
+            ),
+            id=ids.INSPECTOR_PARAM_FORM,
+        )
+
+    body_children = [
+        *header_children,
+        form,
+        html.Hr(),
+        html.Div(
+            "(Run preview to populate)",
+            id=ids.INSPECTOR_PREVIEW,
+            className="text-muted small fst-italic",
+        ),
+        # Non-pipeline nodes don't render a visible Drill-in button, but the
+        # fan-in callback still references BTN_DRILL_IN as an Input — keep the
+        # id resolvable with a hidden placeholder.
+        dbc.Button(id=ids.BTN_DRILL_IN, n_clicks=0, style=_HIDDEN_STYLE),
+    ]
+
+    return html.Div(
+        dbc.Card(dbc.CardBody(body_children), className="h-100"),
+        id=ids.INSPECTOR_CONTAINER,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Breadcrumb
+# ---------------------------------------------------------------------------
+
+
+def build_breadcrumb(state: BuilderState) -> html.Nav:
+    """Render the breadcrumb showing scope drill path.
+
+    Each segment except the last is a clickable button with a pattern-
+    matching id from :func:`breadcrumb_link_id` (depth = position in the
+    chain, 0 = root). Phase 3's drill-out callback maps the depth back to a
+    breadcrumb truncation length.
+
+    Args:
+        state: The full builder state.
+
+    Returns:
+        ``html.Nav`` containing a single ``dbc.Breadcrumb``.
+    """
+
+    labels = _scope_path_labels(state)
+    items: List[dict] = []
+    for depth, label in enumerate(labels):
+        is_last = depth == len(labels) - 1
+        items.append(
+            {
+                "label": label,
+                "active": is_last,
+                # ``href`` is optional; Dash's ``Breadcrumb`` renders text-only
+                # items when omitted. Pattern-matched buttons are placed
+                # alongside via the parent <nav> wrapper.
+            }
+        )
+
+    # Use a list of buttons so we can register pattern-matching callbacks per
+    # depth. dbc.Breadcrumb itself is decorative-only here.
+    children: List[Any] = []
+    for depth, label in enumerate(labels):
+        is_last = depth == len(labels) - 1
+        if is_last:
+            children.append(
+                html.Span(label, className="fw-bold")
+            )
+        else:
+            children.append(
+                dbc.Button(
+                    label,
+                    id=ids.breadcrumb_link_id(depth),
+                    color="link",
+                    size="sm",
+                    className="px-1",
+                    n_clicks=0,
+                )
+            )
+        if not is_last:
+            children.append(html.Span(" / ", className="text-muted mx-1"))
+
+    return html.Nav(
+        children,
+        id=ids.BREADCRUMB_CONTAINER,
+        className="d-flex align-items-center mb-2 small",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Footer
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_io_card() -> dbc.Card:
+    """Save / Load controls. Lives above the inspector in the right column."""
+
+    save_row = dbc.InputGroup(
+        [
+            dbc.Input(
+                id=ids.INPUT_SAVE_PATH,
+                type="text",
+                placeholder="/abs/path/to/pipeline.json",
+                debounce=True,
+            ),
+            dbc.Button("Save", id=ids.BTN_SAVE, color="primary", n_clicks=0),
+        ],
+        size="sm",
+        className="mb-2",
+    )
+    load_row = dbc.InputGroup(
+        [
+            dbc.Input(
+                id=ids.INPUT_LOAD_PATH,
+                type="text",
+                placeholder="/abs/path/to/pipeline.json",
+                debounce=True,
+            ),
+            dbc.Button("Load", id=ids.BTN_LOAD, color="primary", n_clicks=0),
+        ],
+        size="sm",
+        className="mb-0",
+    )
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H6("Pipeline I/O", className="mb-2"),
+                save_row,
+                load_row,
+            ],
+            className="py-2",
+        ),
+        className="mb-2",
+    )
+
+
+def _structure_card() -> dbc.Card:
+    """+ Pipeline / Delete buttons. Lives above the inspector in the right column."""
+
+    structural_buttons = dbc.ButtonGroup(
+        [
+            dbc.Button(
+                "+ Pipeline",
+                id=ids.BTN_NEW_PIPELINE_NODE,
+                color="info",
+                outline=True,
+                n_clicks=0,
+            ),
+            dbc.Button(
+                "Delete selected",
+                id=ids.BTN_DELETE_NODE,
+                color="danger",
+                outline=True,
+                n_clicks=0,
+            ),
+        ],
+        className="w-100",
+        size="sm",
+    )
+    return dbc.Card(
+        dbc.CardBody(
+            [
+                html.H6("Structure", className="mb-2"),
+                structural_buttons,
+            ],
+            className="py-2",
+        ),
+        className="mb-2",
+    )
+
+
+def build_footer(image_root: Optional[Path]) -> dbc.Card:
+    """Render the footer row with image source + grid + run-preview controls.
+
+    Pipeline I/O (Save/Load) and Structure (+ Pipeline / Delete) live above
+    the inspector in the right column — see :func:`_pipeline_io_card` and
+    :func:`_structure_card`.
+
+    Layout (left to right):
+
+    * Directory picker (via :func:`directory_picker`).
+    * ``nrows`` / ``ncols`` overrides for grid pipelines.
+    * "Run preview" button (wrapped in a ``dcc.Loading``).
+
+    Args:
+        image_root: Path forwarded to :func:`directory_picker`. ``None``
+            disables the directory tree section.
+
+    Returns:
+        A :class:`dbc.Card` whose body is the footer row.
+    """
+
+    grid_inputs = dbc.Row(
+        [
+            dbc.Col(
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupText("nrows"),
+                        dbc.Input(
+                            id=ids.INPUT_NROWS,
+                            type="number",
+                            min=1,
+                            step=1,
+                            placeholder="auto",
+                            debounce=True,
+                        ),
+                    ],
+                    size="sm",
+                ),
+                width=6,
+            ),
+            dbc.Col(
+                dbc.InputGroup(
+                    [
+                        dbc.InputGroupText("ncols"),
+                        dbc.Input(
+                            id=ids.INPUT_NCOLS,
+                            type="number",
+                            min=1,
+                            step=1,
+                            placeholder="auto",
+                            debounce=True,
+                        ),
+                    ],
+                    size="sm",
+                ),
+                width=6,
+            ),
+        ],
+        className="g-1 mb-2",
+    )
+
+    run_button = dcc.Loading(
+        id=ids.PREVIEW_LOADING,
+        type="default",
+        children=dbc.Button(
+            "Run preview",
+            id=ids.BTN_RUN_PREVIEW,
+            color="success",
+            n_clicks=0,
+            className="w-100",
+        ),
+    )
+
+    return dbc.Card(
+        dbc.CardBody(
+            dbc.Row(
+                [
+                    dbc.Col(
+                        [
+                            html.H6("Image source", className="mb-2"),
+                            directory_picker(image_root),
+                        ],
+                        md=8,
+                    ),
+                    dbc.Col(
+                        [
+                            html.H6("Grid", className="mb-2"),
+                            grid_inputs,
+                            run_button,
+                        ],
+                        md=4,
+                    ),
+                ],
+                className="g-3",
+            )
+        ),
+        id=ids.FOOTER_CONTAINER,
+        className="mt-3",
+    )
+
+
+# ---------------------------------------------------------------------------
+# App layout
+# ---------------------------------------------------------------------------
+
+
+def build_app_layout(
+    state: BuilderState,
+    registry: "OperationRegistry",
+    image_root: Optional[Path],
+) -> html.Div:
+    """Compose the top-level page layout.
+
+    Three vertical sections wrapped in a ``dbc.Container(fluid=True)``:
+
+    * Breadcrumb nav (full width).
+    * Three-column body — palette, canvas, inspector — sized 3/6/3.
+    * Footer card with image source + I/O controls.
+
+    Mounts the three :class:`dcc.Store` instances callbacks need:
+
+    * :data:`STORE_BUILDER_STATE` seeded with ``state_to_json(state)``.
+    * :data:`STORE_SESSION_ID` configured for ``storage_type='session'``;
+      Phase 3 fills it on first interaction (a fresh uuid per browser tab).
+    * :data:`STORE_INTERMEDIATE_KEYS` for synchronising the canvas with the
+      session-side intermediates cache.
+
+    A floating :class:`dbc.Toast` at id :data:`TOAST_NOTIFICATION` carries
+    save/load/preview status messages.
+
+    Args:
+        state: Initial :class:`BuilderState`. Stored serialised in
+            :data:`STORE_BUILDER_STATE`.
+        registry: Operation registry used to populate the palette and the
+            inspector.
+        image_root: Optional directory root for the directory picker.
+
+    Returns:
+        A :class:`dash.html.Div` ready to assign to ``app.layout``.
+    """
+
+    # Vertical layout strategy:
+    # - The right column has natural height (Pipeline I/O + Structure +
+    #   inspector content). When a node is selected, its param form grows the
+    #   column, which grows the row.
+    # - dbc.Row's default ``align-items: stretch`` stretches every other
+    #   column to match the row height.
+    # - The palette column is made into a flex column whose inner scroll
+    #   wrapper uses ``flex: 1 1 0; min-height: 0`` so the palette content
+    #   does NOT contribute to the row's natural-height calculation. With
+    #   ``flex-basis: 0`` the palette wrapper starts at zero, then stretches
+    #   to fill whatever height the row settles on, and its overflow scrolls.
+    # Picked so the canvas 30% slice gets at least ~210 px and the inspector
+    # 70% slice gets ~490 px — comfortable for a typical 3-5 node pipeline
+    # with a moderate param form.
+    _ROW_MIN_HEIGHT = "700px"
+    _SCROLL_FILL_STYLE = {
+        "flex": "1 1 0",
+        "minHeight": 0,
+        "overflowY": "auto",
+    }
+
+    # Inner container holds the actual scrolling content; the outer wrapper
+    # gives the chevron pseudo-elements a positioning context (see
+    # ``assets/builder.css`` and ``assets/builder.js``).
+    palette_inner = html.Div(
+        [
+            html.Div(
+                [
+                    html.H6("Operations", className="mb-2"),
+                    build_palette(registry),
+                ],
+                className="pheno-palette-section",
+            ),
+            html.Div(
+                [
+                    html.H6("Measurements", className="mb-2"),
+                    build_measure_palette(registry),
+                ],
+                className="pheno-palette-section",
+            ),
+            html.Div(
+                [
+                    html.H6("Post-measurements", className="mb-2"),
+                    build_post_palette(registry),
+                ],
+                className="pheno-palette-section",
+            ),
+        ],
+        className="pheno-scroll pe-2",
+        style=_SCROLL_FILL_STYLE,
+    )
+    # palette_column is a flex column so its child can use ``flex: 1`` to
+    # fill available space without contributing content height to its
+    # parent's natural-size calculation.
+    palette_column = html.Div(
+        palette_inner,
+        className="pheno-scroll-wrap",
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "display": "flex",
+            "flexDirection": "column",
+        },
+    )
+
+    # Inspector now sits under the canvas in the middle column. Its wrapper
+    # uses ``flex: 1`` so it fills whatever flex slot the middle column
+    # allocates (the 70% slice — see ``middle_column`` below). Internal
+    # overflow scrolls when the param form is taller than the slot.
+    inspector_inner = html.Div(
+        build_inspector(state, registry),
+        className="pheno-scroll pe-2",
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "overflowY": "auto",
+        },
+    )
+    inspector_wrap = html.Div(
+        inspector_inner,
+        className="pheno-scroll-wrap",
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "display": "flex",
+            "flexDirection": "column",
+        },
+    )
+
+    # Right portion of the body is itself a 50 / 50 vertical split:
+    #   Top half  = Canvas (md=8 of 9) + Pipeline I/O & Structure (md=4 of 9)
+    #   Bottom half = Inspector (full width — spans both columns)
+    # The two halves both use ``flex: 1 1 0`` so the split is exact regardless
+    # of content size; ``min-height: 0`` lets each half shrink without the
+    # inspector content forcing growth.
+    top_half = dbc.Row(
+        [
+            dbc.Col(
+                build_canvas_section(state.root, state.selected_node_id),
+                md=8,
+                className="d-flex flex-column",
+                style={"minHeight": 0},
+            ),
+            dbc.Col(
+                [_pipeline_io_card(), _structure_card()],
+                md=4,
+                className="border-start ps-3",
+            ),
+        ],
+        className="g-3",
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "marginLeft": 0,
+            "marginRight": 0,
+        },
+    )
+
+    bottom_half = html.Div(
+        inspector_wrap,
+        style={
+            "flex": "1 1 0",
+            "minHeight": 0,
+            "display": "flex",
+            "flexDirection": "column",
+        },
+    )
+
+    # ``html.Hr`` between halves gives a clear visual separator without
+    # competing with the flex sizing. ``flex-shrink: 0`` keeps the rule from
+    # being absorbed when the row gets short; ``my-2`` collapses Bootstrap's
+    # default ``Hr`` margins to a single tidy gap.
+    divider = html.Hr(
+        className="my-2",
+        style={"flexShrink": 0, "width": "100%"},
+    )
+
+    right_section = html.Div(
+        [top_half, divider, bottom_half],
+        style={
+            "display": "flex",
+            "flexDirection": "column",
+            "height": "100%",
+            "minHeight": 0,
+            "width": "100%",
+        },
+    )
+
+    body_row = dbc.Row(
+        [
+            # ``d-flex flex-column`` makes this column a flex container so the
+            # palette wrapper's ``flex: 1`` actually has a flex parent to grow
+            # against. Without it the wrapper would still see ``display:
+            # block`` and ignore its flex sizing.
+            dbc.Col(
+                palette_column,
+                md=3,
+                className="border-end pe-3 d-flex flex-column",
+            ),
+            dbc.Col(
+                right_section,
+                md=9,
+                className="ps-3 d-flex flex-column",
+            ),
+        ],
+        className="g-3",
+        style={"minHeight": _ROW_MIN_HEIGHT, "alignItems": "stretch"},
+    )
+
+    stores = html.Div(
+        [
+            dcc.Store(
+                id=ids.STORE_BUILDER_STATE,
+                data=state_to_json(state),
+            ),
+            dcc.Store(
+                id=ids.STORE_SESSION_ID,
+                storage_type="session",
+                data="",
+            ),
+            dcc.Store(
+                id=ids.STORE_INTERMEDIATE_KEYS,
+                data=[],
+            ),
+            # Sink for clientside canvas-control callbacks (zoom in/out, fit).
+            dcc.Store(
+                id=ids.STORE_CANVAS_CONTROL,
+                data=0,
+            ),
+            # Active image path; populated by the directory browser, consumed
+            # by Run preview.
+            dcc.Store(
+                id=ids.STORE_IMAGE_PATH,
+                data="",
+            ),
+        ]
+    )
+
+    toast = dbc.Toast(
+        id=ids.TOAST_NOTIFICATION,
+        header="Pipeline builder",
+        is_open=False,
+        dismissable=True,
+        duration=5000,
+        icon="primary",
+        style={
+            "position": "fixed",
+            "top": 20,
+            "right": 20,
+            "minWidth": 300,
+            "zIndex": 1080,
+        },
+    )
+
+    return html.Div(
+        [
+            stores,
+            toast,
+            dbc.Container(
+                [
+                    html.Div(
+                        [
+                            html.H4(
+                                "PhenoTypic Pipeline Builder",
+                                className="mb-1",
+                            ),
+                            build_breadcrumb(state),
+                        ],
+                        className="pt-3 pb-2",
+                    ),
+                    body_row,
+                    build_footer(image_root),
+                ],
+                fluid=True,
+            ),
+        ]
+    )
+
+
+__all__ = [
+    "build_palette",
+    "build_canvas",
+    "build_inspector",
+    "build_breadcrumb",
+    "build_footer",
+    "build_app_layout",
+]

--- a/src/phenotypic/gui/builder/_param_form.py
+++ b/src/phenotypic/gui/builder/_param_form.py
@@ -1,0 +1,515 @@
+"""Auto-generate Dash form widgets from OperationRegistry parameter metadata.
+
+Maps :class:`~phenotypic.gui._operation_registry.ParamInfo` entries to Dash
+Bootstrap widgets used by the pipeline builder's inspector pane. Pure functions
+only — no Dash callbacks live here. Phase 3 wires the IDs emitted from this
+module to ``dcc.Store`` updates.
+"""
+
+from __future__ import annotations
+
+import collections.abc as abc
+import enum
+import inspect
+import typing
+from typing import TYPE_CHECKING, Any, get_args, get_origin
+
+import dash_bootstrap_components as dbc  # type: ignore[import-untyped]
+from dash import html
+
+if TYPE_CHECKING:
+    from phenotypic.gui._operation_registry import OperationInfo, ParamInfo
+
+
+# ---------------------------------------------------------------------------
+# Type-classification helpers
+# ---------------------------------------------------------------------------
+
+
+def _unwrap_optional(hint: Any) -> Any:
+    """Return ``T`` from ``T | None`` annotations; otherwise pass through.
+
+    Args:
+        hint: A type hint (possibly a ``Union[T, None]`` / ``Optional[T]``).
+
+    Returns:
+        The non-``None`` member of an Optional/Union, or the original hint when
+        the hint is not Optional.
+    """
+    origin = get_origin(hint)
+    if origin is typing.Union:
+        non_none = [a for a in get_args(hint) if a is not type(None)]
+        if len(non_none) == 1:
+            return non_none[0]
+        if len(non_none) > 1:
+            return non_none[0]
+    return hint
+
+
+def _literal_options(hint: Any) -> list[Any] | None:
+    """Extract literal values from ``Literal[...]`` annotations.
+
+    Args:
+        hint: Type hint to inspect.
+
+    Returns:
+        List of literal values when ``hint`` is a ``Literal[...]``; otherwise
+        ``None``.
+    """
+    inner = _unwrap_optional(hint)
+    if get_origin(inner) is typing.Literal:
+        return list(get_args(inner))
+    return None
+
+
+def _enum_options(hint: Any) -> list[Any] | None:
+    """Extract member values from ``enum.Enum`` annotations.
+
+    Args:
+        hint: Type hint to inspect.
+
+    Returns:
+        List of enum member values when ``hint`` is an Enum subclass; otherwise
+        ``None``.
+    """
+    inner = _unwrap_optional(hint)
+    if inspect.isclass(inner) and issubclass(inner, enum.Enum):
+        return [m.value for m in inner]
+    return None
+
+
+def _is_list_type(hint: Any) -> bool:
+    """Return ``True`` if ``hint`` is ``list[T]`` / ``List[T]`` / ``Iterable[T]``.
+
+    Tuples report as ``False`` here — see :func:`_is_tuple_type`.
+    """
+    inner = _unwrap_optional(hint)
+    origin = get_origin(inner)
+    if origin is list:
+        return True
+    if origin in (
+        abc.Iterable,
+        abc.Sequence,
+        abc.MutableSequence,
+        typing.Iterable,
+        typing.Sequence,
+        typing.MutableSequence,
+    ):
+        return True
+    return inner is list
+
+
+def _is_tuple_type(hint: Any) -> bool:
+    """Return ``True`` if ``hint`` is ``tuple[...]`` / ``Tuple[...]``."""
+    inner = _unwrap_optional(hint)
+    origin = get_origin(inner)
+    if origin is tuple:
+        return True
+    return inner is tuple
+
+
+def _list_item_type(hint: Any) -> Any:
+    """Return the element type for ``list[T]`` / ``tuple[T, ...]`` annotations.
+
+    Returns ``str`` when the element type cannot be determined.
+    """
+    inner = _unwrap_optional(hint)
+    args = get_args(inner)
+    if not args:
+        return str
+    # tuple[T, ...] — the ellipsis means homogeneous; both args[0] is the type
+    return args[0]
+
+
+# ---------------------------------------------------------------------------
+# Value conversion helpers (used by Phase-3 callbacks)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_scalar(text: Any, item_type: Any) -> Any:
+    """Coerce a single token to a Python scalar using ``item_type``.
+
+    Falls back to the original text when coercion fails so that validation can
+    raise a meaningful error from the operation's ``__init__`` / ``__setattr__``.
+    """
+    if text is None or text == "":
+        return None
+    if item_type is bool:
+        if isinstance(text, bool):
+            return text
+        return str(text).strip().lower() in {"1", "true", "yes", "on"}
+    if item_type is int:
+        try:
+            return int(float(text))
+        except (TypeError, ValueError):
+            return text
+    if item_type is float:
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            return text
+    return str(text)
+
+
+def parse_list_value(text: str | None, item_type: Any = str) -> list[Any]:
+    """Parse a comma-separated text value into a list of typed elements.
+
+    Args:
+        text: Raw widget text (may be ``None`` or empty).
+        item_type: Python type to coerce each token to.
+
+    Returns:
+        List of coerced values; empty list when ``text`` is empty.
+    """
+    if text is None:
+        return []
+    cleaned = str(text).strip()
+    if not cleaned:
+        return []
+    tokens = [t.strip() for t in cleaned.split(",")]
+    return [_coerce_scalar(t, item_type) for t in tokens if t != ""]
+
+
+def parse_widget_value(raw: Any, p: "ParamInfo") -> Any:
+    """Convert a Dash widget's reported value back to the right Python type.
+
+    Handles tuple/list comma-split, int/float coercion, enum/literal pass-
+    through, and bool fall-through. Tuples return ``tuple(...)`` so that ops
+    like :class:`FrangiVesselness` (which re-coerces in ``__setattr__``) round-
+    trip cleanly.
+
+    Args:
+        raw: Value reported by the Dash component.
+        p: :class:`ParamInfo` describing the target parameter.
+
+    Returns:
+        Value coerced to the parameter's expected Python type.
+    """
+    inner = _unwrap_optional(p.type_hint)
+
+    if raw is None:
+        return None
+
+    # Literal / Enum: values come back as strings (Select stores .value)
+    literals = _literal_options(p.type_hint)
+    if literals is not None:
+        for lit in literals:
+            if str(lit) == str(raw):
+                return lit
+        return raw
+
+    enum_vals = _enum_options(p.type_hint)
+    if enum_vals is not None:
+        for v in enum_vals:
+            if str(v) == str(raw):
+                return v
+        return raw
+
+    # Bool
+    if inner is bool:
+        if isinstance(raw, bool):
+            return raw
+        return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+
+    # Numeric scalars
+    if inner is int:
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return raw
+    if inner is float:
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return raw
+
+    # Lists / tuples
+    if _is_list_type(p.type_hint):
+        return parse_list_value(raw, _list_item_type(p.type_hint))
+    if _is_tuple_type(p.type_hint):
+        return tuple(parse_list_value(raw, _list_item_type(p.type_hint)))
+
+    # Default: leave as text
+    return raw
+
+
+def serialize_param_for_widget(value: Any, p: "ParamInfo") -> Any:
+    """Format a stored value for display in a Dash widget.
+
+    Inverse of :func:`parse_widget_value`. Tuples / lists become comma-separated
+    text suitable for the underlying ``dbc.Input``; enum members are reduced to
+    their ``.value`` attribute; booleans pass through unchanged.
+
+    Args:
+        value: Value currently stored for the parameter.
+        p: :class:`ParamInfo` describing the target parameter.
+
+    Returns:
+        A widget-ready representation (text, number, or bool).
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, enum.Enum):
+        return value.value
+
+    if isinstance(value, (list, tuple)):
+        return ", ".join(_format_token(v) for v in value)
+
+    if isinstance(value, bool):
+        return value
+
+    return value
+
+
+def _format_token(v: Any) -> str:
+    """Render a sequence element as a stable string for the widget."""
+    if isinstance(v, float):
+        # Avoid ``2.0`` → ``"2.0"`` flapping when user originally typed ``2``.
+        if v.is_integer():
+            return str(int(v))
+        return repr(v)
+    return str(v)
+
+
+# ---------------------------------------------------------------------------
+# Widget builders
+# ---------------------------------------------------------------------------
+
+
+def _widget_for_param(
+    p: "ParamInfo",
+    *,
+    current_value: Any,
+    form_id_prefix: str,
+) -> Any:
+    """Build the primary input widget for a single parameter.
+
+    Args:
+        p: :class:`ParamInfo` from the operation registry.
+        current_value: Existing value to populate the widget with.
+        form_id_prefix: Prefix added to every generated component id so multiple
+            forms can coexist on the same page without id collisions.
+
+    Returns:
+        A Dash component (typically a ``dbc.Input`` / ``dbc.Switch`` /
+        ``dbc.Select`` / ``dbc.Button``).
+    """
+    inner = _unwrap_optional(p.type_hint)
+    initial = (
+        serialize_param_for_widget(current_value, p)
+        if current_value is not None
+        else serialize_param_for_widget(p.default, p)
+    )
+
+    # Operation / pipeline params: emit the placeholder "Edit" button.
+    if p.is_operation or p.is_pipeline:
+        return dbc.Button(
+            "Edit ▸",
+            id={
+                "type": "param-edit-nested",
+                "prefix": form_id_prefix,
+                "name": p.name,
+            },
+            color="secondary",
+            size="sm",
+            outline=True,
+        )
+
+    # Literal / Enum dropdowns.
+    options = _literal_options(p.type_hint) or _enum_options(p.type_hint)
+    if options is not None:
+        return dbc.Select(
+            id={"type": "param-enum", "prefix": form_id_prefix, "name": p.name},
+            options=[{"label": str(v), "value": str(v)} for v in options],
+            value=str(initial) if initial is not None else None,
+        )
+
+    # Bool → Switch.
+    if inner is bool:
+        return dbc.Switch(
+            id={"type": "param-bool", "prefix": form_id_prefix, "name": p.name},
+            label="",
+            value=bool(initial) if initial is not None else False,
+        )
+
+    # int / float → numeric input.
+    if inner is int:
+        return dbc.Input(
+            type="number",
+            id={"type": "param-num", "prefix": form_id_prefix, "name": p.name},
+            value=initial,
+            step=1,
+            debounce=True,
+        )
+    if inner is float:
+        return dbc.Input(
+            type="number",
+            id={"type": "param-num", "prefix": form_id_prefix, "name": p.name},
+            value=initial,
+            step=0.01,
+            debounce=True,
+        )
+
+    # list[T]
+    if _is_list_type(p.type_hint):
+        return dbc.Input(
+            type="text",
+            id={"type": "param-list", "prefix": form_id_prefix, "name": p.name},
+            value=initial if isinstance(initial, str) else "",
+            placeholder="comma-separated",
+            debounce=True,
+        )
+
+    # tuple[...]
+    if _is_tuple_type(p.type_hint):
+        return dbc.Input(
+            type="text",
+            id={"type": "param-tuple", "prefix": form_id_prefix, "name": p.name},
+            value=initial if isinstance(initial, str) else "",
+            placeholder="comma-separated",
+            debounce=True,
+        )
+
+    # str / fallback.
+    return dbc.Input(
+        type="text",
+        id={"type": "param-str", "prefix": form_id_prefix, "name": p.name},
+        value=initial if initial is not None else "",
+        debounce=True,
+    )
+
+
+def _optional_toggle(p: "ParamInfo", *, form_id_prefix: str) -> Any:
+    """Build the "Use default" toggle shown beside Optional widgets.
+
+    Args:
+        p: Parameter being annotated. The toggle defaults to ``True`` when the
+            parameter currently has its default-of-``None`` value.
+        form_id_prefix: Prefix forwarded to the component id.
+    """
+    return dbc.Switch(
+        id={
+            "type": "param-optional-toggle",
+            "prefix": form_id_prefix,
+            "name": p.name,
+        },
+        label="Use default",
+        value=p.default is None,
+    )
+
+
+def _error_slot(p: "ParamInfo", *, form_id_prefix: str) -> Any:
+    """Reserve an empty validation-message div for Phase-3 callbacks to fill."""
+    return html.Div(
+        id={"type": "param-error", "prefix": form_id_prefix, "name": p.name},
+        className="invalid-feedback d-block",
+    )
+
+
+def _param_row(
+    p: "ParamInfo",
+    *,
+    current_values: dict[str, Any],
+    form_id_prefix: str,
+) -> Any:
+    """Render one parameter as a labelled ``dbc.Row``.
+
+    Args:
+        p: :class:`ParamInfo` to render.
+        current_values: Mapping of parameter-name → current value (may be empty).
+        form_id_prefix: Prefix forwarded to every component id in the row.
+    """
+    widget = _widget_for_param(
+        p,
+        current_value=current_values.get(p.name),
+        form_id_prefix=form_id_prefix,
+    )
+
+    label_children: list[Any] = [p.name]
+    label = dbc.Label(label_children, html_for=None, className="fw-semibold")
+
+    helper: list[Any] = []
+    if p.description:
+        helper.append(dbc.FormText(p.description, color="secondary"))
+
+    main_col_children: list[Any] = [widget, *helper, _error_slot(p, form_id_prefix=form_id_prefix)]
+    cols: list[Any] = [
+        dbc.Col(label, width=4),
+        dbc.Col(main_col_children, width=6),
+    ]
+    # The "Use default" toggle only makes sense when the param has a default to
+    # fall back to. ``Optional`` params without a default are required-with-a-
+    # ``None``-sentinel and would otherwise silently produce ``TypeError`` from
+    # ``create_instance`` if the toggle stripped them from the params dict.
+    if p.is_optional and p.has_default:
+        cols.append(
+            dbc.Col(_optional_toggle(p, form_id_prefix=form_id_prefix), width=2)
+        )
+    else:
+        cols.append(dbc.Col(width=2))
+
+    return dbc.Row(cols, className="mb-3 align-items-center")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def param_form(
+    op_info: "OperationInfo",
+    current_values: dict[str, Any],
+    *,
+    form_id_prefix: str,
+) -> dbc.Form:
+    """Generate a parameter form for an operation.
+
+    Walks ``op_info.parameters`` in declaration order and emits one labelled
+    row per parameter. Widget choice is driven by the parameter's type hint:
+    booleans become switches, numerics become number inputs, ``Literal`` and
+    ``Enum`` types become dropdowns, sequences become comma-separated text
+    inputs, and parameters typed as :class:`ImageOperation` /
+    :class:`ImagePipeline` become a placeholder "Edit" button (Phase 3 wires
+    the drill-down).
+
+    Component ids follow the pattern-matching shape ``{"type": "param-<kind>",
+    "prefix": form_id_prefix, "name": p.name}`` so multiple forms can coexist
+    without collisions.
+
+    Args:
+        op_info: Registry metadata for the operation being edited.
+        current_values: Mapping of parameter-name → current value used to seed
+            each widget. Missing keys fall back to the parameter default.
+        form_id_prefix: Prefix added to every emitted component id.
+
+    Returns:
+        ``dbc.Form`` whose children are one ``dbc.Row`` per parameter.
+
+    Examples:
+        >>> from phenotypic.gui import OperationRegistry
+        >>> registry = OperationRegistry()
+        >>> registry.discover()
+        >>> info = registry.get('GaussianBlur')
+        >>> form = param_form(info, current_values={'sigma': 2.0}, form_id_prefix='blur')
+        >>> isinstance(form.children, list)
+        True
+    """
+    rows: list[Any] = []
+    for p in op_info.parameters.values():
+        rows.append(
+            _param_row(
+                p,
+                current_values=current_values,
+                form_id_prefix=form_id_prefix,
+            )
+        )
+    return dbc.Form(rows)
+
+
+__all__ = [
+    "param_form",
+    "parse_list_value",
+    "parse_widget_value",
+    "serialize_param_for_widget",
+]

--- a/src/phenotypic/gui/builder/_session.py
+++ b/src/phenotypic/gui/builder/_session.py
@@ -1,0 +1,252 @@
+"""Per-session in-memory caches for images and pipeline intermediates.
+
+The Dash builder needs server-side storage for two things that are too big or
+too type-rich to round-trip through ``dcc.Store`` JSON:
+
+- The currently loaded :class:`phenotypic.Image` (or :class:`GridImage`).
+- The map of ``node_id -> intermediate`` produced by
+  :meth:`ImagePipeline.apply_with_intermediates`.
+
+Both live in a single :class:`IntermediatesCache` keyed by a per-tab uuid that
+the front end persists in a ``dcc.Store(storage_type='session')``. The cache
+is bounded — at most ``max_sessions`` distinct sessions, with eviction in
+FIFO order on the session-id list, and at most ``max_per_session``
+intermediates per session (LRU on the inner dict).
+
+Concurrency is handled with a single ``threading.Lock``. This is a deliberate
+single-process design — the SSH-tunneled HPCC use case does not require
+multi-process replication, and Dash's thread-per-request model is well within
+the lock's contention budget.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - type-only imports
+    from phenotypic import Image
+
+
+@dataclass
+class SessionData:
+    """Mutable per-session state.
+
+    Attributes:
+        image: The currently loaded :class:`phenotypic.Image` (or
+            :class:`GridImage`); ``None`` when nothing is loaded yet.
+        image_path: Path string from which ``image`` was loaded (informational).
+            ``None`` when ``image`` came from the synthetic plate fallback.
+        intermediates: ``node_id -> Image | DataFrame`` map of per-step
+            intermediates produced by the most recent preview run. Eviction
+            order is LRU (oldest accessed first). Maintained as an
+            :class:`OrderedDict` so :meth:`set_intermediate` can move accessed
+            keys to the end without copying.
+    """
+
+    image: Optional["Image"] = None
+    image_path: Optional[str] = None
+    intermediates: "OrderedDict[str, Any]" = field(default_factory=OrderedDict)
+
+
+class IntermediatesCache:
+    """Bounded LRU cache of per-session image + intermediates state.
+
+    Designed for a single-process Dash deployment behind an SSH tunnel.
+    Concurrency is coarse-grained: every public method takes a single lock,
+    which is fine at the request rates this app sees in practice.
+
+    Args:
+        max_sessions: Cap on the number of distinct session ids tracked.
+            FIFO eviction on the *insertion* order — the oldest session is
+            dropped when a new one would push the count over this cap.
+        max_per_session: Cap on the number of intermediates retained for any
+            single session. LRU eviction on the inner :class:`OrderedDict`.
+    """
+
+    def __init__(self, max_sessions: int = 4, max_per_session: int = 16) -> None:
+        self._max_sessions = max_sessions
+        self._max_per_session = max_per_session
+        # OrderedDict so we can FIFO-evict the oldest session.
+        self._sessions: "OrderedDict[str, SessionData]" = OrderedDict()
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_session(self, session_id: str) -> SessionData:
+        """Return the :class:`SessionData` for *session_id*, creating it lazily.
+
+        Caller must hold ``self._lock``.
+        """
+
+        data = self._sessions.get(session_id)
+        if data is None:
+            data = SessionData()
+            self._sessions[session_id] = data
+            self._evict_oldest_sessions()
+        return data
+
+    def _evict_oldest_sessions(self) -> None:
+        """Drop the oldest sessions until count <= ``self._max_sessions``."""
+
+        while len(self._sessions) > self._max_sessions:
+            self._sessions.popitem(last=False)
+
+    def _evict_oldest_intermediates(self, data: SessionData) -> None:
+        """Drop oldest intermediates until count <= ``self._max_per_session``."""
+
+        while len(data.intermediates) > self._max_per_session:
+            data.intermediates.popitem(last=False)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_image(
+        self, session_id: str
+    ) -> "tuple[Optional[Image], Optional[str]]":
+        """Return ``(image, path)`` for *session_id*, or ``(None, None)``.
+
+        Returning a tuple of immutable references avoids exposing the
+        mutable :class:`SessionData` to callers that would otherwise mutate
+        it outside the cache lock.
+
+        Args:
+            session_id: Per-tab uuid stored in ``STORE_SESSION_ID``.
+
+        Returns:
+            ``(image, image_path)`` for the session. Both elements are
+            ``None`` when nothing has been loaded yet.
+        """
+
+        with self._lock:
+            data = self._sessions.get(session_id)
+            if data is None:
+                return (None, None)
+            return (data.image, data.image_path)
+
+    def set_image(
+        self,
+        session_id: str,
+        image: "Image | None",
+        path: Optional[str],
+    ) -> None:
+        """Replace the cached image for *session_id*.
+
+        Clearing the image (passing ``None``) also clears any intermediates
+        derived from it, since their node-id labels would no longer match.
+
+        Args:
+            session_id: Per-tab uuid.
+            image: New :class:`Image` to cache, or ``None`` to clear.
+            path: Path string to remember alongside the image (informational).
+        """
+
+        with self._lock:
+            data = self._ensure_session(session_id)
+            data.image = image
+            data.image_path = path
+            if image is None:
+                data.intermediates.clear()
+
+    def set_intermediate(self, session_id: str, node_id: str, value: Any) -> None:
+        """Store *value* as the intermediate for *node_id*.
+
+        If *node_id* already exists, it's moved to the most-recently-used end.
+
+        Args:
+            session_id: Per-tab uuid.
+            node_id: ``StepNode.node_id`` produced by ``_state``.
+            value: An :class:`Image` (or :class:`pd.DataFrame` for measurement
+                / post-measurement steps).
+        """
+
+        with self._lock:
+            data = self._ensure_session(session_id)
+            if node_id in data.intermediates:
+                data.intermediates.pop(node_id)
+            data.intermediates[node_id] = value
+            self._evict_oldest_intermediates(data)
+
+    def get_intermediate(self, session_id: str, node_id: str) -> Any:
+        """Return the cached intermediate for *node_id*, or ``None``.
+
+        Touches the LRU order so frequently-viewed nodes survive eviction.
+
+        Args:
+            session_id: Per-tab uuid.
+            node_id: ``StepNode.node_id`` to look up.
+
+        Returns:
+            The cached value, or ``None`` if the session or node has no
+            recorded intermediate.
+        """
+
+        with self._lock:
+            data = self._sessions.get(session_id)
+            if data is None or node_id not in data.intermediates:
+                return None
+            value = data.intermediates.pop(node_id)
+            data.intermediates[node_id] = value  # bump to MRU end
+            return value
+
+    def clear(self, session_id: str) -> None:
+        """Drop the entire cache entry for *session_id*.
+
+        Args:
+            session_id: Per-tab uuid to forget.
+        """
+
+        with self._lock:
+            self._sessions.pop(session_id, None)
+
+    def known_intermediate_keys(self, session_id: str) -> list[str]:
+        """Snapshot the cached intermediate keys for *session_id*.
+
+        Useful for populating ``STORE_INTERMEDIATE_KEYS`` after a preview run
+        so the canvas can mark nodes that have a hot intermediate.
+
+        Args:
+            session_id: Per-tab uuid.
+
+        Returns:
+            Ordered list of node-ids currently cached (oldest -> newest).
+        """
+
+        with self._lock:
+            data = self._sessions.get(session_id)
+            if data is None:
+                return []
+            return list(data.intermediates.keys())
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton accessor
+# ---------------------------------------------------------------------------
+
+_GLOBAL_CACHE: Optional[IntermediatesCache] = None
+_GLOBAL_LOCK = threading.Lock()
+
+
+def get_cache() -> IntermediatesCache:
+    """Return the process-wide :class:`IntermediatesCache` singleton.
+
+    Lazy-initialised on first call. Thread-safe.
+
+    Returns:
+        The shared :class:`IntermediatesCache`. All callbacks should route
+        through this rather than constructing their own instance.
+    """
+
+    global _GLOBAL_CACHE
+    with _GLOBAL_LOCK:
+        if _GLOBAL_CACHE is None:
+            _GLOBAL_CACHE = IntermediatesCache()
+        return _GLOBAL_CACHE
+
+
+__all__ = ["SessionData", "IntermediatesCache", "get_cache"]

--- a/src/phenotypic/gui/builder/_state.py
+++ b/src/phenotypic/gui/builder/_state.py
@@ -1,0 +1,758 @@
+"""Pure-Python state model for the Dash pipeline builder.
+
+This module defines the dataclasses that back the builder canvas and the
+pure functions that translate between that in-memory state and a
+:class:`phenotypic.ImagePipeline`.  The data structures are intentionally
+JSON-friendly so they can travel through ``dcc.Store`` without losing
+fidelity.
+
+The module imports only stdlib + ``phenotypic``; no Dash dependencies.
+
+Examples:
+    Build a tiny scope and round-trip it through an ``ImagePipeline``:
+
+    >>> from phenotypic.gui.builder._state import (
+    ...     BuilderScope, StepNode, to_pipeline, from_pipeline,
+    ... )
+    >>> scope = BuilderScope(
+    ...     nodes=[StepNode(node_id="a1", class_name="GaussianBlur",
+    ...                     params={"sigma": 1.5})],
+    ...     name="demo",
+    ... )
+    >>> pipeline = to_pipeline(scope)
+    >>> from_pipeline(pipeline).nodes[0].class_name
+    'GaussianBlur'
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+from phenotypic import ImagePipeline
+from phenotypic.abc_ import ImageOperation, MeasureFeatures, PostMeasurement
+from phenotypic.gui._operation_registry import (
+    OperationRegistry,
+    get_registry,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Sentinel class name used for nested ``ImagePipeline`` step nodes.
+PIPELINE_CLASS_NAME = "ImagePipeline"
+
+
+@dataclass
+class StepNode:
+    """One step in a builder canvas.
+
+    A ``StepNode`` is the canvas-layer counterpart of a single operation in an
+    :class:`~phenotypic.ImagePipeline`.  It captures the class to instantiate,
+    the parameter values entered by the user, and (when the step is itself a
+    nested pipeline) the inner :class:`BuilderScope`.
+
+    Attributes:
+        node_id: Short, stable identifier (8-char hex slice of a UUID4).
+            Used as the cytoscape node id and to address sub-scopes via the
+            breadcrumb path.
+        class_name: Registry key (e.g. ``"GaussianBlur"``) or the sentinel
+            ``"ImagePipeline"`` when the node represents a nested pipeline.
+        params: Raw parameter values.  Scalars are stored as-is; values
+            corresponding to operation-typed parameters are stored as JSON
+            dicts shaped like ``{"__type__": "operation", "class_name": ...,
+            "params": {...}}``.
+        label: User-editable display name.  ``None`` means the canvas should
+            fall back to ``class_name``.
+        nested: Inner :class:`BuilderScope` populated only when
+            ``class_name == "ImagePipeline"``.
+    """
+
+    node_id: str
+    class_name: str
+    params: Dict[str, Any] = field(default_factory=dict)
+    label: Optional[str] = None
+    nested: Optional["BuilderScope"] = None
+
+
+@dataclass
+class BuilderScope:
+    """Linear ordered list of steps mixing ops/meas/post.
+
+    A scope corresponds to a single :class:`~phenotypic.ImagePipeline` once
+    converted via :func:`to_pipeline`.  Stage (ops/meas/post) is inferred per
+    node from its class via the operation registry.
+
+    Attributes:
+        nodes: Ordered :class:`StepNode` list.  Insertion order is the
+            execution order; partitioning into ops/meas/post happens at
+            convert time.
+        name: Pipeline ``name`` to assign on conversion.
+        desc: Pipeline ``desc`` to assign on conversion.
+        nrows: Optional grid row preset (forwarded to ``ImagePipeline``).
+        ncols: Optional grid column preset (forwarded to ``ImagePipeline``).
+    """
+
+    nodes: List[StepNode] = field(default_factory=list)
+    name: str = "Pipeline"
+    desc: str = ""
+    nrows: Optional[int] = None
+    ncols: Optional[int] = None
+
+
+@dataclass
+class BuilderState:
+    """Top-level state for the Dash builder.
+
+    Attributes:
+        root: The outermost :class:`BuilderScope`; what the user sees when
+            the breadcrumb is empty.
+        breadcrumb: Ordered list of breadcrumb segments describing how the
+            user has drilled into nested scopes.  Each segment is a dict of
+            the form ``{"node_id": <id>, "param": <param_name | None>}``.
+            ``param=None`` means a regular ``ImagePipeline`` drill-in (uses
+            ``StepNode.nested``); ``param=<name>`` means drilling into an
+            operation-typed parameter slot on a non-pipeline node.  Empty
+            list means "viewing ``root``".
+        selected_node_id: ``node_id`` of the currently focused step in the
+            visible scope, if any.
+    """
+
+    root: BuilderScope = field(default_factory=BuilderScope)
+    breadcrumb: List[Dict[str, Any]] = field(default_factory=list)
+    selected_node_id: Optional[str] = None
+
+
+# Sentinel key used to store synthesized singleton :class:`BuilderScope` dicts
+# inside a non-pipeline node's ``params`` while the user is editing an
+# operation-typed parameter through drill-down.  Stripped before
+# :func:`to_pipeline` so the underlying ``ImagePipeline`` never sees it.
+_PARAM_SCOPE_KEY = "__op_param_scope__"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_node_id() -> str:
+    """Return a fresh 8-character node identifier.
+
+    Returns:
+        Short hex string suitable for use as both ``StepNode.node_id`` and
+        the corresponding cytoscape node id.
+    """
+
+    return uuid.uuid4().hex[:8]
+
+
+def _is_operation_param_marker(value: Any) -> bool:
+    """Check if *value* is an op-typed parameter dict marker.
+
+    Args:
+        value: Candidate parameter value pulled from ``StepNode.params``.
+
+    Returns:
+        ``True`` when *value* looks like ``{"__type__": "operation", ...}``
+        (with either ``class_name`` or ``class``), otherwise ``False``.
+    """
+
+    if not isinstance(value, dict):
+        return False
+    if value.get("__type__") != "operation":
+        return False
+    return ("class_name" in value) or ("class" in value)
+
+
+def _is_pipeline_param_marker(value: Any) -> bool:
+    """Check if *value* is a pipeline-typed parameter dict marker.
+
+    Args:
+        value: Candidate parameter value pulled from ``StepNode.params``.
+
+    Returns:
+        ``True`` when *value* looks like a serialized nested pipeline
+        carrying a ``BuilderScope`` payload.
+    """
+
+    if not isinstance(value, dict):
+        return False
+    return value.get("__type__") in {"pipeline", "pipeline_operation"} and (
+        "scope" in value or "config" in value
+    )
+
+
+def _resolve_param_value(
+    value: Any, registry: OperationRegistry
+) -> Any:
+    """Recursively turn a stored param value into a runtime object.
+
+    Operation markers (``{"__type__": "operation", ...}``) are converted into
+    real :class:`~phenotypic.abc_.ImageOperation` instances; pipeline markers
+    are converted into :class:`~phenotypic.ImagePipeline` instances; scalars
+    pass through unchanged.
+
+    Args:
+        value: Raw parameter value from a :class:`StepNode`.
+        registry: Operation registry used for class lookup / instantiation.
+
+    Returns:
+        The resolved runtime value.
+    """
+
+    if _is_pipeline_param_marker(value):
+        scope_dict = value.get("scope")
+        if scope_dict is not None:
+            return to_pipeline(_scope_from_dict(scope_dict))
+        # Fallback for raw ``config`` payload (canonical to_json shape).
+        return ImagePipeline.from_json(value["config"])
+
+    if _is_operation_param_marker(value):
+        class_name = value.get("class_name") or value["class"]
+        inner_params = value.get("params", {}) or {}
+        resolved_inner = {
+            k: _resolve_param_value(v, registry) for k, v in inner_params.items()
+        }
+        return registry.create_instance(class_name, **resolved_inner)
+
+    if isinstance(value, list):
+        return [_resolve_param_value(v, registry) for v in value]
+
+    return value
+
+
+def _operation_to_param_dict(op: Any, registry: OperationRegistry) -> Dict[str, Any]:
+    """Serialize an ``ImageOperation`` instance into a JSON-friendly dict.
+
+    Used by :func:`from_pipeline` when capturing operation-typed params.
+
+    Args:
+        op: An :class:`ImageOperation` (or :class:`ImagePipeline`) instance.
+        registry: Registry used to enumerate the inner op's parameters so we
+            can recurse cleanly through nested op-typed values.
+
+    Returns:
+        A dict of shape ``{"__type__": "operation", "class_name": ...,
+        "params": {...}}`` (or ``{"__type__": "pipeline", "scope": ...}`` for
+        nested pipelines).
+    """
+
+    if isinstance(op, ImagePipeline):
+        return {
+            "__type__": "pipeline",
+            "class_name": PIPELINE_CLASS_NAME,
+            "scope": _scope_to_dict(from_pipeline(op)),
+        }
+
+    class_name = type(op).__name__
+    info = registry.get(class_name)
+    params: Dict[str, Any] = {}
+
+    if info is None:
+        # Fall back to ``__dict__`` introspection for unknown classes.
+        for key, value in vars(op).items():
+            if key.startswith("_"):
+                continue
+            params[key] = _serialize_param_value(value, registry)
+        return {
+            "__type__": "operation",
+            "class_name": class_name,
+            "params": params,
+        }
+
+    for param_name in info.parameters:
+        if not hasattr(op, param_name):
+            continue
+        current = getattr(op, param_name)
+        params[param_name] = _serialize_param_value(current, registry)
+
+    return {
+        "__type__": "operation",
+        "class_name": class_name,
+        "params": params,
+    }
+
+
+def _serialize_param_value(value: Any, registry: OperationRegistry) -> Any:
+    """Convert a runtime param value into a JSON-friendly representation.
+
+    Args:
+        value: Value pulled from an op instance via ``getattr``.
+        registry: Registry used when recursing into nested op params.
+
+    Returns:
+        A JSON-friendly value: scalars as-is, ``ImageOperation`` /
+        ``ImagePipeline`` instances as marker dicts, lists recursively
+        processed.
+    """
+
+    if isinstance(value, ImagePipeline):
+        return _operation_to_param_dict(value, registry)
+    if isinstance(value, ImageOperation):
+        return _operation_to_param_dict(value, registry)
+    if isinstance(value, (list, tuple)):
+        return [_serialize_param_value(v, registry) for v in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Public conversion API
+# ---------------------------------------------------------------------------
+
+
+def to_pipeline(scope: BuilderScope) -> ImagePipeline:
+    """Convert a :class:`BuilderScope` into an :class:`ImagePipeline`.
+
+    Each :class:`StepNode` is instantiated through the operation registry;
+    nested :class:`BuilderScope` references recurse to produce inner
+    :class:`ImagePipeline` instances.  The resulting instance list is
+    partitioned by ``isinstance`` against
+    :class:`~phenotypic.abc_.MeasureFeatures` /
+    :class:`~phenotypic.abc_.PostMeasurement` (everything else falls into
+    ``ops``, including nested pipelines), then handed to
+    :class:`ImagePipeline` so that ``__make_unique`` mints dict keys for us.
+
+    Args:
+        scope: The :class:`BuilderScope` to materialize.
+
+    Returns:
+        A fresh :class:`ImagePipeline` with ``ops``/``meas``/``post``
+        populated in the order implied by ``scope.nodes``.
+    """
+
+    registry = get_registry()
+    instances: List[Any] = []
+
+    for node in scope.nodes:
+        if node.class_name == PIPELINE_CLASS_NAME:
+            inner_scope = node.nested or BuilderScope()
+            instances.append(to_pipeline(inner_scope))
+            continue
+
+        resolved_params = {
+            name: _resolve_param_value(value, registry)
+            for name, value in node.params.items()
+            if name != _PARAM_SCOPE_KEY
+        }
+        instance = registry.create_instance(node.class_name, **resolved_params)
+        instances.append(instance)
+
+    ops_list: List[Any] = []
+    meas_list: List[MeasureFeatures] = []
+    post_list: List[PostMeasurement] = []
+
+    for inst in instances:
+        if isinstance(inst, MeasureFeatures):
+            meas_list.append(inst)
+        elif isinstance(inst, PostMeasurement):
+            post_list.append(inst)
+        else:
+            ops_list.append(inst)
+
+    return ImagePipeline(
+        ops=ops_list,
+        meas=meas_list,
+        post=post_list,
+        name=scope.name,
+        desc=scope.desc,
+        nrows=scope.nrows,
+        ncols=scope.ncols,
+    )
+
+
+def from_pipeline(pipeline: ImagePipeline) -> BuilderScope:
+    """Convert an :class:`ImagePipeline` back into a :class:`BuilderScope`.
+
+    Walks ``pipeline.get_ops()`` then ``get_meas()`` then ``get_post()`` to
+    preserve execution order and produces one :class:`StepNode` per entry.
+    Nested :class:`ImagePipeline` values inside ``_ops`` recurse via this
+    function; operation-typed parameters (per the registry) are captured as
+    JSON-friendly marker dicts.
+
+    Args:
+        pipeline: The pipeline to mirror.
+
+    Returns:
+        A :class:`BuilderScope` whose ``nodes`` reproduce the pipeline's
+        contents in execution order.
+    """
+
+    registry = get_registry()
+    nodes: List[StepNode] = []
+
+    pairs: List[tuple[str, Any]] = []
+    pairs.extend(pipeline.get_ops().items())
+    pairs.extend(pipeline.get_meas().items())
+    pairs.extend(pipeline.get_post().items())
+
+    for name, op in pairs:
+        node_id = _new_node_id()
+
+        if isinstance(op, ImagePipeline):
+            nodes.append(
+                StepNode(
+                    node_id=node_id,
+                    class_name=PIPELINE_CLASS_NAME,
+                    params={},
+                    label=name,
+                    nested=from_pipeline(op),
+                )
+            )
+            continue
+
+        class_name = type(op).__name__
+        info = registry.get(class_name)
+        params: Dict[str, Any] = {}
+
+        if info is None:
+            # Unknown to the registry: fall back to ``vars`` introspection.
+            for key, value in vars(op).items():
+                if key.startswith("_"):
+                    continue
+                params[key] = _serialize_param_value(value, registry)
+        else:
+            for param_name, param_info in info.parameters.items():
+                if not hasattr(op, param_name):
+                    continue
+                current = getattr(op, param_name)
+                if (param_info.is_operation or param_info.is_pipeline) and current is None:
+                    params[param_name] = None
+                else:
+                    params[param_name] = _serialize_param_value(current, registry)
+
+        nodes.append(
+            StepNode(
+                node_id=node_id,
+                class_name=class_name,
+                params=params,
+                label=name,
+                nested=None,
+            )
+        )
+
+    return BuilderScope(
+        nodes=nodes,
+        name=pipeline.name,
+        desc=pipeline._desc if pipeline._desc is not None else "",
+        nrows=pipeline.nrows,
+        ncols=pipeline.ncols,
+    )
+
+
+def _normalize_breadcrumb_segment(seg: Any) -> Dict[str, Any]:
+    """Coerce a breadcrumb segment to ``{"node_id": ..., "param": ...}`` form.
+
+    Accepts both the legacy plain-string form (``"<node_id>"``) and the new
+    dict form so that existing JSON dumps continue to load.
+
+    Args:
+        seg: A breadcrumb entry, either a string (legacy) or a dict.
+
+    Returns:
+        A dict with required ``node_id`` and (possibly ``None``) ``param``
+        keys.
+    """
+
+    if isinstance(seg, str):
+        return {"node_id": seg, "param": None}
+    if isinstance(seg, dict) and "node_id" in seg:
+        return {"node_id": seg["node_id"], "param": seg.get("param")}
+    raise ValueError(f"unrecognised breadcrumb segment: {seg!r}")
+
+
+def _ensure_param_scope(node: StepNode, param_name: str) -> BuilderScope:
+    """Return (creating if absent) the synthesized scope for an op-typed param.
+
+    The scope lives under ``node.params[_PARAM_SCOPE_KEY][param_name]`` as a
+    dict produced by :func:`_scope_to_dict` so it round-trips through JSON
+    cleanly.  This helper rehydrates it into a :class:`BuilderScope` and
+    seeds it from any existing operation-marker stored in
+    ``node.params[param_name]``.
+
+    Args:
+        node: Parent step node that owns the parameter slot.
+        param_name: Name of the operation-typed parameter being edited.
+
+    Returns:
+        The synthesised :class:`BuilderScope` (one node max).
+    """
+
+    scopes = node.params.setdefault(_PARAM_SCOPE_KEY, {})
+    scope_dict = scopes.get(param_name)
+    if scope_dict is None:
+        seed_node: Optional[StepNode] = None
+        existing = node.params.get(param_name)
+        if isinstance(existing, dict) and _is_operation_param_marker(existing):
+            class_name = existing.get("class_name") or existing.get("class")
+            seed_node = StepNode(
+                node_id=_new_node_id(),
+                class_name=str(class_name),
+                params=dict(existing.get("params") or {}),
+                label=str(class_name),
+            )
+        elif isinstance(existing, dict) and _is_pipeline_param_marker(existing):
+            seed_node = StepNode(
+                node_id=_new_node_id(),
+                class_name=PIPELINE_CLASS_NAME,
+                params={},
+                label=PIPELINE_CLASS_NAME,
+                nested=_scope_from_dict(existing.get("scope") or {}),
+            )
+        scope = BuilderScope(
+            nodes=[seed_node] if seed_node is not None else [],
+            name=f"{node.label or node.class_name}.{param_name}",
+        )
+        scopes[param_name] = _scope_to_dict(scope)
+        return scope
+    return _scope_from_dict(scope_dict)
+
+
+def _commit_param_scope(node: StepNode, param_name: str) -> None:
+    """Mirror the singleton scope back into ``node.params[param_name]``.
+
+    Called when the user drills out of an operation-typed-parameter scope so
+    that the canonical serialized form (an operation marker dict) reflects
+    whatever the user assembled inside the singleton.
+
+    Args:
+        node: Parent step node owning the param slot.
+        param_name: Operation-typed parameter being committed.
+    """
+
+    scopes = node.params.get(_PARAM_SCOPE_KEY) or {}
+    scope_dict = scopes.get(param_name)
+    if scope_dict is None:
+        return
+
+    scope = _scope_from_dict(scope_dict)
+    if not scope.nodes:
+        node.params[param_name] = None
+        return
+
+    inner = scope.nodes[0]
+    if inner.class_name == PIPELINE_CLASS_NAME:
+        node.params[param_name] = {
+            "__type__": "pipeline",
+            "class_name": PIPELINE_CLASS_NAME,
+            "scope": _scope_to_dict(inner.nested or BuilderScope()),
+        }
+    else:
+        node.params[param_name] = {
+            "__type__": "operation",
+            "class_name": inner.class_name,
+            "params": {
+                k: v for k, v in inner.params.items() if k != _PARAM_SCOPE_KEY
+            },
+        }
+
+
+def current_scope(state: BuilderState) -> BuilderScope:
+    """Resolve the breadcrumb to the scope the user is currently editing.
+
+    Walks each segment in turn:
+
+    * For a regular pipeline drill (``param=None``), descends into
+      ``match.nested``.
+    * For an op-typed parameter drill (``param=<name>``), descends into the
+      synthesised singleton scope stored under
+      ``match.params[_PARAM_SCOPE_KEY][param]`` (created lazily on first
+      visit, seeded from any existing operation-marker dict at
+      ``match.params[param]``).
+
+    Args:
+        state: The full :class:`BuilderState`.
+
+    Returns:
+        The :class:`BuilderScope` referenced by the breadcrumb.
+
+    Raises:
+        KeyError: If a ``node_id`` in the breadcrumb cannot be located in
+            its parent scope, or if the matching pipeline node has no nested
+            scope.
+    """
+
+    scope = state.root
+    for raw in state.breadcrumb:
+        seg = _normalize_breadcrumb_segment(raw)
+        node_id = seg["node_id"]
+        param = seg.get("param")
+        match = next((n for n in scope.nodes if n.node_id == node_id), None)
+        if match is None:
+            raise KeyError(
+                f"breadcrumb node_id {node_id!r} not found in current scope"
+            )
+        if param is None:
+            if match.nested is None:
+                raise KeyError(
+                    f"breadcrumb node_id {node_id!r} does not have a nested scope"
+                )
+            scope = match.nested
+        else:
+            scope = _ensure_param_scope(match, param)
+    return scope
+
+
+def stage_of(class_name: str) -> Literal["ops", "meas", "post"]:
+    """Return the pipeline stage a class belongs to.
+
+    Args:
+        class_name: Registry key (e.g. ``"OtsuDetector"``) or the
+            ``"ImagePipeline"`` sentinel.
+
+    Returns:
+        ``"meas"`` if the class is a :class:`MeasureFeatures` subclass,
+        ``"post"`` if it's a :class:`PostMeasurement` subclass, otherwise
+        ``"ops"`` (which is also the bucket for nested pipelines).
+
+    Raises:
+        KeyError: If *class_name* is not registered (and is not the
+            ``ImagePipeline`` sentinel).
+    """
+
+    if class_name == PIPELINE_CLASS_NAME:
+        return "ops"
+
+    registry = get_registry()
+    info = registry.get(class_name)
+    if info is None:
+        raise KeyError(f"Operation '{class_name}' not found in registry")
+
+    cls = info.cls
+    if issubclass(cls, MeasureFeatures):
+        return "meas"
+    if issubclass(cls, PostMeasurement):
+        return "post"
+    return "ops"
+
+
+# ---------------------------------------------------------------------------
+# JSON serialization for ``dcc.Store``
+# ---------------------------------------------------------------------------
+
+
+def _scope_to_dict(scope: BuilderScope) -> Dict[str, Any]:
+    """Recursively dump a :class:`BuilderScope` to a JSON-friendly dict.
+
+    Args:
+        scope: The scope to serialize.
+
+    Returns:
+        A nested dict mirroring the :class:`BuilderScope` shape.
+    """
+
+    return {
+        "nodes": [_node_to_dict(n) for n in scope.nodes],
+        "name": scope.name,
+        "desc": scope.desc,
+        "nrows": scope.nrows,
+        "ncols": scope.ncols,
+    }
+
+
+def _node_to_dict(node: StepNode) -> Dict[str, Any]:
+    """Recursively dump a :class:`StepNode` to a JSON-friendly dict.
+
+    Args:
+        node: The node to serialize.
+
+    Returns:
+        A dict mirroring the :class:`StepNode` shape, with ``nested``
+        recursed via :func:`_scope_to_dict`.
+    """
+
+    return {
+        "node_id": node.node_id,
+        "class_name": node.class_name,
+        "params": node.params,
+        "label": node.label,
+        "nested": _scope_to_dict(node.nested) if node.nested is not None else None,
+    }
+
+
+def _scope_from_dict(data: Dict[str, Any]) -> BuilderScope:
+    """Inverse of :func:`_scope_to_dict`.
+
+    Args:
+        data: Dict previously produced by :func:`_scope_to_dict` (or an
+            equivalent JSON payload).
+
+    Returns:
+        A reconstructed :class:`BuilderScope`.
+    """
+
+    nodes = [_node_from_dict(n) for n in data.get("nodes", [])]
+    return BuilderScope(
+        nodes=nodes,
+        name=data.get("name", "Pipeline"),
+        desc=data.get("desc", ""),
+        nrows=data.get("nrows"),
+        ncols=data.get("ncols"),
+    )
+
+
+def _node_from_dict(data: Dict[str, Any]) -> StepNode:
+    """Inverse of :func:`_node_to_dict`.
+
+    Args:
+        data: Dict previously produced by :func:`_node_to_dict`.
+
+    Returns:
+        A reconstructed :class:`StepNode` (with nested scope recursed).
+    """
+
+    nested_data = data.get("nested")
+    nested = _scope_from_dict(nested_data) if nested_data is not None else None
+    return StepNode(
+        node_id=data["node_id"],
+        class_name=data["class_name"],
+        params=data.get("params", {}) or {},
+        label=data.get("label"),
+        nested=nested,
+    )
+
+
+def state_to_json(state: BuilderState) -> Dict[str, Any]:
+    """Convert a :class:`BuilderState` into a JSON-friendly dict.
+
+    Suitable for round-tripping through ``dcc.Store``; the output contains
+    only stdlib-compatible types (``dict``, ``list``, ``str``, ``int``,
+    ``float``, ``bool``, ``None``) provided the underlying ``StepNode.params``
+    values are themselves JSON-friendly (which is the contract for the GUI
+    layer).
+
+    Args:
+        state: The state to serialize.
+
+    Returns:
+        Dict with ``root``, ``breadcrumb``, and ``selected_node_id`` keys.
+    """
+
+    return {
+        "root": _scope_to_dict(state.root),
+        "breadcrumb": list(state.breadcrumb),
+        "selected_node_id": state.selected_node_id,
+    }
+
+
+def state_from_json(data: Dict[str, Any]) -> BuilderState:
+    """Inverse of :func:`state_to_json`.
+
+    Args:
+        data: Dict previously produced by :func:`state_to_json` or an
+            equivalent JSON payload.
+
+    Returns:
+        A reconstructed :class:`BuilderState`.
+    """
+
+    root_data = data.get("root")
+    root = _scope_from_dict(root_data) if root_data is not None else BuilderScope()
+    raw_crumbs = data.get("breadcrumb", []) or []
+    crumbs = [_normalize_breadcrumb_segment(seg) for seg in raw_crumbs]
+    return BuilderState(
+        root=root,
+        breadcrumb=crumbs,
+        selected_node_id=data.get("selected_node_id"),
+    )

--- a/src/phenotypic/gui/builder/assets/builder.css
+++ b/src/phenotypic/gui/builder/assets/builder.css
@@ -1,0 +1,82 @@
+/* PhenoTypic Pipeline Builder — visual styles auto-loaded by Dash.
+ *
+ * Dash discovers any *.css under an ``assets/`` folder colocated with the
+ * module that calls ``dash.Dash(__name__)``
+ * (``phenotypic/gui/builder/_app.py``). No manual <link> registration needed.
+ */
+
+/* ===========================================================================
+ * Scroll affordance — explicit chevron indicators
+ *
+ * Markup contract:
+ *   <div class="pheno-scroll-wrap">
+ *       <div class="pheno-scroll" ...>...</div>
+ *   </div>
+ *
+ * The companion script (``builder.js``) sets ``data-more-up="1"`` and/or
+ * ``data-more-down="1"`` on the wrapper based on the inner scroll element's
+ * ``scrollTop``, ``scrollHeight``, and ``clientHeight``. The CSS reveals the
+ * appropriate chevron only when its data attribute is present, so each
+ * indicator appears strictly when there is content to scroll toward.
+ * ========================================================================= */
+
+.pheno-scroll-wrap {
+    position: relative;
+}
+
+/* Inner scroll container — bare, no shadows. The chevrons live on the
+ * wrapper, which is more reliable across browsers than ``background-
+ * attachment: local`` (which struggles when child elements have their own
+ * backgrounds, e.g. the accordion). */
+.pheno-scroll {
+    position: relative;
+}
+
+/* Shared base style for both chevrons. Rendered as round badges anchored to
+ * the right edge of the scroll container so they don't span the full width
+ * (full-width banners visually compete with the content underneath). */
+.pheno-scroll-wrap::before,
+.pheno-scroll-wrap::after {
+    content: "";
+    position: absolute;
+    right: 6px;
+    width: 24px;
+    height: 24px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.18s ease-in-out;
+    z-index: 5;
+    background-color: rgba(255, 255, 255, 0.96);
+    border: 1px solid rgba(0, 0, 0, 0.12);
+    border-radius: 50%;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 14px 14px;
+}
+
+.pheno-scroll-wrap::before {
+    top: 6px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='%23495057' d='M7.247 4.86l-4.796 5.481c-.566.647-.106 1.659.753 1.659h9.592a1 1 0 0 0 .753-1.659l-4.796-5.48a1 1 0 0 0-1.506 0z'/></svg>");
+}
+
+.pheno-scroll-wrap::after {
+    bottom: 6px;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='%23495057' d='M7.247 11.14l-4.796-5.481C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/></svg>");
+}
+
+/* Chevron visibility is driven by data attributes the JS sets at scroll /
+ * resize / mutation time. Absent attribute = chevron stays at opacity 0. */
+.pheno-scroll-wrap[data-more-up="1"]::before {
+    opacity: 1;
+}
+
+.pheno-scroll-wrap[data-more-down="1"]::after {
+    opacity: 1;
+}
+
+/* Section spacing — keeps consecutive palette sections (Operations,
+ * Measurements, Post-measurements) tight against each other. */
+.pheno-palette-section + .pheno-palette-section {
+    margin-top: 0.75rem;
+}

--- a/src/phenotypic/gui/builder/assets/builder.js
+++ b/src/phenotypic/gui/builder/assets/builder.js
@@ -1,0 +1,226 @@
+/* PhenoTypic Pipeline Builder — clientside helpers (auto-loaded by Dash).
+ *
+ * Exposes ``window.phenoGetCy()`` so clientside callbacks (registered in
+ * ``_callbacks.py``) can drive the cytoscape canvas directly via its native
+ * API — ``cy.fit()`` / ``cy.zoom()`` — instead of fighting dash-cytoscape's
+ * prop change detection.
+ */
+
+(function () {
+    "use strict";
+
+    /** Locate the live cytoscape.js instance backing the dash-cytoscape
+     *  component with id ``canvas-cytoscape``.
+     *
+     *  Tries (in order):
+     *    1. The cytoscape.js registry attached to the container element.
+     *    2. The React fiber tree, walking down looking for a node whose
+     *       ``stateNode`` exposes ``_cy`` or ``cy``.
+     *
+     *  Returns the cy instance, or ``null`` if it can't be located (e.g.
+     *  before the canvas has finished mounting).
+     */
+    window.phenoGetCy = function phenoGetCy() {
+        const container = document.getElementById("canvas-cytoscape");
+        if (!container) return null;
+
+        // 1. cytoscape.js attaches the instance via ``_cyreg`` on the container.
+        if (container._cyreg && container._cyreg.cy) {
+            return container._cyreg.cy;
+        }
+
+        // 2. Walk the React fiber tree from the wrapper.
+        const wrap =
+            document.getElementById("canvas-cytoscape-wrapper") || container;
+        const fiberKey = Object.keys(wrap).find(
+            (k) => k.startsWith("__reactFiber") || k.startsWith("__reactInternalInstance"),
+        );
+        if (!fiberKey) return null;
+
+        const stack = [wrap[fiberKey]];
+        const seen = new Set();
+        while (stack.length) {
+            const node = stack.pop();
+            if (!node || seen.has(node)) continue;
+            seen.add(node);
+            const inst = node.stateNode;
+            if (inst) {
+                if (inst._cy) return inst._cy;
+                if (inst.cy) return inst.cy;
+            }
+            if (node.child) stack.push(node.child);
+            if (node.sibling) stack.push(node.sibling);
+        }
+        return null;
+    };
+
+    /* Watch the cytoscape container for size changes (the layout settles
+     * after fonts load, accordions expand, etc.) and call ``cy.resize()`` +
+     * ``cy.fit()`` so the chain is always centered. ``cy.resize()`` is a
+     * no-op when the size genuinely hasn't changed; ``cy.fit()`` re-centers
+     * without re-running the layout algorithm so user-dragged positions
+     * are preserved. */
+    function watchCanvasResize() {
+        const container = document.getElementById("canvas-cytoscape");
+        if (!container || typeof ResizeObserver === "undefined") return;
+        let lastW = 0,
+            lastH = 0;
+        const ro = new ResizeObserver(() => {
+            const cy = window.phenoGetCy();
+            if (!cy) return;
+            const w = cy.width();
+            const h = cy.height();
+            if (w === lastW && h === lastH) return;
+            lastW = w;
+            lastH = h;
+            if (w > 0 && h > 0) {
+                cy.resize();
+                cy.fit(undefined, 24);
+            }
+        });
+        ro.observe(container);
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", watchCanvasResize);
+    } else {
+        // ``setTimeout`` defers past Dash's initial render so the cytoscape
+        // component has had time to mount its container.
+        setTimeout(watchCanvasResize, 100);
+    }
+    // Re-bind whenever Dash swaps the canvas wrapper subtree.
+    new MutationObserver(() => {
+        const c = document.getElementById("canvas-cytoscape");
+        if (c && !c.__phenoResizeBound) {
+            c.__phenoResizeBound = true;
+            watchCanvasResize();
+        }
+    }).observe(document.body, { childList: true, subtree: true });
+})();
+
+
+/* PhenoTypic Pipeline Builder — scroll affordance helper.
+ *
+ * Dash auto-loads any *.js under the ``assets/`` folder colocated with the
+ * module that calls ``dash.Dash(__name__)``. This script wires the
+ * ``data-more-up`` / ``data-more-down`` attributes on each
+ * ``.pheno-scroll-wrap`` so its CSS chevrons (top / bottom) appear strictly
+ * when there is content above / below the visible viewport.
+ *
+ * Designed to survive Dash callbacks that swap subtrees (e.g. the inspector):
+ * a single MutationObserver re-attaches scroll listeners whenever a new
+ * ``.pheno-scroll-wrap`` is inserted into the DOM.
+ */
+
+(function () {
+    "use strict";
+
+    const TOP_THRESHOLD = 4;
+    const BOTTOM_THRESHOLD = 4;
+
+    /** Update wrapper data attributes for the current inner-scroll metrics. */
+    function refreshIndicators(wrap) {
+        const inner = wrap.querySelector(".pheno-scroll");
+        if (!inner) {
+            wrap.removeAttribute("data-more-up");
+            wrap.removeAttribute("data-more-down");
+            return;
+        }
+        const scrollTop = inner.scrollTop;
+        const scrollHeight = inner.scrollHeight;
+        const clientHeight = inner.clientHeight;
+        const overflows = scrollHeight - clientHeight > 1;
+
+        const moreUp = overflows && scrollTop > TOP_THRESHOLD;
+        const moreDown =
+            overflows && scrollTop + clientHeight < scrollHeight - BOTTOM_THRESHOLD;
+
+        if (moreUp) {
+            wrap.setAttribute("data-more-up", "1");
+        } else {
+            wrap.removeAttribute("data-more-up");
+        }
+        if (moreDown) {
+            wrap.setAttribute("data-more-down", "1");
+        } else {
+            wrap.removeAttribute("data-more-down");
+        }
+    }
+
+    /** Bind scroll + resize listeners to a single wrapper. Idempotent. */
+    function bindWrapper(wrap) {
+        if (wrap.__phenoScrollBound) return;
+        wrap.__phenoScrollBound = true;
+
+        const inner = wrap.querySelector(".pheno-scroll");
+        if (!inner) return;
+
+        // Scroll listener (passive — read-only metrics).
+        inner.addEventListener("scroll", () => refreshIndicators(wrap), {
+            passive: true,
+        });
+
+        // ResizeObserver covers content additions/removals (palette grows,
+        // inspector form swaps in, viewport resizes).
+        if (typeof ResizeObserver !== "undefined") {
+            const ro = new ResizeObserver(() => refreshIndicators(wrap));
+            ro.observe(inner);
+            // Observe a few likely children so adding a tall accordion section
+            // updates the indicators without a manual scroll.
+            for (const child of inner.children) {
+                ro.observe(child);
+            }
+        }
+
+        // Initial paint.
+        // Defer one frame so layout has settled (Bootstrap accordions need a
+        // tick to compute their own heights).
+        requestAnimationFrame(() => refreshIndicators(wrap));
+    }
+
+    /** Discover and bind every ``.pheno-scroll-wrap`` currently in the DOM. */
+    function bindAll(root) {
+        const scope = root || document;
+        const wraps = scope.querySelectorAll(".pheno-scroll-wrap");
+        wraps.forEach(bindWrapper);
+        // Bootstrap accordions emit transitionend events when expanding —
+        // refresh the indicators after each so the post-expand height is
+        // reflected immediately.
+        scope
+            .querySelectorAll(".pheno-scroll-wrap .accordion-collapse")
+            .forEach((collapse) => {
+                if (collapse.__phenoTransitionBound) return;
+                collapse.__phenoTransitionBound = true;
+                collapse.addEventListener("transitionend", () => {
+                    const wrap = collapse.closest(".pheno-scroll-wrap");
+                    if (wrap) refreshIndicators(wrap);
+                });
+            });
+    }
+
+    function watchForNewWrappers() {
+        const observer = new MutationObserver((mutations) => {
+            for (const m of mutations) {
+                for (const node of m.addedNodes) {
+                    if (!(node instanceof Element)) continue;
+                    if (node.classList && node.classList.contains("pheno-scroll-wrap")) {
+                        bindWrapper(node);
+                    }
+                    bindAll(node);
+                }
+            }
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    function start() {
+        bindAll();
+        watchForNewWrappers();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", start);
+    } else {
+        start();
+    }
+})();

--- a/tests/gui/builder/test_callbacks.py
+++ b/tests/gui/builder/test_callbacks.py
@@ -1,0 +1,173 @@
+"""Unit tests for the pure mutation helper in :mod:`_callbacks`.
+
+These tests exercise :func:`_dispatch_state_update` without booting a Dash
+server: it's a JSON-in / JSON-out function, so we can validate the full
+mutation surface in milliseconds.
+"""
+
+from __future__ import annotations
+
+from phenotypic.gui.builder._callbacks import _dispatch_state_update
+from phenotypic.gui.builder._state import (
+    BuilderScope,
+    BuilderState,
+    StepNode,
+    state_to_json,
+)
+
+
+def _seed_state() -> dict:
+    """Return a JSON state dict with two ops at the root scope."""
+
+    state = BuilderState(
+        root=BuilderScope(
+            nodes=[
+                StepNode(node_id="aaa", class_name="GaussianBlur"),
+                StepNode(node_id="bbb", class_name="OtsuDetector"),
+            ],
+            name="root",
+        ),
+    )
+    return state_to_json(state)
+
+
+def test_add_node_appends_and_selects() -> None:
+    """``add_node`` appends to the visible scope and updates ``selected_node_id``."""
+
+    state = _seed_state()
+    out = _dispatch_state_update(state, "add_node", {"class_name": "MeasureSize"})
+
+    assert len(out["root"]["nodes"]) == 3
+    assert out["root"]["nodes"][-1]["class_name"] == "MeasureSize"
+    assert out["selected_node_id"] == out["root"]["nodes"][-1]["node_id"]
+    # Original input is not mutated.
+    assert len(state["root"]["nodes"]) == 2
+
+
+def test_delete_node_removes_selection() -> None:
+    """``delete_node`` removes the selected node and clears ``selected_node_id``."""
+
+    state = _seed_state()
+    state["selected_node_id"] = "aaa"
+
+    out = _dispatch_state_update(state, "delete_node", {})
+    remaining = [n["node_id"] for n in out["root"]["nodes"]]
+    assert remaining == ["bbb"]
+    assert out["selected_node_id"] is None
+
+
+def test_edit_param_writes_into_node() -> None:
+    """``edit_param`` writes ``params[name]`` into the addressed node."""
+
+    state = _seed_state()
+
+    out = _dispatch_state_update(
+        state,
+        "edit_param",
+        {"node_id": "aaa", "name": "sigma", "value": 2.5, "omit": False},
+    )
+    blur = next(n for n in out["root"]["nodes"] if n["node_id"] == "aaa")
+    assert blur["params"]["sigma"] == 2.5
+
+
+def test_edit_param_with_omit_strips_key() -> None:
+    """``edit_param`` with ``omit=True`` removes the param entirely."""
+
+    state = _seed_state()
+    state["root"]["nodes"][0]["params"]["sigma"] = 1.0
+
+    out = _dispatch_state_update(
+        state,
+        "edit_param",
+        {"node_id": "aaa", "name": "sigma", "omit": True},
+    )
+    blur = next(n for n in out["root"]["nodes"] if n["node_id"] == "aaa")
+    assert "sigma" not in blur["params"]
+
+
+def test_reorder_swaps_nodes() -> None:
+    """``reorder`` re-sequences the visible scope to match the supplied order."""
+
+    state = _seed_state()
+    out = _dispatch_state_update(
+        state,
+        "reorder",
+        {"order": ["bbb", "aaa"]},
+    )
+    assert [n["node_id"] for n in out["root"]["nodes"]] == ["bbb", "aaa"]
+
+
+def test_drill_in_pushes_breadcrumb_when_node_has_nested_scope() -> None:
+    """Drill-in pushes onto the breadcrumb only when the node has ``nested``."""
+
+    state = state_to_json(
+        BuilderState(
+            root=BuilderScope(
+                nodes=[
+                    StepNode(
+                        node_id="pipe",
+                        class_name="ImagePipeline",
+                        nested=BuilderScope(name="inner"),
+                    ),
+                ],
+            ),
+            selected_node_id="pipe",
+        )
+    )
+    out = _dispatch_state_update(state, "drill_in", {})
+    assert out["breadcrumb"] == [{"node_id": "pipe", "param": None}]
+    assert out["selected_node_id"] is None
+
+
+def test_drill_in_param_round_trip() -> None:
+    """Drilling into an op-typed param scope and back commits the inner node.
+
+    The mutation should:
+
+    1. Append a ``{"node_id", "param"}`` segment to the breadcrumb.
+    2. Seed an empty singleton scope under the param key.
+    3. After adding a node inside and walking back, the inner node's
+       serialized operation marker should land on
+       ``parent.params[param_name]``.
+    """
+
+    state = state_to_json(
+        BuilderState(
+            root=BuilderScope(
+                nodes=[
+                    StepNode(node_id="parent", class_name="GaussianBlur"),
+                ],
+            ),
+            selected_node_id="parent",
+        )
+    )
+
+    # Drill in.
+    after_drill = _dispatch_state_update(
+        state,
+        "drill_in_param",
+        {"node_id": "parent", "param_name": "sub_op"},
+    )
+    assert after_drill["breadcrumb"] == [
+        {"node_id": "parent", "param": "sub_op"}
+    ]
+
+    # Add a node inside the singleton scope (drill_in_param already pushed
+    # the breadcrumb, so subsequent ``add_node`` lands inside the param scope).
+    after_add = _dispatch_state_update(
+        after_drill, "add_node", {"class_name": "OtsuDetector"}
+    )
+    parent = after_add["root"]["nodes"][0]
+    inner_scope = parent["params"]["__op_param_scope__"]["sub_op"]
+    assert len(inner_scope["nodes"]) == 1
+    assert inner_scope["nodes"][0]["class_name"] == "OtsuDetector"
+
+    # Drill back out via breadcrumb_to depth=0.
+    after_out = _dispatch_state_update(
+        after_add, "breadcrumb_to", {"depth": 0}
+    )
+    parent = after_out["root"]["nodes"][0]
+    marker = parent["params"]["sub_op"]
+    assert marker is not None
+    assert marker["__type__"] == "operation"
+    assert marker["class_name"] == "OtsuDetector"

--- a/tests/gui/builder/test_state_roundtrip.py
+++ b/tests/gui/builder/test_state_roundtrip.py
@@ -1,0 +1,296 @@
+"""Round-trip tests for :mod:`phenotypic.gui.builder._state`.
+
+These tests exercise the pure-Python state model defined for the Dash
+pipeline builder.  They convert :class:`BuilderScope` instances to
+:class:`~phenotypic.ImagePipeline` and back, asserting that class names,
+labels, scalar params, nested pipelines, and operation-typed parameters all
+survive the trip.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from phenotypic import ImagePipeline
+from phenotypic.gui._operation_registry import get_registry
+from phenotypic.gui.builder._state import (
+    BuilderScope,
+    BuilderState,
+    StepNode,
+    current_scope,
+    from_pipeline,
+    stage_of,
+    state_from_json,
+    state_to_json,
+    to_pipeline,
+)
+
+
+def test_flat_pipeline_roundtrip() -> None:
+    """A linear ops/meas chain survives ``to_pipeline`` -> ``from_pipeline``."""
+
+    registry = get_registry()
+    for required in ("GaussianBlur", "OtsuDetector", "MeasureSize"):
+        assert registry.get(required) is not None, (
+            f"Expected '{required}' in the operation registry"
+        )
+
+    scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="aaaa1111",
+                class_name="GaussianBlur",
+                params={"sigma": 2.0},
+                label="GaussianBlur",
+            ),
+            StepNode(
+                node_id="bbbb2222",
+                class_name="OtsuDetector",
+                params={"ignore_zeros": False, "ignore_borders": True},
+                label="OtsuDetector",
+            ),
+            StepNode(
+                node_id="cccc3333",
+                class_name="MeasureSize",
+                params={},
+                label="MeasureSize",
+            ),
+        ],
+        name="flat_demo",
+        desc="three-step demo pipeline",
+    )
+
+    pipeline = to_pipeline(scope)
+
+    assert isinstance(pipeline, ImagePipeline)
+    assert pipeline.name == "flat_demo"
+    assert list(pipeline.get_ops().keys()) == ["GaussianBlur", "OtsuDetector"]
+    assert list(pipeline.get_meas().keys()) == ["MeasureSize"]
+    assert pipeline.get_ops()["GaussianBlur"].sigma == 2.0
+    assert pipeline.get_ops()["OtsuDetector"].ignore_borders is True
+
+    # to_json round-trip should be JSON-serializable.
+    json_str = pipeline.to_json()
+    assert isinstance(json_str, str)
+    parsed = json.loads(json_str)
+    assert "pipe_cfgs" in parsed and "meas" in parsed
+
+    # from_pipeline should mirror the structure (with fresh node_ids and
+    # canonical labels coming from the minted dict keys).
+    rebuilt_scope = from_pipeline(pipeline)
+    assert [n.class_name for n in rebuilt_scope.nodes] == [
+        "GaussianBlur",
+        "OtsuDetector",
+        "MeasureSize",
+    ]
+    assert [n.label for n in rebuilt_scope.nodes] == [
+        "GaussianBlur",
+        "OtsuDetector",
+        "MeasureSize",
+    ]
+    assert rebuilt_scope.nodes[0].params["sigma"] == 2.0
+    assert rebuilt_scope.nodes[1].params["ignore_borders"] is True
+
+    # state-level JSON round-trip
+    state = BuilderState(root=scope)
+    state_json = state_to_json(state)
+    json.dumps(state_json)  # must be JSON-serializable in stdlib
+    rehydrated = state_from_json(state_json)
+    assert [n.class_name for n in rehydrated.root.nodes] == [
+        "GaussianBlur",
+        "OtsuDetector",
+        "MeasureSize",
+    ]
+    assert rehydrated.root.nodes[0].params["sigma"] == 2.0
+
+
+def test_nested_pipeline_roundtrip() -> None:
+    """A nested ``ImagePipeline`` step survives a full round-trip."""
+
+    inner_scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="inner001",
+                class_name="GaussianBlur",
+                params={"sigma": 1.25},
+                label="GaussianBlur",
+            ),
+            StepNode(
+                node_id="inner002",
+                class_name="OtsuDetector",
+                params={"ignore_zeros": True, "ignore_borders": False},
+                label="OtsuDetector",
+            ),
+        ],
+        name="inner_pipe",
+        desc="nested",
+    )
+
+    outer_scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="outer001",
+                class_name="ImagePipeline",
+                params={},
+                label="inner_pipe",
+                nested=inner_scope,
+            ),
+            StepNode(
+                node_id="outer002",
+                class_name="MeasureSize",
+                params={},
+                label="MeasureSize",
+            ),
+        ],
+        name="outer_pipe",
+    )
+
+    pipeline = to_pipeline(outer_scope)
+    ops = pipeline.get_ops()
+    # Outer ops dict should contain exactly one ImagePipeline-typed entry.
+    assert len(ops) == 1
+    only_op = next(iter(ops.values()))
+    assert isinstance(only_op, ImagePipeline)
+    assert list(only_op.get_ops().keys()) == ["GaussianBlur", "OtsuDetector"]
+    assert only_op.get_ops()["GaussianBlur"].sigma == 1.25
+    assert only_op.get_ops()["OtsuDetector"].ignore_zeros is True
+    assert list(pipeline.get_meas().keys()) == ["MeasureSize"]
+
+    # from_pipeline should keep the nested structure intact.
+    rebuilt_scope = from_pipeline(pipeline)
+    assert len(rebuilt_scope.nodes) == 2
+    nested_node = rebuilt_scope.nodes[0]
+    assert nested_node.class_name == "ImagePipeline"
+    assert nested_node.nested is not None
+    assert [n.class_name for n in nested_node.nested.nodes] == [
+        "GaussianBlur",
+        "OtsuDetector",
+    ]
+    assert nested_node.nested.nodes[0].params["sigma"] == 1.25
+
+    # current_scope should be able to drill into the nested pipeline.
+    state = BuilderState(root=rebuilt_scope, breadcrumb=[nested_node.node_id])
+    drilled = current_scope(state)
+    assert drilled is nested_node.nested
+
+    # stage_of for ImagePipeline is "ops".
+    assert stage_of("ImagePipeline") == "ops"
+    assert stage_of("MeasureSize") == "meas"
+    assert stage_of("GaussianBlur") == "ops"
+
+
+def test_op_typed_param_roundtrip() -> None:
+    """An op carrying an op-typed param survives a full round-trip."""
+
+    registry = get_registry()
+
+    # Find an op with an operation-typed parameter that has a non-pipeline
+    # acceptable concrete class we can plug in.
+    candidate_name = None
+    candidate_param = None
+    for op_name, info in registry.get_all().items():
+        for param in info.parameters.values():
+            if param.is_operation and param.is_optional:
+                candidate_name = op_name
+                candidate_param = param.name
+                break
+        if candidate_name is not None:
+            break
+
+    if candidate_name is None or candidate_param is None:
+        pytest.skip(
+            "no registered op exposes an Optional operation-typed parameter"
+        )
+
+    # Use OtsuDetector as a generic ObjectDetector substitute since the only
+    # current candidate (FilamentousFungiDetector) accepts an ObjectDetector.
+    inner_marker = {
+        "__type__": "operation",
+        "class_name": "OtsuDetector",
+        "params": {"ignore_zeros": True, "ignore_borders": False},
+    }
+
+    scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="ffd00001",
+                class_name=candidate_name,
+                params={candidate_param: inner_marker},
+                label=candidate_name,
+            ),
+        ],
+        name="op_param_demo",
+    )
+
+    pipeline = to_pipeline(scope)
+    ops = pipeline.get_ops()
+    assert candidate_name in ops
+    outer_op = ops[candidate_name]
+    inner_op = getattr(outer_op, candidate_param)
+    assert type(inner_op).__name__ == "OtsuDetector"
+    assert inner_op.ignore_zeros is True
+    assert inner_op.ignore_borders is False
+
+    rebuilt_scope = from_pipeline(pipeline)
+    assert len(rebuilt_scope.nodes) == 1
+    rebuilt_node = rebuilt_scope.nodes[0]
+    assert rebuilt_node.class_name == candidate_name
+    rebuilt_marker = rebuilt_node.params[candidate_param]
+    assert isinstance(rebuilt_marker, dict)
+    assert rebuilt_marker["__type__"] == "operation"
+    assert rebuilt_marker["class_name"] == "OtsuDetector"
+    assert rebuilt_marker["params"]["ignore_zeros"] is True
+    assert rebuilt_marker["params"]["ignore_borders"] is False
+
+    # Re-converting the rebuilt scope must produce an equivalent pipeline.
+    re_pipeline = to_pipeline(rebuilt_scope)
+    re_inner = getattr(re_pipeline.get_ops()[candidate_name], candidate_param)
+    assert type(re_inner).__name__ == "OtsuDetector"
+    assert re_inner.ignore_zeros is True
+
+
+@pytest.mark.slow
+def test_nested_pipeline_apply_with_intermediates() -> None:
+    """1-deep nested pipeline runs end-to-end on the synthetic plate."""
+
+    pytest.importorskip("phenotypic.data._synthetic_data")
+    from phenotypic.data._synthetic_data import load_synth_yeast_plate
+
+    inner_scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="inner_a",
+                class_name="GaussianBlur",
+                params={"sigma": 1.0},
+                label="GaussianBlur",
+            ),
+            StepNode(
+                node_id="inner_b",
+                class_name="OtsuDetector",
+                params={},
+                label="OtsuDetector",
+            ),
+        ],
+        name="enhance_then_detect",
+    )
+
+    outer_scope = BuilderScope(
+        nodes=[
+            StepNode(
+                node_id="outer_a",
+                class_name="ImagePipeline",
+                params={},
+                label="enhance_then_detect",
+                nested=inner_scope,
+            ),
+        ],
+        name="end_to_end",
+    )
+
+    pipeline = to_pipeline(outer_scope)
+    image = load_synth_yeast_plate()
+    result = pipeline.apply_with_intermediates(image)
+    assert result.image is not None
+    assert len(result.intermediates) >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -409,6 +409,15 @@ css = [
 ]
 
 [[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
 name = "bm3d"
 version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -901,6 +910,47 @@ wheels = [
 ]
 
 [[package]]
+name = "dash"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "importlib-metadata" },
+    { name = "nest-asyncio" },
+    { name = "plotly" },
+    { name = "requests" },
+    { name = "retrying" },
+    { name = "setuptools" },
+    { name = "typing-extensions" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/44/da/a13ae3a6528bd51a6901461dbff4549c6009de203d6249a89b9a09ac5cfb/dash-4.1.0.tar.gz", hash = "sha256:17a92a87b0c1eacc025079a705e44e72cd4c5794629c0a2909942b611faeb595", size = 6927689, upload-time = "2026-03-23T20:39:47.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/00/10b1f8b3885fc4add1853e9603af15c593fa0be20d37c158c4d811e868dc/dash-4.1.0-py3-none-any.whl", hash = "sha256:1af9f302bc14061061012cdb129b7e370d3604b12a7f730b252ad8e4966f01f7", size = 7232489, upload-time = "2026-03-23T20:39:40.658Z" },
+]
+
+[[package]]
+name = "dash-bootstrap-components"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/d4/5b7da808ff5acb3a6ca702f504d8ef05bc7d4c475b18dadefd783b1120c3/dash_bootstrap_components-2.0.4.tar.gz", hash = "sha256:c3206c0923774bbc6a6ddaa7822b8d9aa5326b0d3c1e7cd795cc975025fe2484", size = 115599, upload-time = "2025-08-20T19:42:09.449Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/38/1efeec8b4d741c09ccd169baf8a00c07a0176b58e418d4cd0c30dffedd22/dash_bootstrap_components-2.0.4-py3-none-any.whl", hash = "sha256:767cf0084586c1b2b614ccf50f79fe4525fdbbf8e3a161ed60016e584a14f5d1", size = 204044, upload-time = "2025-08-20T19:42:07.928Z" },
+]
+
+[[package]]
+name = "dash-cytoscape"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b7/0d511af853024241dc3192bea77e4753ea606187bd2dd777a8209a5b01bb/dash_cytoscape-1.0.2.tar.gz", hash = "sha256:a61019d2184d63a2b3b5c06d056d3b867a04223a674cc3c7cf900a561a9a59aa", size = 3992593, upload-time = "2024-07-15T11:39:06.185Z" }
+
+[[package]]
 name = "dask"
 version = "2025.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1102,6 +1152,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1e/b6/a48a72e751594366cd01263144ea4bfba2b0e082fca30828d89c2a472575/findiff-0.12.2.tar.gz", hash = "sha256:ccfbcd5ac8efce496ff9e789018db1f385c53489b42ef8f4eda14487cd8cdea4", size = 1630783, upload-time = "2025-12-03T09:59:32.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/92/29a08a3281a87ae04e9ff266d869f568241075744290d46e7666ec816c0b/findiff-0.12.2-py3-none-any.whl", hash = "sha256:df29142703ec793333b095c8213ff23effe7746715e89302a8d1ef627c19ec13", size = 26700, upload-time = "2025-12-03T09:59:30.552Z" },
+]
+
+[[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
 ]
 
 [[package]]
@@ -1680,6 +1747,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -3667,6 +3743,9 @@ dependencies = [
     { name = "bm3d" },
     { name = "click" },
     { name = "colour-science" },
+    { name = "dash" },
+    { name = "dash-bootstrap-components" },
+    { name = "dash-cytoscape" },
     { name = "duckdb" },
     { name = "exifread" },
     { name = "findiff" },
@@ -3769,6 +3848,9 @@ requires-dist = [
     { name = "bokeh", marker = "extra == 'gui'", specifier = ">=3.3" },
     { name = "click", specifier = ">=8.3.0" },
     { name = "colour-science", specifier = ">=0.4.6" },
+    { name = "dash", specifier = ">=4.1.0" },
+    { name = "dash-bootstrap-components", specifier = ">=2.0.4" },
+    { name = "dash-cytoscape", specifier = ">=1.0.2" },
     { name = "duckdb", specifier = ">=1.2.0" },
     { name = "exifread", specifier = ">=3.5.1" },
     { name = "findiff", specifier = ">=0.12.2" },
@@ -4987,6 +5069,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "retrying"
+version = "1.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/5a/b17e1e257d3e6f2e7758930e1256832c9ddd576f8631781e6a072914befa/retrying-1.4.2.tar.gz", hash = "sha256:d102e75d53d8d30b88562d45361d6c6c934da06fab31bd81c0420acb97a8ba39", size = 11411, upload-time = "2025-08-03T03:35:25.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f3/6cd296376653270ac1b423bb30bd70942d9916b6978c6f40472d6ac038e7/retrying-1.4.2-py3-none-any.whl", hash = "sha256:bbc004aeb542a74f3569aeddf42a2516efefcdaff90df0eb38fbfbf19f179f59", size = 10859, upload-time = "2025-08-03T03:35:23.829Z" },
 ]
 
 [[package]]
@@ -6505,6 +6596,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/fb/c492d6daa5ec067c2988ac80c61359ace5c4c674c532985ac5a123436cec/websockets-15.0.1-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b359ed09954d7c18bbc1680f380c7301f92c60bf924171629c5db97febb12f04", size = 174155, upload-time = "2025-03-05T20:03:25.321Z" },
     { url = "https://files.pythonhosted.org/packages/68/a1/dcb68430b1d00b698ae7a7e0194433bce4f07ded185f0ee5fb21e2a2e91e/websockets-15.0.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:cad21560da69f4ce7658ca2cb83138fb4cf695a2ba3e475e0559e05991aa8122", size = 176884, upload-time = "2025-03-05T20:03:27.934Z" },
     { url = "https://files.pythonhosted.org/packages/fa/a8/5b41e0da817d64113292ab1f8247140aac61cbf6cfd085d6a0fa77f4984f/websockets-15.0.1-py3-none-any.whl", hash = "sha256:f7a866fbc1e97b5c617ee4116daaa09b722101d4a3c170c787450ba409f9736f", size = 169743, upload-time = "2025-03-05T20:03:39.41Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Galaxy-style drag-and-drop node editor for assembling ImagePipeline objects interactively over an SSH tunnel. Operations from every category (enhance / detect / refine / correction / measure / post) drop onto a cytoscape canvas; per-step parameter forms are auto-generated from the registry. Run preview executes apply_with_intermediates against a synthetic plate or server-side image and surfaces per-node thumbnails or DataTables in the inspector. Pipelines round-trip through to_json / from_json on a server-side path.

Supports nested ImagePipeline drill-down (with breadcrumb) and op-typed parameter editing: clicking Edit ▸ on a parameter like FilamentousFungiDetector.inoculum_detector pushes a singleton sub-scope that commits back into the parent's params on drill-out.

Includes ImagePipelineCore.get_post() to mirror get_ops/get_meas, and extends OperationRegistry.discover() to the post module so post- measurement transforms appear in the palette.