### PR TITLE
ci: split run-pytest into fast PR lane + nightly/post-merge full lane

### DIFF
--- a/.github/workflows/run-pytest-full.yml
+++ b/.github/workflows/run-pytest-full.yml
@@ -1,0 +1,196 @@
+name: run-pytest-full
+# Nightly + post-merge full lane. Runs the cross-platform matrix and includes
+# slow-marked tests, which are excluded from the PR lane in run-pytest.yml.
+#
+# Triggers:
+#   * schedule (07:00 UTC nightly)         — catch flakes and time-sensitive regressions
+#   * push: branches: [main] (post-merge)  — gated by check-freshness skip guard
+#   * workflow_dispatch                    — manual full run on any ref
+#
+# Matrix:
+#   * Linux x Python {3.10, 3.11, 3.12}
+#   * macOS-14 x Python 3.12 (public repo only)
+#   * Windows-latest x Python 3.12
+#
+# Run command override:
+#   ``-o "addopts=--verbose --capture=no"`` overrides the
+#   ``addopts = "--verbose --capture=no -m 'not slow'"`` default in
+#   pyproject.toml so slow tests are collected and run.
+#
+# No --testmon: the nightly lane is a clean full run; testmon's "skip
+# unchanged" semantics are useless when we want to run everything.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'      # 07:00 UTC nightly
+  push:
+    branches: [main]          # post-merge full-matrix verification
+  workflow_dispatch:
+
+# Never cancel a running nightly: a fresh push that arrives mid-run shouldn't
+# abort the in-flight slow-test sweep. Both runs will complete on their own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  check-freshness:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.set-output.outputs.skip }}
+    steps:
+      - name: Check for successful manual full-lane run on this SHA
+        if: github.event_name == 'push'
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.sha;
+
+            // Look for a successful workflow_dispatch run of THIS workflow
+            // on the merged SHA. If one exists (developer pre-flighted the
+            // full matrix before merging), skip the post-merge run.
+            const { data: runs } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: '.github/workflows/run-pytest-full.yml',
+              event: 'workflow_dispatch',
+              head_sha: headSha,
+              status: 'success',
+              per_page: 1,
+            });
+
+            if (runs.workflow_runs.length > 0) {
+              const manualRun = runs.workflow_runs[0];
+              core.setOutput('skip', 'true');
+              core.info(`Skipping full lane: workflow_dispatch run #${manualRun.id} already covered ${headSha}`);
+              return;
+            }
+
+            core.setOutput('skip', 'false');
+
+      - name: Set output
+        id: set-output
+        run: |
+          if [ "${{ github.event_name }}" == "push" ]; then
+            echo "skip=${{ steps.check.outputs.skip }}" >> $GITHUB_OUTPUT
+          else
+            # schedule + workflow_dispatch always run
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+  tests-linux-full:
+    needs: check-freshness
+    if: needs.check-freshness.outputs.skip != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python-version: "3.10"
+          - os: ubuntu-latest
+            python-version: "3.11"
+          - os: ubuntu-latest
+            python-version: "3.12"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y exiftool
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv lock
+          uv sync --group dev --all-extras
+
+      - name: Run tests (full, slow included)
+        run: |
+          source .venv/bin/activate
+          pytest -n auto -o "addopts=--verbose --capture=no" --durations=20
+
+  tests-macos-full:
+    needs: check-freshness
+    if: needs.check-freshness.outputs.skip != 'true' && github.event.repository.visibility == 'public'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            python-version: "3.12"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv lock
+          uv sync --group dev --all-extras
+
+      - name: Run tests (full, slow included)
+        run: |
+          source .venv/bin/activate
+          pytest -n auto -o "addopts=--verbose --capture=no" --durations=20
+
+  tests-windows-full:
+    needs: check-freshness
+    if: needs.check-freshness.outputs.skip != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            python-version: "3.12"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv lock
+          uv sync --group dev --all-extras
+
+      - name: Run tests (full, slow included)
+        run: |
+          .venv\Scripts\activate
+          pytest -n auto -o "addopts=--verbose --capture=no" --durations=20
+        shell: pwsh

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -1,15 +1,22 @@
 name: run-pytest
+# Fast PR lane. Goal: ~10-15 min wall-clock for PR-time signal.
+#
+# Matrix: Linux x Python {3.10 (floor), 3.12 (ceiling)}. Windows, macOS, and
+# Python 3.11 move to the nightly + post-merge full lane in
+# ``run-pytest-full.yml``. Slow tests are excluded by default via
+# ``addopts = "-m 'not slow'"`` in pyproject.toml.
+#
 # Testmon caching strategy:
