### PR TITLE
measure(grid_spatial): rework neighbor distance to use dist_transform

### DIFF
--- a/src/phenotypic/measure/_measure_grid_spatial.py
+++ b/src/phenotypic/measure/_measure_grid_spatial.py
@@ -7,20 +7,24 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from phenotypic._core._grid_image import GridImage
 
-import pandas as pd
 import numpy as np
+import pandas as pd
+from scipy import ndimage as ndi
 
 from phenotypic.abc_ import GridMeasureFeatures
 from phenotypic.tools_.constants_ import OBJECT
-from phenotypic.tools_.measurement_info import GRID_SPATIAL, BBOX, GRID
+from phenotypic.tools_.measurement_info import GRID_SPATIAL, GRID
 
 
 class MeasureGridSpatial(GridMeasureFeatures):
-    """Measure edge-to-edge distances to neighbors in adjacent grid cells.
+    """Measure pixel-to-pixel distances to neighbors in adjacent grid cells.
 
     For each detected colony, identify the nearest object in the left,
-    right, above, and below grid cells and compute the minimum
-    bounding-box edge-to-edge distance. Edge and corner colonies report
+    right, above, and below grid cells and report the minimum Euclidean
+    distance between their pixel masks. Distances are computed via a
+    per-section distance transform over a local window covering the target
+    cell and its immediate neighbors, so round colonies are not
+    over-estimated by their bounding boxes. Edge and corner colonies report
     ``NaN`` for directions beyond the plate boundary.
 
     Returns:
@@ -31,18 +35,22 @@ class MeasureGridSpatial(GridMeasureFeatures):
             - RightNeighborObjLabel, RightDistance.
             - AboveNeighborObjLabel, AboveDistance.
             - UnderNeighborObjLabel, UnderDistance.
-            - ``NaN`` where no neighbor exists in a given direction.
+            - ``NaN`` where no neighbor exists (out of plate, empty
+              neighbor cell, or the colony is shielded by another colony
+              in the same cell).
 
     Best For:
         - Quantifying colony spacing and crowding to assess nutrient
-          competition risk on arrayed plates.
+          competition risk on arrayed plates, especially for round or
+          irregular colony shapes where bounding-box geometry overstates
+          proximity.
         - Flagging closely spaced colonies that may cross-contaminate.
         - Enabling neighbor-aware paired statistical comparisons for
           competition or cooperation studies.
 
     Consider Also:
-        - :class:`MeasureGridLinRegStats` for regression-based
-          positional quality metrics.
+        - :class:`MeasureGridLinRegStats` for regression-based positional
+          quality metrics.
         - :class:`MeasureGridSpread` for within-well colony dispersion
           rather than between-well distances.
         - :class:`MeasureBounds` for raw bounding boxes and centroids
@@ -55,167 +63,173 @@ class MeasureGridSpatial(GridMeasureFeatures):
 
     _measurement_infoclass = GRID_SPATIAL
 
+    # (d_row, d_col, label_col, dist_col)
+    _DIRECTIONS = (
+        (0, -1, GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL,
+         GRID_SPATIAL.LEFT_DISTANCE),
+        (0, +1, GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL,
+         GRID_SPATIAL.RIGHT_DISTANCE),
+        (-1, 0, GRID_SPATIAL.ABOVE_NEIGHBOR_OBJ_LABEL,
+         GRID_SPATIAL.ABOVE_DISTANCE),
+        (+1, 0, GRID_SPATIAL.UNDER_NEIGHBOR_OBJ_LABEL,
+         GRID_SPATIAL.UNDER_DISTANCE),
+    )
+
     def _operate(self, image: GridImage) -> pd.DataFrame:
-        gs_table = image.grid.info(include_metadata=False)
+        grid_info = image.grid.info(include_metadata=False)
+        # Densify once; subsequent windowing is pure numpy slicing on this view.
+        objmap_full = image.objmap[:]
+        nrows, ncols = image.grid.nrows, image.grid.ncols
 
-        # Build lookup: (row, col) -> list of (label, min_rr, max_rr, min_cc, max_cc)
-        cell_lookup = self._build_cell_lookup(gs_table)
+        labels = grid_info[OBJECT.LABEL].to_numpy()
+        n_objs = len(labels)
+        label_to_row = {int(label): i for i, label in enumerate(labels)}
 
-        # Initialize result arrays (MeasurementInfo members are strings, use directly)
-        n_objects = len(gs_table)
-        results = {
-            GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL : np.full(n_objects, np.nan),
-            GRID_SPATIAL.LEFT_DISTANCE           : np.full(n_objects, np.nan),
-            GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL: np.full(n_objects, np.nan),
-            GRID_SPATIAL.RIGHT_DISTANCE          : np.full(n_objects, np.nan),
-            GRID_SPATIAL.ABOVE_NEIGHBOR_OBJ_LABEL: np.full(n_objects, np.nan),
-            GRID_SPATIAL.ABOVE_DISTANCE          : np.full(n_objects, np.nan),
-            GRID_SPATIAL.UNDER_NEIGHBOR_OBJ_LABEL: np.full(n_objects, np.nan),
-            GRID_SPATIAL.UNDER_DISTANCE          : np.full(n_objects, np.nan),
+        results: dict = {
+            GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL : np.full(n_objs, np.nan),
+            GRID_SPATIAL.LEFT_DISTANCE           : np.full(n_objs, np.nan),
+            GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL: np.full(n_objs, np.nan),
+            GRID_SPATIAL.RIGHT_DISTANCE          : np.full(n_objs, np.nan),
+            GRID_SPATIAL.ABOVE_NEIGHBOR_OBJ_LABEL: np.full(n_objs, np.nan),
+            GRID_SPATIAL.ABOVE_DISTANCE          : np.full(n_objs, np.nan),
+            GRID_SPATIAL.UNDER_NEIGHBOR_OBJ_LABEL: np.full(n_objs, np.nan),
+            GRID_SPATIAL.UNDER_DISTANCE          : np.full(n_objs, np.nan),
         }
 
-        # Process each object
-        for i, (idx, row) in enumerate(gs_table.iterrows()):
-            obj_row = row[GRID.ROW_NUM]
-            obj_col = row[GRID.COL_NUM]
-            obj_bbox = self._extract_bbox(row)
+        # Build (row, col) -> section_df once so neighbour lookups are O(1)
+        # instead of an O(n_objects) DataFrame scan per direction per target.
+        section_groups: dict[tuple[int, int], pd.DataFrame] = {}
+        for (g_row, g_col), sec_df in grid_info.groupby(
+                [GRID.ROW_NUM, GRID.COL_NUM], observed=True
+        ):
+            if pd.isna(g_row) or pd.isna(g_col):
+                continue
+            section_groups[(int(g_row), int(g_col))] = sec_df
 
-            if pd.isna(obj_row) or pd.isna(obj_col):
+        for (target_row, target_col), section_df in section_groups.items():
+            target_idx = int(image.grid._idx_ref_matrix[target_row, target_col])
+            target_labels = section_df[OBJECT.LABEL].to_numpy().astype(np.int64)
+            if target_labels.size == 0:
                 continue
 
-            obj_row, obj_col = int(obj_row), int(obj_col)
+            target_bbox = self._section_bbox(image, target_idx, grid_info)
 
-            # Check each direction: (direction_name, neighbor_row, neighbor_col, label_col, dist_col)
-            directions = [
-                (obj_row, obj_col - 1, GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL,
-                 GRID_SPATIAL.LEFT_DISTANCE),
-                (obj_row, obj_col + 1, GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL,
-                 GRID_SPATIAL.RIGHT_DISTANCE),
-                (obj_row - 1, obj_col, GRID_SPATIAL.ABOVE_NEIGHBOR_OBJ_LABEL,
-                 GRID_SPATIAL.ABOVE_DISTANCE),
-                (obj_row + 1, obj_col, GRID_SPATIAL.UNDER_NEIGHBOR_OBJ_LABEL,
-                 GRID_SPATIAL.UNDER_DISTANCE),
-            ]
+            valid_neighbors = self._collect_neighbors(
+                    image, grid_info, section_groups,
+                    target_row, target_col, nrows, ncols,
+            )
+            if not valid_neighbors:
+                continue
 
-            for n_row, n_col, label_col, dist_col in directions:
-                neighbor_label, neighbor_dist = self._find_closest_neighbor(
-                        cell_lookup, n_row, n_col, obj_bbox
-                )
-                if neighbor_label is not None:
-                    results[label_col][i] = neighbor_label
-                    results[dist_col][i] = neighbor_dist
+            # Include target bbox so any target-object pixels that spilled past
+            # the section's grid edges are still seeded into target_mask (the
+            # object-fitting bounds may extend beyond the naive grid edges).
+            all_bboxes = [target_bbox] + [n[2] for n in valid_neighbors]
+            win = self._window_bbox(all_bboxes)
 
-        # Build output DataFrame
+            objmap_win = objmap_full[win[0]:win[1] + 1, win[2]:win[3] + 1]
+            target_mask = np.isin(objmap_win, target_labels)
+            if not target_mask.any():
+                continue
+
+            # Distance from each window pixel to the nearest target-section
+            # object pixel, with index back-pointers so we can attribute every
+            # pixel to a specific target object.
+            dt, indices = ndi.distance_transform_edt(
+                    ~target_mask, return_indices=True
+            )
+            nearest_target_label = objmap_win[indices[0], indices[1]]
+
+            for (_n_row, _n_col, n_bbox, n_labels,
+                 label_col, dist_col) in valid_neighbors:
+                lo_rr = n_bbox[0] - win[0]
+                hi_rr = n_bbox[1] - win[0] + 1
+                lo_cc = n_bbox[2] - win[2]
+                hi_cc = n_bbox[3] - win[2] + 1
+
+                objmap_n = objmap_win[lo_rr:hi_rr, lo_cc:hi_cc]
+                neighbor_pixel_mask = np.isin(objmap_n, n_labels)
+                if not neighbor_pixel_mask.any():
+                    continue
+
+                dt_n = dt[lo_rr:hi_rr, lo_cc:hi_cc]
+                nearest_n = nearest_target_label[lo_rr:hi_rr, lo_cc:hi_cc]
+
+                for target_label in target_labels:
+                    cand = neighbor_pixel_mask & (nearest_n == target_label)
+                    if not cand.any():
+                        continue
+                    cand_dt = dt_n[cand]
+                    cand_obj = objmap_n[cand]
+                    argmin = int(np.argmin(cand_dt))
+                    row_idx = label_to_row[int(target_label)]
+                    results[label_col][row_idx] = int(cand_obj[argmin])
+                    results[dist_col][row_idx] = float(cand_dt[argmin])
+
         df = pd.DataFrame(results)
-        df.insert(0, OBJECT.LABEL, gs_table[OBJECT.LABEL].values)
+        df.insert(0, OBJECT.LABEL, labels)
         return df
 
-    def _build_cell_lookup(self, gs_table: pd.DataFrame) -> dict:
-        """Build lookup mapping (row, col) -> list of (label, bbox).
+    @staticmethod
+    def _section_bbox(
+            image: GridImage, idx: int, grid_info: pd.DataFrame
+    ) -> tuple[int, int, int, int]:
+        """Return integer (min_rr, max_rr, min_cc, max_cc) for a grid section.
 
-        Args:
-            gs_table: DataFrame from image.grid.info() with object positions.
-
-        Returns:
-            Dictionary mapping (grid_row, grid_col) tuples to lists of
-            (object_label, bbox_tuple) for all objects in that cell.
+        Uses the object-fitting section slices so colonies that spill past
+        their grid line are not cropped at the boundary.
         """
-        lookup = {}
-        for _, row in gs_table.iterrows():
-            grid_row = row[GRID.ROW_NUM]
-            grid_col = row[GRID.COL_NUM]
-            if pd.isna(grid_row) or pd.isna(grid_col):
-                continue
-            key = (int(grid_row), int(grid_col))
-            bbox = self._extract_bbox(row)
-            label = row[OBJECT.LABEL]
-            lookup.setdefault(key, []).append((label, bbox))
-        return lookup
-
-    def _extract_bbox(self, row: pd.Series) -> tuple:
-        """Extract bounding box tuple from DataFrame row.
-
-        Args:
-            row: Single row from grid info DataFrame.
-
-        Returns:
-            Tuple of (min_rr, max_rr, min_cc, max_cc) bounding box coordinates.
-        """
+        (min_rr, min_cc), (max_rr, max_cc) = (
+            image.grid._adv_get_grid_section_slices(idx, grid_info)
+        )
         return (
-            row[BBOX.MIN_RR],
-            row[BBOX.MAX_RR],
-            row[BBOX.MIN_CC],
-            row[BBOX.MAX_CC],
+            int(np.asarray(min_rr).item()),
+            int(np.asarray(max_rr).item()),
+            int(np.asarray(min_cc).item()),
+            int(np.asarray(max_cc).item()),
         )
 
-    def _find_closest_neighbor(
-            self, lookup: dict, n_row: int, n_col: int, obj_bbox: tuple
-    ) -> tuple:
-        """Find closest object in neighbor cell.
-
-        Args:
-            lookup: Cell lookup dictionary from _build_cell_lookup.
-            n_row: Grid row index of neighbor cell.
-            n_col: Grid column index of neighbor cell.
-            obj_bbox: Bounding box of the current object.
-
-        Returns:
-            Tuple of (neighbor_label, distance) if neighbor exists,
-            otherwise (None, None).
-        """
-        if n_row < 0 or n_col < 0:
-            return None, None
-
-        neighbors = lookup.get((n_row, n_col), [])
-        if not neighbors:
-            return None, None
-
-        closest_label = None
-        closest_dist = np.inf
-
-        for label, n_bbox in neighbors:
-            dist = self._bbox_distance(obj_bbox, n_bbox)
-            if dist < closest_dist:
-                closest_dist = dist
-                closest_label = label
-
-        return closest_label, closest_dist
-
     @staticmethod
-    def _bbox_distance(bbox1: tuple, bbox2: tuple) -> float:
-        """Compute minimum edge-to-edge Euclidean distance between bounding boxes.
+    def _window_bbox(
+            bboxes: list[tuple[int, int, int, int]]
+    ) -> tuple[int, int, int, int]:
+        """Union of (min_rr, max_rr, min_cc, max_cc) bboxes."""
+        arr = np.asarray(bboxes, dtype=np.int64)
+        return (
+            int(arr[:, 0].min()),
+            int(arr[:, 1].max()),
+            int(arr[:, 2].min()),
+            int(arr[:, 3].max()),
+        )
 
-        This computes the minimum distance between any point on the first bounding
-        box and any point on the second bounding box. If the boxes overlap, the
-        distance is 0.
-
-        Args:
-            bbox1: First bounding box as (min_rr, max_rr, min_cc, max_cc).
-            bbox2: Second bounding box as (min_rr, max_rr, min_cc, max_cc).
-
-        Returns:
-            Minimum Euclidean distance between the bounding boxes (0 if overlapping).
-        """
-        min_rr1, max_rr1, min_cc1, max_cc1 = bbox1
-        min_rr2, max_rr2, min_cc2, max_cc2 = bbox2
-
-        # Distance in row direction (0 if overlapping)
-        if max_rr1 < min_rr2:
-            rr_dist = min_rr2 - max_rr1
-        elif max_rr2 < min_rr1:
-            rr_dist = min_rr1 - max_rr2
-        else:
-            rr_dist = 0
-
-        # Distance in column direction (0 if overlapping)
-        if max_cc1 < min_cc2:
-            cc_dist = min_cc2 - max_cc1
-        elif max_cc2 < min_cc1:
-            cc_dist = min_cc1 - max_cc2
-        else:
-            cc_dist = 0
-
-        return np.sqrt(rr_dist ** 2 + cc_dist ** 2)
+    def _collect_neighbors(
+            self,
+            image: GridImage,
+            grid_info: pd.DataFrame,
+            section_groups: dict[tuple[int, int], pd.DataFrame],
+            target_row: int,
+            target_col: int,
+            nrows: int,
+            ncols: int,
+    ) -> list[tuple[int, int, tuple[int, int, int, int], np.ndarray, str, str]]:
+        """Enumerate valid (in-bounds, non-empty) neighbor sections."""
+        valid: list[tuple[
+            int, int, tuple[int, int, int, int], np.ndarray, str, str
+        ]] = []
+        for d_row, d_col, label_col, dist_col in self._DIRECTIONS:
+            n_row, n_col = target_row + d_row, target_col + d_col
+            if not (0 <= n_row < nrows and 0 <= n_col < ncols):
+                continue
+            n_section_df = section_groups.get((n_row, n_col))
+            if n_section_df is None or n_section_df.empty:
+                continue
+            n_idx = int(image.grid._idx_ref_matrix[n_row, n_col])
+            n_bbox = self._section_bbox(image, n_idx, grid_info)
+            n_labels = n_section_df[OBJECT.LABEL].to_numpy().astype(np.int64)
+            valid.append(
+                    (n_row, n_col, n_bbox, n_labels, label_col, dist_col)
+            )
+        return valid
 
 
 MeasureGridSpatial.__doc__ = GRID_SPATIAL.append_rst_to_doc(MeasureGridSpatial)

--- a/src/phenotypic/tools_/measurement_info/_grid_spatial.py
+++ b/src/phenotypic/tools_/measurement_info/_grid_spatial.py
@@ -12,27 +12,28 @@ class GRID_SPATIAL(MeasurementInfo):
 
     LEFT_NEIGHBOR_OBJ_LABEL = "LeftNeighborObjLabel", ("The object label of the left"
                                                        " neighbor colony")
-    LEFT_DISTANCE = "LeftDistance", ("The distance of the left neighbor colony"
-                                     " calculated using euclidean distance between"
-                                     " bounding boxes")
+    LEFT_DISTANCE = "LeftDistance", ("The minimum pixel-to-pixel distance to the left"
+                                     " neighbor colony, computed via a Euclidean"
+                                     " distance transform of object pixel masks")
 
     RIGHT_NEIGHBOR_OBJ_LABEL = "RightNeighborObjLabel", ("The object label of"
                                                          " the right neighbor colony")
     RIGHT_DISTANCE = (
         "RightDistance",
-        "The distance of the right neighbor colony calculated"
-        " using euclidean distance between bounding boxes"
+        "The minimum pixel-to-pixel distance to the right neighbor colony, computed"
+        " via a Euclidean distance transform of object pixel masks"
     )
     ABOVE_NEIGHBOR_OBJ_LABEL = "AboveNeighborObjLabel", ("The object label of"
                                                          " the above neighbor colony")
     ABOVE_DISTANCE = (
         "AboveDistance",
-        "The distance of the above neighbor colony calculated using euclidean"
-        " distance between bounding boxes"
+        "The minimum pixel-to-pixel distance to the above neighbor colony, computed"
+        " via a Euclidean distance transform of object pixel masks"
     )
     UNDER_NEIGHBOR_OBJ_LABEL = ("UnderNeighborObjLabel",
                                 "The object label of the under neighbor colony")
     UNDER_DISTANCE = (
         "UnderDistance",
-        "The distance of the under neighbor colony calculated using euclidean distance between bounding boxes"
+        "The minimum pixel-to-pixel distance to the under neighbor colony, computed"
+        " via a Euclidean distance transform of object pixel masks"
     )

--- a/tests/unit/measure/test_measure_grid_spatial.py
+++ b/tests/unit/measure/test_measure_grid_spatial.py
@@ -4,10 +4,50 @@ import pytest
 import pandas as pd
 import numpy as np
 
+from phenotypic import GridImage
 from phenotypic.data import load_synth_yeast_plate
+from phenotypic.grid import ManualGridFinder
 from phenotypic.measure import MeasureGridSpatial
 from phenotypic.tools_.constants_ import OBJECT
 from phenotypic.tools_.measurement_info import GRID_SPATIAL, GRID
+
+
+def _circle(objmap: np.ndarray, label: int, rr: int, cc: int, radius: int) -> None:
+    """Stamp a filled disc with the given label into ``objmap`` in place."""
+    rr_grid, cc_grid = np.ogrid[:objmap.shape[0], :objmap.shape[1]]
+    mask = (rr_grid - rr) ** 2 + (cc_grid - cc) ** 2 <= radius ** 2
+    objmap[mask] = label
+
+
+def _make_synthetic_grid_image(
+        height: int,
+        width: int,
+        row_edges: np.ndarray,
+        col_edges: np.ndarray,
+        circles: list[tuple[int, int, int, int]],
+) -> GridImage:
+    """Build a GridImage with a ManualGridFinder and a hand-crafted objmap.
+
+    Args:
+        height: Image height in pixels.
+        width: Image width in pixels.
+        row_edges: Manual grid row edges.
+        col_edges: Manual grid column edges.
+        circles: List of (label, center_row, center_col, radius) discs to stamp.
+
+    Returns:
+        A GridImage with the synthetic objmap injected and the grid finder
+        configured so ``grid.info()`` returns the expected grid assignments.
+    """
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    finder = ManualGridFinder(row_edges=row_edges, col_edges=col_edges)
+    image = GridImage(arr=arr, grid_finder=finder)
+
+    objmap = np.zeros((height, width), dtype=np.uint16)
+    for label, rr, cc, radius in circles:
+        _circle(objmap, label, rr, cc, radius)
+    image.objmap[:] = objmap
+    return image
 
 
 class TestMeasureGridSpatial:
@@ -121,65 +161,183 @@ class TestMeasureGridSpatial:
                     f"Neighbor label {label} in {col} is not a valid object label"
 
 
-class TestBboxDistance:
-    """Tests for the bounding box distance calculation."""
+class TestWindowBbox:
+    """Unit tests for the pure-numpy window union helper."""
 
-    def test_non_overlapping_horizontal(self):
-        """Test distance between horizontally separated boxes."""
-        bbox1 = (0, 10, 0, 10)  # min_rr, max_rr, min_cc, max_cc
-        bbox2 = (0, 10, 20, 30)  # 10 pixels apart in column direction
+    def test_single_bbox_unchanged(self):
+        bbox = (10, 20, 30, 40)
+        assert MeasureGridSpatial._window_bbox([bbox]) == bbox
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 10.0
+    def test_union_takes_extremes(self):
+        bboxes = [
+            (10, 20, 30, 40),
+            (5, 25, 35, 50),
+            (8, 18, 28, 45),
+        ]
+        # min of mins, max of maxs over (min_rr, max_rr, min_cc, max_cc)
+        assert MeasureGridSpatial._window_bbox(bboxes) == (5, 25, 28, 50)
 
-    def test_non_overlapping_vertical(self):
-        """Test distance between vertically separated boxes."""
-        bbox1 = (0, 10, 0, 10)
-        bbox2 = (20, 30, 0, 10)  # 10 pixels apart in row direction
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 10.0
+class TestEdtDistance:
+    """End-to-end tests of the EDT-based algorithm with synthetic GridImages."""
 
-    def test_overlapping_boxes(self):
-        """Overlapping boxes should have distance 0."""
-        bbox1 = (0, 10, 0, 10)
-        bbox2 = (5, 15, 5, 15)  # Overlaps in both dimensions
+    def test_two_circles_in_adjacent_cells_match_edge_to_edge_distance(self):
+        """Distance between two circles in adjacent cells equals center-to-center
+        minus the two radii (true pixel-to-pixel)."""
+        # 1x2 grid, 100x100 image, one circle per cell at the cell center
+        image = _make_synthetic_grid_image(
+            height=100,
+            width=100,
+            row_edges=np.array([0, 100]),
+            col_edges=np.array([0, 50, 100]),
+            circles=[
+                (1, 50, 25, 5),  # left cell, center (50, 25), r=5
+                (2, 50, 75, 5),  # right cell, center (50, 75), r=5
+            ],
+        )
+        df = MeasureGridSpatial().measure(image)
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 0.0
+        left = df[df[OBJECT.LABEL] == 1].iloc[0]
+        right = df[df[OBJECT.LABEL] == 2].iloc[0]
 
-    def test_touching_boxes(self):
-        """Boxes that touch (share an edge) should have distance 0."""
-        bbox1 = (0, 10, 0, 10)
-        bbox2 = (0, 10, 10, 20)  # Touches at column 10
+        # Center-to-center column distance = 50; subtract two radii of 5
+        expected = 50.0 - 5 - 5
+        # Allow ±1 px slack for rasterization
+        assert abs(left[GRID_SPATIAL.RIGHT_DISTANCE] - expected) <= 1.0
+        assert int(left[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL]) == 2
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 0.0
+        # Reciprocal
+        assert abs(right[GRID_SPATIAL.LEFT_DISTANCE] - expected) <= 1.0
+        assert int(right[GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL]) == 1
 
-    def test_diagonal_separation(self):
-        """Test distance between diagonally separated boxes."""
-        bbox1 = (0, 10, 0, 10)
-        bbox2 = (20, 30, 20, 30)  # 10 apart in both directions
+        # Edge-of-plate NaNs hold
+        assert pd.isna(left[GRID_SPATIAL.LEFT_DISTANCE])
+        assert pd.isna(right[GRID_SPATIAL.RIGHT_DISTANCE])
+        assert pd.isna(left[GRID_SPATIAL.ABOVE_DISTANCE])
+        assert pd.isna(left[GRID_SPATIAL.UNDER_DISTANCE])
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        expected = np.sqrt(100 + 100)  # sqrt(10^2 + 10^2)
-        assert np.isclose(dist, expected)
+    def test_diagonal_circles_match_true_mask_distance(self):
+        """For diagonally separated circles, EDT gives the true mask-to-mask
+        distance (≈ center-to-center − 2·radius), which differs measurably
+        from the bbox-corner approximation the old method used."""
+        # 1x2 grid; left circle in top region of left cell, right circle in
+        # bottom region of right cell — diagonal even within the left/right
+        # neighbour relation
+        image = _make_synthetic_grid_image(
+            height=100,
+            width=100,
+            row_edges=np.array([0, 100]),
+            col_edges=np.array([0, 50, 100]),
+            circles=[
+                (1, 20, 20, 5),
+                (2, 80, 80, 5),
+            ],
+        )
+        df = MeasureGridSpatial().measure(image)
+        right_dist = df[df[OBJECT.LABEL] == 1].iloc[0][GRID_SPATIAL.RIGHT_DISTANCE]
 
-    def test_single_pixel_boxes(self):
-        """Test distance between single-pixel boxes."""
-        bbox1 = (5, 5, 5, 5)  # Single pixel at (5, 5)
-        bbox2 = (5, 5, 8, 8)  # Single pixel at (5, 8)
+        # True closest-pixel distance ≈ ||(80,80) − (20,20)|| − 2·r
+        center_dist = np.sqrt(60 ** 2 + 60 ** 2)
+        expected = center_dist - 2 * 5
+        assert abs(right_dist - expected) <= 1.5
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 3.0
+        # The old bbox-corner geometry connected the inner corners of the
+        # two boxes — (25, 25) and (75, 75) — giving sqrt(50^2 + 50^2)
+        # ≈ 70.71, which is the wrong answer for these circles.
+        bbox_corner_dist = np.sqrt(50 ** 2 + 50 ** 2)
+        assert abs(right_dist - bbox_corner_dist) > 2.0
 
-    def test_one_dimensional_overlap(self):
-        """Boxes overlapping in one dimension only."""
-        bbox1 = (0, 10, 0, 10)
-        bbox2 = (5, 15, 20, 30)  # Overlaps in rows, separated in cols
+    def test_multi_object_target_section_per_object_distances(self):
+        """Two target objects in the same cell each get their own RightDistance,
+        attributed via the Voronoi partition of the window."""
+        # Target cell at (0, 0) holds two circles stacked vertically.
+        # Right neighbour cell at (0, 1) holds two circles stacked vertically.
+        # The top target's nearest right neighbour should be the top-right;
+        # the bottom target's should be the bottom-right.
+        image = _make_synthetic_grid_image(
+            height=100,
+            width=100,
+            row_edges=np.array([0, 100]),
+            col_edges=np.array([0, 50, 100]),
+            circles=[
+                (1, 20, 20, 4),  # target top
+                (2, 80, 20, 4),  # target bottom
+                (3, 20, 80, 4),  # neighbour top
+                (4, 80, 80, 4),  # neighbour bottom
+            ],
+        )
+        df = MeasureGridSpatial().measure(image)
 
-        dist = MeasureGridSpatial._bbox_distance(bbox1, bbox2)
-        assert dist == 10.0  # Distance only in column direction
+        top = df[df[OBJECT.LABEL] == 1].iloc[0]
+        bot = df[df[OBJECT.LABEL] == 2].iloc[0]
+
+        # Each target attributes to the closer neighbour (same vertical level)
+        assert int(top[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL]) == 3
+        assert int(bot[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL]) == 4
+
+        # Both gaps are along the same row, both ≈ 60 - 4 - 4 = 52
+        expected = 60.0 - 4 - 4
+        assert abs(top[GRID_SPATIAL.RIGHT_DISTANCE] - expected) <= 1.0
+        assert abs(bot[GRID_SPATIAL.RIGHT_DISTANCE] - expected) <= 1.0
+
+    def test_shielded_target_returns_nan(self):
+        """When a second target object sits between the first target and the
+        right neighbour cell, the first target owns no Voronoi territory in
+        the right cell and gets NaN for that direction."""
+        # Target cell (0,0) holds two circles aligned horizontally:
+        #   circle 1 at (50, 10) — far from right cell
+        #   circle 2 at (50, 40) — close to right cell, "in the way"
+        # Right cell (0,1) holds one circle at (50, 75).
+        # From any pixel in the right cell, circle 2 is closer than circle 1,
+        # so circle 1 has no closest-attribution to right-cell pixels.
+        image = _make_synthetic_grid_image(
+            height=100,
+            width=100,
+            row_edges=np.array([0, 100]),
+            col_edges=np.array([0, 50, 100]),
+            circles=[
+                (1, 50, 10, 3),
+                (2, 50, 40, 3),
+                (3, 50, 75, 3),
+            ],
+        )
+        df = MeasureGridSpatial().measure(image)
+
+        shielded = df[df[OBJECT.LABEL] == 1].iloc[0]
+        front = df[df[OBJECT.LABEL] == 2].iloc[0]
+
+        # Circle 1 is shielded by circle 2 from the right neighbour
+        assert pd.isna(shielded[GRID_SPATIAL.RIGHT_DISTANCE])
+        assert pd.isna(shielded[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL])
+
+        # Circle 2 reports the real gap to circle 3
+        assert int(front[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL]) == 3
+        expected = (75 - 40) - 3 - 3
+        assert abs(front[GRID_SPATIAL.RIGHT_DISTANCE] - expected) <= 1.0
+
+    def test_empty_neighbor_cell_yields_nan(self):
+        """An in-bounds neighbour cell with no detected objects → NaN."""
+        # 1x3 grid; only the leftmost and rightmost cells have circles
+        image = _make_synthetic_grid_image(
+            height=100,
+            width=180,
+            row_edges=np.array([0, 100]),
+            col_edges=np.array([0, 60, 120, 180]),
+            circles=[
+                (1, 50, 30, 5),   # left cell
+                (2, 50, 150, 5),  # right cell — middle is empty
+            ],
+        )
+        df = MeasureGridSpatial().measure(image)
+
+        left = df[df[OBJECT.LABEL] == 1].iloc[0]
+        right = df[df[OBJECT.LABEL] == 2].iloc[0]
+
+        # Each colony's immediate neighbour cell is empty → NaN
+        assert pd.isna(left[GRID_SPATIAL.RIGHT_DISTANCE])
+        assert pd.isna(left[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL])
+        assert pd.isna(right[GRID_SPATIAL.LEFT_DISTANCE])
+        assert pd.isna(right[GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL])
 
 
 class TestMeasureGridSpatialIntegration:
@@ -190,24 +348,47 @@ class TestMeasureGridSpatialIntegration:
         return load_synth_yeast_plate()
 
     def test_reciprocal_neighbors(self, sample_image):
-        """If A's right neighbor is B, then B's left neighbor should be A."""
+        """For single-object cells, A's right neighbor B implies B's left
+        neighbor is A. (Multi-object cells can pick different closest objects
+        in each direction, so strict reciprocity only holds for the 1:1
+        regime.)"""
         measurer = MeasureGridSpatial()
         df = measurer.measure(sample_image)
+        grid_info = sample_image.grid.info(include_metadata=False)
 
-        # Find pairs where right neighbor is defined
+        # Labels in cells that contain exactly one object
+        cell_counts = grid_info.groupby(
+            [GRID.ROW_NUM, GRID.COL_NUM], observed=True
+        ).size()
+        single_object_cells = set(cell_counts[cell_counts == 1].index)
+        label_to_cell = {
+            int(row[OBJECT.LABEL]): (int(row[GRID.ROW_NUM]), int(row[GRID.COL_NUM]))
+            for _, row in grid_info.iterrows()
+        }
+
+        checked = 0
         for _, row in df.iterrows():
+            obj_label = int(row[OBJECT.LABEL])
+            if label_to_cell[obj_label] not in single_object_cells:
+                continue
             right_neighbor = row[GRID_SPATIAL.RIGHT_NEIGHBOR_OBJ_LABEL]
-            if pd.notna(right_neighbor):
-                obj_label = row[OBJECT.LABEL]
-                # Find the neighbor's row
-                neighbor_row = df[df[OBJECT.LABEL] == int(right_neighbor)]
-                if len(neighbor_row) > 0:
-                    # The neighbor's left neighbor should be us
-                    left_of_neighbor = neighbor_row[GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL].iloc[0]
-                    if pd.notna(left_of_neighbor):
-                        # Note: This may not always be true if there are multiple
-                        # objects per cell; the closest one is selected
-                        pass  # Skip strict assertion for multi-object cells
+            if pd.isna(right_neighbor):
+                continue
+            r_label = int(right_neighbor)
+            if label_to_cell[r_label] not in single_object_cells:
+                continue
+
+            neighbor_row = df[df[OBJECT.LABEL] == r_label].iloc[0]
+            left_of_neighbor = neighbor_row[GRID_SPATIAL.LEFT_NEIGHBOR_OBJ_LABEL]
+            assert pd.notna(left_of_neighbor), \
+                f"Object {r_label} should have a left neighbor (us, {obj_label})"
+            assert int(left_of_neighbor) == obj_label, \
+                f"Reciprocity broken: {obj_label} -> right -> {r_label}, but " \
+                f"{r_label} -> left -> {int(left_of_neighbor)}"
+            checked += 1
+
+        assert checked > 0, \
+            "Sample plate had no single-object adjacent pairs to verify"
 
     def test_consistent_distances(self, sample_image):
         """Distance from A to B should equal distance from B to A."""


### PR DESCRIPTION
Replace bbox edge-to-edge with a Euclidean distance transform on the actual colony pixel masks. Per target grid section, compute one DT over a window covering the section + its 4 valid neighbors using scipy.ndimage.distance_transform_edt(..., return_indices=True), then back-attribute every window pixel to a specific target object via the returned indices for per-object per-direction distances. Output schema and NaN semantics for OOB/empty neighbors are unchanged; multi-object target cells now correctly partition neighbor pixels by Voronoi proximity. Drops the old bbox helpers and updates GRID_SPATIAL column descriptions to match.