-# pytest-testmon records which source files each test depends on (stored in .testmondata, a SQLite file).
-# On PR runs, we restore the .testmondata cache built from main so testmon only runs tests whose
-# dependencies changed in the PR. On pushes to main (after merge), we run with --testmon to update
-# the baseline cache for future PRs. On cache miss (first run, or dependency change), testmon runs
-# everything -- this is expected, not an error. Limitation: testmon tracks Python source only, not
-# config files, data fixtures, or environment variables.
+# pytest-testmon records which source files each test depends on (stored in
+# .testmondata, a SQLite file). On PR runs, we restore the .testmondata cache
+# built from main so testmon only runs tests whose dependencies changed in the
+# PR. The full lane runs without testmon to keep the nightly cache fresh and
+# to avoid skipping any tests on a clean run. On cache miss (first run, or
+# dependency change), testmon runs everything -- this is expected, not an
+# error. Limitation: testmon tracks Python source only, not config files, data
+# fixtures, or environment variables.
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main, dev]
   workflow_dispatch:
@@ -79,11 +86,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Ubuntu: test Python 3.10, 3.11, 3.12
+          # Ubuntu: floor (3.10) + ceiling (3.12). Python 3.11 moves to the
+          # nightly + post-merge full lane in run-pytest-full.yml.
           - os: ubuntu-latest
             python-version: "3.10"
-          - os: ubuntu-latest
-            python-version: "3.11"
           - os: ubuntu-latest
             python-version: "3.12"
 
@@ -124,106 +130,10 @@ jobs:
         run: |
           source .venv/bin/activate
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            pytest -n auto  # Full parallel run
+            pytest -n auto  # Full parallel run, addopts still excludes -m slow
           else
-            pytest --testmon  # Selective: PR (skip unchanged) or push-to-main (update baseline)
+            pytest --testmon  # Selective: PR (skip unchanged dependencies)
           fi
 
-  tests-windows:
-    needs: check-manual-run
-    # Run Windows tests unless a successful manual run exists
-    if: needs.check-manual-run.outputs.skip != 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # Windows: only Python 3.12
-          - os: windows-latest
-            python-version: "3.12"
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          version: "latest"
-
-      - name: Install dependencies
-        run: |
-          uv lock
-          uv sync --group dev --all-extras
-
-      - name: Cache testmon data
-        uses: actions/cache@v5
-        with:
-          path: .testmondata
-          key: testmon-${{ runner.os }}-py${{ matrix.python-version }}-${{ github.ref_name }}-${{ hashFiles('uv.lock') }}-${{ github.sha }}
-          restore-keys: |
-            testmon-${{ runner.os }}-py${{ matrix.python-version }}-main-${{ hashFiles('uv.lock') }}-
-            testmon-${{ runner.os }}-py${{ matrix.python-version }}-main-
-
-      - name: Run tests
-        run: |
-          .venv\Scripts\activate
-          if ($env:GITHUB_EVENT_NAME -eq "workflow_dispatch") {
-            pytest -n auto  # Full parallel run
-          } else {
-            pytest --testmon  # Selective: PR (skip unchanged) or push-to-main (update baseline)
-          }
-        shell: pwsh
-
-  tests-macos:
-    needs: check-manual-run
-    # Run macOS tests only when the repository is public and no successful manual run exists
-    if: needs.check-manual-run.outputs.skip != 'true' && github.event.repository.visibility == 'public'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          # macOS: only Python 3.12
-          - os: macos-14
-            python-version: "3.12"
-
-    runs-on: ${{matrix.os}}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
-        with:
-          version: "latest"
-
-      - name: Install dependencies
-        run: |
-          uv lock
-          uv sync --group dev --all-extras
-
-      - name: Cache testmon data
-        uses: actions/cache@v5
-        with:
-          path: .testmondata
-          key: testmon-${{ runner.os }}-py${{ matrix.python-version }}-${{ github.ref_name }}-${{ hashFiles('uv.lock') }}-${{ github.sha }}
-          restore-keys: |
-            testmon-${{ runner.os }}-py${{ matrix.python-version }}-main-${{ hashFiles('uv.lock') }}-
-            testmon-${{ runner.os }}-py${{ matrix.python-version }}-main-
-
-      - name: Run tests
-        run: |
-          source .venv/bin/activate
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            pytest -n auto  # Full parallel run
-          else
-            pytest --testmon  # Selective: PR (skip unchanged) or push-to-main (update baseline)
-          fi
+  # tests-windows and tests-macos moved to .github/workflows/run-pytest-full.yml
+  # which runs nightly + on push to main + on workflow_dispatch.

--- a/tests/unit/core/test_diagnostics_dashboard.py
+++ b/tests/unit/core/test_diagnostics_dashboard.py
@@ -9,9 +9,15 @@ from phenotypic._core._image_parts.panel_accessor._diagnostics_dashboard import 
     PANEL_AVAILABLE,
 )
 
-pytestmark = pytest.mark.skipif(
-    not PANEL_AVAILABLE, reason="Panel/param not installed"
-)
+# Module-level markers:
+# - skipif: dashboard requires Panel/param, optional dependency
+# - slow: full Panel/Bokeh dashboard rendering on a real plate is heavy and
+#   the dashboard rarely changes per PR; runs on the nightly + post-merge full
+#   lane only.
+pytestmark = [
+    pytest.mark.skipif(not PANEL_AVAILABLE, reason="Panel/param not installed"),
+    pytest.mark.slow,
+]
 
 if PANEL_AVAILABLE:
     import panel as pn

--- a/tests/unit/core/test_image_hdf_roundtrip.py
+++ b/tests/unit/core/test_image_hdf_roundtrip.py
@@ -19,6 +19,11 @@ from phenotypic import Image, GridImage
 from phenotypic.grid import AutoGridFinder
 from phenotypic.tools_.constants_ import GAMMA_ENCODINGS
 
+# Module-level slow marker: full HDF5 schema and back-compat matrix. The
+# companion binary-roundtrip suite in tests/unit/core/ stays on the fast lane
+# as the smoke check; this file moves to the nightly + post-merge full lane.
+pytestmark = pytest.mark.slow
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/unit/test_pickleable.py
+++ b/tests/unit/test_pickleable.py
@@ -3,7 +3,12 @@ import pytest
 
 from unit.test_fixtures import _public
 
-# Filter out CLI objects that aren't meant to be pickled
+# Module-level slow marker: this is a coverage probe that walks the entire
+# phenotypic public namespace. The walk is heavy and the matrix doesn't move
+# under typical PRs, so we run it on the nightly + post-merge full lane only.
+pytestmark = pytest.mark.slow
+
+# Filter out CLI objects that aren't meant to be serialized
 _pickleable_public = [
     (qualname, obj) for qualname, obj in _public
     if (


### PR DESCRIPTION
## Summary

Splits `run-pytest.yml` into two workflows so PR runs consume **~125 fewer billable runner-minutes per PR** (drop macOS ~33 min + Windows ~46 min + Linux 3.11 ~46 min from the PR matrix). Wall-clock per PR is unchanged — the remaining Linux jobs still run in parallel — but every PR now bills 2 runner-jobs instead of 5.

- **PR lane** (`run-pytest.yml`, trimmed): `pull_request` + `workflow_dispatch` only. Matrix: Linux × Python {3.10, 3.12}. Default `addopts = "-m 'not slow'"` from `pyproject.toml` excludes slow tests; `--testmon` selective re-run kept.
- **Nightly + post-merge full lane** (`run-pytest-full.yml`, new): full matrix (Linux × {3.10, 3.11, 3.12} + macOS × 3.12 + Windows × 3.12). Triggers: cron `0 7 * * *`, `push: branches: [main]` with freshness guard, `workflow_dispatch`. Runs slow tests via `-o "addopts=--verbose --capture=no"`, no testmon, `--durations=20` for visibility.

Three coverage-probe test files moved to `@pytest.mark.slow` (module-level):

- `tests/unit/test_pickleable.py` — public-API serialization walk
- `tests/unit/core/test_image_hdf_roundtrip.py` — HDF schema/back-compat matrix
- `tests/unit/core/test_diagnostics_dashboard.py` — Panel/Bokeh dashboard rendering

Companion suite `tests/unit/core/test_image_pickle.py` stays on the fast lane as the smoke binary-roundtrip check.

### Freshness guard

The `check-freshness` job in `run-pytest-full.yml` mirrors `check-manual-run` from the PR lane: on `push: main`, it queries the workflow-runs API for a successful `workflow_dispatch` run of `run-pytest-full.yml` on the same SHA. If found (developer pre-flighted the full matrix before merging), the post-merge run is skipped. `schedule` and `workflow_dispatch` always run.

## Branch-protection update (manual, after merge)

GitHub branch protection rules don't live in workflow files. After this lands, update **Settings → Branches → main → Required status checks**:

- **Required** (PR-time, reachable from `pull_request`): `tests-linux (ubuntu-latest, 3.10)`, `tests-linux (ubuntu-latest, 3.12)`, `e2e`, `features-md-gate`, `docs-build`, `Smoke-regenerate tutorial screenshots`, `Workflows registry gate (WORKFLOWS.md vs capture script)`, `check-manual-run`.
- **Remove**: `tests-linux (ubuntu-latest, 3.11)`, `tests-macos (macos-14, 3.12)`, `tests-windows (windows-latest, 3.12)` — now advisory; nightly + post-merge enforces them.
- **Do NOT add**: `tests-linux-full`, `tests-macos-full`, `tests-windows-full`, `check-freshness` — these run on `schedule`/`push`, not on `pull_request`, so they can't satisfy a PR-time required check.

## Test plan

- [x] `uv run pytest tests/unit -m "not slow"` — 2082 passed, 3 skipped, 396 deselected, 66 warnings in 10:35
- [x] `uv run pytest <three new slow files> --collect-only` — 335 deselected
- [x] `uv run pytest <three new slow files> -m slow --collect-only` — 335 collected
- [x] `uv run mypy src/phenotypic` — 754 errors (identical to main; no new errors introduced)
- [x] `python -c "import yaml; yaml.safe_load(open(p)) for p in [...]"` — both workflow YAMLs parse
- [ ] Manual `gh workflow run run-pytest-full.yml --ref main` after merge to dry-run the nightly lane
- [ ] Spot-check that slow tests in the three marked files are *actually* collected and run on the full lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)