### PR TITLE
perf(gui/builder): pre-bake preview PNGs instead of caching full Images

### DIFF
--- a/src/phenotypic/gui/CLAUDE.md
+++ b/src/phenotypic/gui/CLAUDE.md
@@ -226,3 +226,31 @@ badge contrast variants and prohibited combinations.
 - **`inject_design_tokens` is idempotent** — both the sub-app `_app.py`
   factories AND `wrap_in_chrome` call it; only the first call inserts
   the `<style>` block (marker comment de-dupes).
+
+---
+
+## Builder preview cache
+
+The builder's `Run preview` does NOT cache full `Image` instances. Each
+intermediate is rendered to a PNG **at preview-run time** by
+`render_node_preview` (see `builder/_image_renderer.py`) and the resulting
+bytes — together with measurement DataFrames and `PreviewRenderError`
+sentinels — are what live in `IntermediatesCache` (`builder/_session.py`).
+The inspector base64-wraps the bytes for `<img src=…>` and is otherwise
+a no-op on selection.
+
+- **Per-stage rule** (encoded inside `render_node_preview`):
+  - Enhancer → PNG of `detect_mat`.
+  - Detector / Refiner → overlay PNG (`label2rgb` of `objmap` over
+    `detect_mat`, scikit-image-fallback to a tab20 colormap).
+  - Corrector / nested `ImagePipeline` / unknown → PNG of `rgb`.
+- **Why**: pre-baking collapses worst-case resident memory from ~1–2 GB
+  (full Images per node × bounded sessions) to ~10–15 MB of PNG bytes,
+  and makes inspector node-switching effectively free.
+- **Render failures don't kill the preview** — they're caught per-node
+  and stored as `PreviewRenderError(message)` so the inspector can
+  surface the error inline while the rest of the run-preview output
+  remains valid.
+- **Testable seam**: `_callbacks._bake_preview_cache(state, pipeline,
+  result, session_id, cache)` is the unit the integration tests target;
+  `run_preview` itself is a thin Dash-callback adapter around it.

--- a/src/phenotypic/gui/FEATURES.md
+++ b/src/phenotypic/gui/FEATURES.md
@@ -56,6 +56,13 @@ See ``GUI_SPEC_V1.md`` for the canonical design.
 | Mounted under /builder/ | Shell mount                         | Reachable at `/builder/`; assets resolve under prefix                  | ✅ shipping | integration | tests/integration/gui/test_smoke_shell.py::test_builder_mount_routes |
 | Standalone parity    | `python -m phenotypic.gui.builder`     | Continues to work with default `url_prefix="/"`                        | ✅ shipping | manual      | n/a (manual)                                                      |
 
+## Builder pipeline editor
+
+| Feature                    | Element                    | Expected behaviour                                                                      | Status     | Test layer  | Test ref                                                                                          |
+| -------------------------- | -------------------------- | --------------------------------------------------------------------------------------- | ---------- | ----------- | ------------------------------------------------------------------------------------------------- |
+| Breadcrumb update payload  | Breadcrumb nav             | Callback updates replace the existing nav's children without nesting another breadcrumb | ✅ shipping | integration | tests/gui/builder/test_callbacks.py::test_render_views_returns_breadcrumb_children_not_nested_nav |
+| Optional numeric params    | Parameter form number input | PEP 604 optional numeric operation parameters render as number inputs and parse as numbers | ✅ shipping | integration | tests/gui/builder/test_point_picker_param_form.py::test_pep604_optional_int_param_uses_numeric_widget_and_parser |
+
 ## Builder point picker
 
 | Feature              | Element                                  | Expected behaviour                                                                                       | Status     | Test layer  | Test ref                                                                                          |

--- a/src/phenotypic/gui/_operation_registry.py
+++ b/src/phenotypic/gui/_operation_registry.py
@@ -9,6 +9,7 @@ No Panel/GUI dependencies - uses only stdlib and existing phenotypic dependencie
 from __future__ import annotations
 
 import inspect
+import types
 import typing
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
@@ -16,6 +17,12 @@ from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
 from phenotypic import ImagePipeline
 from phenotypic.abc_ import ImageOperation
 from phenotypic.tools_.mixin import PointPickerMixin
+
+
+def _is_union_origin(origin: Any) -> bool:
+    """Return ``True`` for both ``typing.Union`` and PEP 604 unions."""
+
+    return origin is Union or origin is types.UnionType
 
 
 @dataclass
@@ -350,7 +357,7 @@ class OperationRegistry:
         is_optional = False
 
         origin = get_origin(hint)
-        if origin is Union:
+        if _is_union_origin(origin):
             args = get_args(hint)
             is_optional = type(None) in args
             for arg in args:

--- a/src/phenotypic/gui/builder/_callbacks.py
+++ b/src/phenotypic/gui/builder/_callbacks.py
@@ -58,7 +58,11 @@ from phenotypic.gui.builder._directory_browser import (
     directory_tree,
     find_synthetic_plate_path,
 )
-from phenotypic.gui.builder._image_renderer import dataframe_to_table, to_data_uri
+from phenotypic.gui.builder._image_renderer import (
+    bytes_to_data_uri,
+    dataframe_to_table,
+    render_node_preview,
+)
 from phenotypic.gui.builder._layout import (
     build_breadcrumb,
     build_canvas,
@@ -69,7 +73,7 @@ from phenotypic.gui.builder._modal_browser import (
     render_load_picker_body,
 )
 from phenotypic.gui.builder._param_form import parse_widget_value
-from phenotypic.gui.builder._session import get_cache
+from phenotypic.gui.builder._session import PreviewRenderError, get_cache
 from phenotypic.gui.builder._state import (
     PIPELINE_CLASS_NAME,
     BuilderState,
@@ -1100,37 +1104,7 @@ def register_callbacks(app: dash.Dash) -> None:
             cache.set_image(session_id, image, str(image_path) if image_path else None)
 
             result = pipeline.apply_with_intermediates(image)
-
-            # Map intermediate keys ("GaussianBlur", "GaussianBlur_2", ...) back
-            # to BuilderState node-ids by walking ops in declaration order.
-            ops_nodes: List[StepNode] = [
-                n
-                for n in state.root.nodes
-                if n.class_name == PIPELINE_CLASS_NAME
-                or stage_of(n.class_name) == "ops"
-            ]
-            for op_key, node in zip(pipeline.get_ops().keys(), ops_nodes):
-                inter = result.intermediates.get(op_key)
-                if inter is not None:
-                    cache.set_intermediate(session_id, node.node_id, inter)
-
-            # Run measurements if any are configured.  Their output is a single
-            # DataFrame; attach it to every measurement / post node so the
-            # inspector can show it for whichever the user selects.  measure()
-            # needs the *processed* image (objmap populated by the detector
-            # chain), not the raw input.
-            if pipeline.get_meas() or pipeline.get_post():
-                try:
-                    df = pipeline.measure(result.image)
-                    meas_nodes = [
-                        n
-                        for n in state.root.nodes
-                        if stage_of(n.class_name) in {"meas", "post"}
-                    ]
-                    for node in meas_nodes:
-                        cache.set_intermediate(session_id, node.node_id, df)
-                except Exception as meas_exc:  # noqa: BLE001
-                    logger.warning("measure() failed: %s", meas_exc)
+            _bake_preview_cache(state, pipeline, result, session_id, cache)
 
             duration = time.time() - t0
             keys = cache.known_intermediate_keys(session_id)
@@ -1217,6 +1191,13 @@ def register_callbacks(app: dash.Dash) -> None:
                 className="text-muted",
             )
 
+        # Sentinel: render failed during preview run — surface the message.
+        if isinstance(cached, PreviewRenderError):
+            return html.Div(
+                f"(Could not render preview: {cached.message})",
+                className="text-warning",
+            )
+
         # DataFrame preview for measurement / post nodes.
         try:
             import pandas as pd  # type: ignore[import-untyped]
@@ -1226,15 +1207,21 @@ def register_callbacks(app: dash.Dash) -> None:
         if pd is not None and isinstance(cached, pd.DataFrame):
             return dataframe_to_table(cached)
 
-        channel = _preview_channel_for(node.class_name)
-        try:
-            uri = to_data_uri(cached, channel=channel)  # type: ignore[arg-type]
-        except Exception as exc:  # noqa: BLE001
-            return html.Div(
-                f"(Could not render preview: {_format_exception(exc)})",
-                className="text-warning",
+        # Pre-baked PNG bytes — wrap and ship. The cache contract stores
+        # `bytes` (not bytearray); the union check is only for type narrowing.
+        if isinstance(cached, bytes):
+            return html.Img(
+                src=bytes_to_data_uri(cached),
+                style={"maxWidth": "100%"},
             )
-        return html.Img(src=uri, style={"maxWidth": "100%"})
+
+        # Unreachable under the current cache contract; defensive log.
+        logger.warning(  # pragma: no cover
+            "Unexpected cache payload type %s for node %s",
+            type(cached).__name__,
+            state.selected_node_id,
+        )
+        return no_update  # pragma: no cover
 
     # ----------------------------------------------------------------------
     # 5. Save modal — open / close / confirm / dir-nav / body re-render
@@ -1995,6 +1982,77 @@ def register_callbacks(app: dash.Dash) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _bake_preview_cache(
+    state: "BuilderState",
+    pipeline: Any,
+    result: Any,
+    session_id: str,
+    cache: Any,
+) -> None:
+    """Render every intermediate to PNG bytes (or DataFrame) into *cache*.
+
+    Pulled out of ``run_preview`` so the cache contract — bytes for ops,
+    DataFrame for meas/post, ``PreviewRenderError`` on render failure — can
+    be exercised end-to-end without booting a Dash server.
+
+    Args:
+        state: The deserialised :class:`BuilderState` driving the preview.
+        pipeline: The compiled :class:`ImagePipeline`.
+        result: The :class:`IntermediateResult` returned by
+            :meth:`ImagePipeline.apply_with_intermediates`.
+        session_id: Per-tab uuid keying the cache.
+        cache: The :class:`IntermediatesCache` to populate.
+    """
+
+    # Map intermediate keys ("GaussianBlur", "GaussianBlur_2", ...) back to
+    # BuilderState node-ids by walking ops in declaration order.
+    ops_nodes: List[StepNode] = [
+        n
+        for n in state.root.nodes
+        if n.class_name == PIPELINE_CLASS_NAME
+        or stage_of(n.class_name) == "ops"
+    ]
+    # Pre-bake one PNG per ops intermediate so the inspector never has to
+    # re-encode the source Image on selection. Source Images go out of scope
+    # at the end of the loop body — only the bytes are retained in the cache.
+    for op_key, node in zip(pipeline.get_ops().keys(), ops_nodes):
+        inter = result.intermediates.get(op_key)
+        if inter is None:
+            continue
+        try:
+            png = render_node_preview(inter, node.class_name)
+        except Exception as render_exc:  # noqa: BLE001
+            logger.warning(
+                "Preview render failed for %s (%s): %s",
+                node.class_name, node.node_id, render_exc,
+            )
+            cache.set_intermediate(
+                session_id,
+                node.node_id,
+                PreviewRenderError(_format_exception(render_exc)),
+            )
+            continue
+        cache.set_intermediate(session_id, node.node_id, png)
+
+    # Run measurements if any are configured. Their output is a single
+    # DataFrame; attach it to every measurement / post node so the inspector
+    # can show it for whichever the user selects. measure() needs the
+    # *processed* image (objmap populated by the detector chain), not the
+    # raw input.
+    if pipeline.get_meas() or pipeline.get_post():
+        try:
+            df = pipeline.measure(result.image)
+            meas_nodes = [
+                n
+                for n in state.root.nodes
+                if stage_of(n.class_name) in {"meas", "post"}
+            ]
+            for node in meas_nodes:
+                cache.set_intermediate(session_id, node.node_id, df)
+        except Exception as meas_exc:  # noqa: BLE001
+            logger.warning("measure() failed: %s", meas_exc)
+
+
 def _load_preview_image(
     image_path: Optional[str],
     uses_grid: bool,
@@ -2024,35 +2082,6 @@ def _load_preview_image(
             ncols=int(ncols) if ncols else 12,
         )
     return Image.imread(p)
-
-
-def _preview_channel_for(class_name: str) -> str:
-    """Pick the image channel best showing *class_name*'s output.
-
-    Enhancers act on ``detect_mat``; detectors/refiners populate the object
-    map; everything else (correctors, nested pipelines, unknown classes,
-    measurement nodes that fell through here) defaults to RGB.
-    """
-
-    try:
-        stage = stage_of(class_name)
-    except KeyError:
-        return "rgb"
-    if stage != "ops":
-        return "rgb"
-    try:
-        from phenotypic.gui._operation_registry import get_registry
-
-        info = get_registry().get(class_name)
-    except Exception:  # noqa: BLE001
-        return "rgb"
-    if info is None:
-        return "rgb"
-    if info.category == "Enhancer":
-        return "detect_mat"
-    if info.category in {"Detector", "Refiner"}:
-        return "objmap"
-    return "rgb"
 
 
 def _pipeline_uses_grid(pipeline: Any, grid_op_cls: type) -> bool:

--- a/src/phenotypic/gui/builder/_callbacks.py
+++ b/src/phenotypic/gui/builder/_callbacks.py
@@ -618,7 +618,10 @@ def _render_views(state: BuilderState) -> Tuple[Any, Any, Any]:
         state: Live :class:`BuilderState` object.
 
     Returns:
-        Tuple of ``(breadcrumb, canvas, inspector)`` Dash component subtrees.
+        Tuple of ``(breadcrumb_children, canvas, inspector)`` Dash component
+        subtrees. The breadcrumb callback target is the existing nav's
+        ``children`` property, so returning a full nav here would nest the
+        breadcrumb inside itself on every update.
     """
 
     registry = _registry()
@@ -633,7 +636,7 @@ def _render_views(state: BuilderState) -> Tuple[Any, Any, Any]:
 
     canvas = build_canvas(scope, state.selected_node_id)
     inspector = build_inspector(state, registry)
-    breadcrumb = build_breadcrumb(state)
+    breadcrumb = build_breadcrumb(state).children
     return breadcrumb, canvas, inspector
 
 

--- a/src/phenotypic/gui/builder/_image_renderer.py
+++ b/src/phenotypic/gui/builder/_image_renderer.py
@@ -3,11 +3,16 @@
 The pipeline-builder inspector pane embeds previews via plain ``<img src=...>``
 tags rather than streaming endpoints — base64-encoded PNGs avoid spinning up a
 per-session asset route. Channels supported: ``rgb``, ``gray``, ``detect_mat``,
-and ``objmap``.
+and ``objmap``. Detector / refiner nodes get a separate overlay renderer that
+alpha-blends the objmap onto the post-op detect_mat
+(:func:`to_overlay_png_bytes`).
 
 Large source arrays are downscaled with ``cv2.resize(INTER_AREA)`` *before*
 encoding so a 4000×6000 uint16 plate doesn't pay PIL's slow per-pixel thumbnail
 cost.
+
+The builder pre-bakes one PNG per intermediate at preview-run time so the
+inspector never re-encodes on selection (see :func:`render_node_preview`).
 """
 
 from __future__ import annotations
@@ -21,9 +26,13 @@ import numpy as np
 from dash import dash_table
 from PIL import Image as PILImage
 
+from phenotypic.gui._operation_registry import get_registry
+from phenotypic.gui.builder._state import stage_of
+
 if TYPE_CHECKING:  # pragma: no cover - import only used for type hints
     import pandas as pd  # type: ignore[import-untyped]
     import phenotypic
+    from phenotypic.gui._operation_registry import OperationInfo
 
 
 ChannelName = Literal["rgb", "gray", "detect_mat", "objmap"]
@@ -147,9 +156,9 @@ def _label_map_to_rgb(arr: np.ndarray) -> np.ndarray:
         return np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
     except Exception:
         try:
-            import matplotlib.cm as cm
+            import matplotlib
 
-            cmap = cm.get_cmap("tab20", 20)
+            cmap = matplotlib.colormaps["tab20"]
             idx = (arr.astype(np.int64) % 20).astype(np.int64)
             rgba = cmap(idx)
             rgba[arr == 0] = (0.0, 0.0, 0.0, 1.0)
@@ -193,17 +202,26 @@ def _channel_to_rgb_uint8(arr: np.ndarray, channel: ChannelName) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 
-def to_data_uri(
+def _encode_png(rgb_uint8: np.ndarray) -> bytes:
+    """PIL-encode an ``(H, W, 3)`` uint8 array as PNG bytes."""
+
+    pil = PILImage.fromarray(rgb_uint8, mode="RGB")
+    buf = io.BytesIO()
+    pil.save(buf, format="PNG", optimize=False)
+    return buf.getvalue()
+
+
+def to_png_bytes(
     image: "phenotypic.Image",
     channel: ChannelName = "rgb",
     *,
     max_dim: int = 512,
-) -> str:
-    """Render an :class:`Image` channel as a base64 PNG data URI.
+) -> bytes:
+    """Render an :class:`Image` channel as raw PNG bytes (no base64 wrap).
 
     The image is downscaled with ``cv2.resize(INTER_AREA)`` before PNG encoding
-    so multi-megapixel raw scans encode in a fraction of a second. The output
-    is suitable for direct use as the ``src`` of an HTML ``<img>`` element.
+    so multi-megapixel raw scans encode in a fraction of a second. Use
+    :func:`bytes_to_data_uri` to wrap the result for an HTML ``<img>`` ``src``.
 
     Args:
         image: PhenoTypic :class:`Image` (or :class:`GridImage`) instance.
@@ -213,10 +231,57 @@ def to_data_uri(
             in pixels. Defaults to ``512``.
 
     Returns:
-        A string of the form ``"data:image/png;base64,<...>"``.
+        Raw PNG-encoded bytes (starting with the ``\\x89PNG`` magic).
 
     Raises:
         ValueError: If ``channel`` is not one of the supported names.
+
+    Examples:
+        >>> from phenotypic.data._synthetic_data import load_synth_yeast_plate
+        >>> img = load_synth_yeast_plate()
+        >>> blob = to_png_bytes(img, channel="rgb")
+        >>> blob[:8] == b"\\x89PNG\\r\\n\\x1a\\n"
+        True
+    """
+    arr = _read_channel(image, channel)
+    arr = _downscale(arr, max_dim=max_dim)
+    rgb_uint8 = _channel_to_rgb_uint8(arr, channel)
+    return _encode_png(rgb_uint8)
+
+
+def bytes_to_data_uri(blob: bytes) -> str:
+    """Wrap raw PNG bytes as a ``data:image/png;base64,...`` URI string.
+
+    Args:
+        blob: Raw PNG-encoded bytes.
+
+    Returns:
+        A URI suitable for direct use as the ``src`` of an HTML ``<img>``
+        element.
+    """
+    encoded = base64.b64encode(bytes(blob)).decode("ascii")
+    return f"data:image/png;base64,{encoded}"
+
+
+def to_data_uri(
+    image: "phenotypic.Image",
+    channel: ChannelName = "rgb",
+    *,
+    max_dim: int = 512,
+) -> str:
+    """Render an :class:`Image` channel as a base64 PNG data URI.
+
+    Thin wrapper over :func:`to_png_bytes` + :func:`bytes_to_data_uri`. Kept
+    for callers that want one-shot rendering; the builder cache pre-bakes
+    raw bytes via :func:`to_png_bytes` directly.
+
+    Args:
+        image: PhenoTypic :class:`Image` (or :class:`GridImage`) instance.
+        channel: One of ``"rgb"``, ``"gray"``, ``"detect_mat"``, ``"objmap"``.
+        max_dim: Maximum length of the longer spatial side, in pixels.
+
+    Returns:
+        A string of the form ``"data:image/png;base64,<...>"``.
 
     Examples:
         >>> from phenotypic.data._synthetic_data import load_synth_yeast_plate
@@ -225,15 +290,137 @@ def to_data_uri(
         >>> uri.startswith("data:image/png;base64,")
         True
     """
-    arr = _read_channel(image, channel)
-    arr = _downscale(arr, max_dim=max_dim)
-    rgb_uint8 = _channel_to_rgb_uint8(arr, channel)
+    return bytes_to_data_uri(to_png_bytes(image, channel, max_dim=max_dim))
 
-    pil = PILImage.fromarray(rgb_uint8, mode="RGB")
-    buf = io.BytesIO()
-    pil.save(buf, format="PNG", optimize=False)
-    encoded = base64.b64encode(buf.getvalue()).decode("ascii")
-    return f"data:image/png;base64,{encoded}"
+
+def to_overlay_png_bytes(
+    image: "phenotypic.Image",
+    *,
+    max_dim: int = 512,
+    alpha: float = 0.4,
+) -> bytes:
+    """Composite the objmap (alpha-blended) over the post-op detect_mat.
+
+    Used for detector / refiner intermediates so the inspector shows
+    *which colonies were segmented at this step* against the same grayscale
+    background the detector saw. Falls back to a plain
+    :func:`_label_map_to_rgb` colormap on the objmap when ``scikit-image``
+    isn't importable, matching the existing fallback in
+    :func:`_label_map_to_rgb` itself.
+
+    Args:
+        image: PhenoTypic :class:`Image` whose ``detect_mat`` and ``objmap``
+            accessors should both be valid (post-detector / post-refiner).
+        max_dim: Maximum length of the longer spatial side after resizing.
+        alpha: Label-overlay opacity in ``[0, 1]``. Higher = more colored.
+
+    Returns:
+        Raw PNG bytes encoding an ``(H, W, 3)`` uint8 overlay.
+    """
+    detect = _read_channel(image, "detect_mat")
+    objmap = _read_channel(image, "objmap")
+
+    detect = _downscale(detect, max_dim=max_dim)
+    objmap = _downscale(objmap, max_dim=max_dim)
+
+    base_u8 = _normalize_to_uint8(detect)
+    if base_u8.ndim == 3:
+        base_u8 = base_u8[..., :3]
+    else:
+        base_u8 = np.stack([base_u8] * 3, axis=-1)
+
+    try:
+        from skimage.color import label2rgb
+
+        rgb = label2rgb(
+            objmap,
+            image=base_u8,
+            bg_label=0,
+            alpha=float(alpha),
+            image_alpha=1.0,
+            kind="overlay",
+        )
+        rgb_u8 = np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
+    except Exception:
+        rgb_u8 = _label_map_to_rgb(objmap)
+
+    return _encode_png(rgb_u8)
+
+
+# ---------------------------------------------------------------------------
+# Per-stage dispatcher
+# ---------------------------------------------------------------------------
+
+
+def _registry_info_for(class_name: str) -> "OperationInfo | None":
+    """Return the :class:`OperationInfo` for *class_name*, or ``None``."""
+
+    try:
+        return get_registry().get(class_name)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _channel_for_class(
+    class_name: str, info: "OperationInfo | None"
+) -> ChannelName:
+    """Pick the channel best showing *class_name*'s output (non-overlay).
+
+    Fallback channel selector for stages that don't get the overlay renderer
+    (correctors, nested pipelines, unknown classes, measurement nodes that
+    fell through here). ``info`` is passed in so callers don't pay the
+    registry lookup twice.
+    """
+
+    try:
+        stage = stage_of(class_name)
+    except KeyError:
+        return "rgb"
+    if stage != "ops" or info is None:
+        return "rgb"
+    if info.category == "Enhancer":
+        return "detect_mat"
+    if info.category in {"Detector", "Refiner"}:
+        # Safety-net channel for the case where the overlay renderer raises
+        # and the caller falls back to a single-channel render.
+        return "objmap"
+    return "rgb"
+
+
+def render_node_preview(
+    image: "phenotypic.Image",
+    class_name: str,
+    *,
+    max_dim: int = 512,
+) -> bytes:
+    """Render the node-appropriate PNG for a pipeline intermediate.
+
+    Per-stage rule (matches the GUI's "show what this op did" intent):
+
+    * Enhancers → :func:`to_png_bytes` on ``detect_mat``.
+    * Detectors / Refiners → :func:`to_overlay_png_bytes` (objmap on
+      detect_mat).
+    * Correctors / nested ``Pipeline`` / unknown → :func:`to_png_bytes` on
+      ``rgb``.
+
+    Pre-baked once at preview-run time and cached as bytes; the inspector
+    only base64-wraps for display.
+
+    Args:
+        image: Post-op intermediate :class:`Image`.
+        class_name: Operation class name from ``StepNode.class_name``.
+        max_dim: Maximum length of the longer spatial side after resizing.
+
+    Returns:
+        Raw PNG bytes.
+    """
+
+    info = _registry_info_for(class_name)
+    if info is not None and info.category in {"Detector", "Refiner"}:
+        return to_overlay_png_bytes(image, max_dim=max_dim)
+
+    channel = _channel_for_class(class_name, info)
+    return to_png_bytes(image, channel, max_dim=max_dim)
 
 
 def dataframe_to_table(
@@ -285,4 +472,11 @@ def dataframe_to_table(
     return dash_table.DataTable(**kwargs)  # type: ignore[attr-defined]
 
 
-__all__ = ["to_data_uri", "dataframe_to_table"]
+__all__ = [
+    "to_data_uri",
+    "to_png_bytes",
+    "bytes_to_data_uri",
+    "to_overlay_png_bytes",
+    "render_node_preview",
+    "dataframe_to_table",
+]

--- a/src/phenotypic/gui/builder/_param_form.py
+++ b/src/phenotypic/gui/builder/_param_form.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import collections.abc as abc
 import enum
 import inspect
+import types
 import typing
 from typing import TYPE_CHECKING, Any, Optional, get_args, get_origin
 
@@ -40,11 +41,9 @@ def _unwrap_optional(hint: Any) -> Any:
         the hint is not Optional.
     """
     origin = get_origin(hint)
-    if origin is typing.Union:
+    if origin in (typing.Union, types.UnionType):
         non_none = [a for a in get_args(hint) if a is not type(None)]
         if len(non_none) == 1:
-            return non_none[0]
-        if len(non_none) > 1:
             return non_none[0]
     return hint
 

--- a/src/phenotypic/gui/builder/_point_picker.py
+++ b/src/phenotypic/gui/builder/_point_picker.py
@@ -547,6 +547,48 @@ def _stage_png_for_session(
     return ok
 
 
+def _stage_intermediate_png_bytes(
+    session_id: str,
+    image_root: Optional[Path],
+    png_bytes: bytes,
+) -> bool:
+    """Write a pre-baked intermediate PNG into the per-session cache.
+
+    The builder's preview run encodes each ops node's intermediate to a
+    PNG once via ``render_node_preview`` (see ``builder/_image_renderer.py``);
+    the bytes live in :class:`IntermediatesCache`. The picker re-uses that
+    pre-baked output verbatim — no re-encoding — so the per-stage render
+    rule (overlay for detector/refiner, detect_mat for enhancer, rgb for
+    corrector) survives into the modal's DZI source.
+
+    Skips the write when the same bytes object was already staged for this
+    session — keeps the DZI tile pyramid valid across modal-open round-trips.
+    """
+    if not _safe_session_id(session_id):
+        return False
+    cache_dir = _session_cache_dir(image_root, session_id)
+    png_path = _channel_png_path(cache_dir, "intermediate")
+
+    cache_key = (session_id, "intermediate")
+    if (
+        png_path.exists()
+        and _LAST_DUMPED.get(cache_key) == id(png_bytes)
+    ):
+        return True
+
+    try:
+        png_path.parent.mkdir(parents=True, exist_ok=True)
+        png_path.write_bytes(png_bytes)
+    except Exception:
+        logger.exception(
+            "Failed to stage intermediate PNG for session %s", session_id
+        )
+        return False
+
+    _LAST_DUMPED[cache_key] = id(png_bytes)
+    return True
+
+
 def _dzi_url(session_id: str, source: str) -> str:
     """Build the DZI manifest URL the JS layer should mount.
 
@@ -658,10 +700,10 @@ def register_point_picker_callbacks(app: dash.Dash) -> None:
                 session_id, "rgb", sandbox_root, image
             )
             if predecessor_id is not None:
-                pred_image = cache.get_intermediate(session_id, predecessor_id)
-                if pred_image is not None and hasattr(pred_image, "rgb"):
-                    intermediate_ok = _stage_png_for_session(
-                        session_id, "intermediate", sandbox_root, pred_image
+                pred_value = cache.get_intermediate(session_id, predecessor_id)
+                if isinstance(pred_value, (bytes, bytearray)):
+                    intermediate_ok = _stage_intermediate_png_bytes(
+                        session_id, sandbox_root, bytes(pred_value)
                     )
 
         # Build the initial DZI URL (default: rgb). If rgb couldn't be
@@ -737,15 +779,14 @@ def register_point_picker_callbacks(app: dash.Dash) -> None:
                     state_data, target_node
                 )
                 if predecessor_id is not None:
-                    pred_image = get_cache().get_intermediate(
+                    pred_value = get_cache().get_intermediate(
                         session_id, predecessor_id
                     )
-                    if pred_image is not None:
-                        avail_out["intermediate"] = _stage_png_for_session(
+                    if isinstance(pred_value, (bytes, bytearray)):
+                        avail_out["intermediate"] = _stage_intermediate_png_bytes(
                             session_id,
-                            "intermediate",
                             _resolve_image_root(app),
-                            pred_image,
+                            bytes(pred_value),
                         )
 
         return (_dzi_url(session_id, value), avail_out)

--- a/src/phenotypic/gui/builder/_session.py
+++ b/src/phenotypic/gui/builder/_session.py
@@ -1,10 +1,10 @@
-"""Per-session in-memory caches for images and pipeline intermediates.
+"""Per-session in-memory caches for images and pre-baked previews.
 
 The Dash builder needs server-side storage for two things that are too big or
 too type-rich to round-trip through ``dcc.Store`` JSON:
 
 - The currently loaded :class:`phenotypic.Image` (or :class:`GridImage`).
-- The map of ``node_id -> intermediate`` produced by
+- The map of ``node_id -> rendered preview`` produced after
   :meth:`ImagePipeline.apply_with_intermediates`.
 
 Both live in a single :class:`IntermediatesCache` keyed by a per-tab uuid that
@@ -12,6 +12,18 @@ the front end persists in a ``dcc.Store(storage_type='session')``. The cache
 is bounded — at most ``max_sessions`` distinct sessions, with eviction in
 FIFO order on the session-id list, and at most ``max_per_session``
 intermediates per session (LRU on the inner dict).
+
+**Cached preview payload contract** — each intermediate slot holds one of:
+
+- :class:`bytes` — raw PNG bytes pre-baked by ``render_node_preview`` (one
+  per ops node).
+- :class:`pandas.DataFrame` — the measurement / post-measurement output table.
+- :class:`PreviewRenderError` — sentinel describing a failed render so the
+  inspector can surface the message inline.
+
+This is a hard departure from the pre-pre-bake design which stored full
+``Image`` / ``GridImage`` instances. Dropping the source images after
+rendering shrinks worst-case resident memory by ~100×.
 
 Concurrency is handled with a single ``threading.Lock``. This is a deliberate
 single-process design — the SSH-tunneled HPCC use case does not require
@@ -24,10 +36,32 @@ from __future__ import annotations
 import threading
 from collections import OrderedDict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 if TYPE_CHECKING:  # pragma: no cover - type-only imports
+    import pandas as pd  # type: ignore[import-untyped]
+
     from phenotypic import Image
+
+
+@dataclass(frozen=True)
+class PreviewRenderError:
+    """Sentinel marking an intermediate slot whose render failed.
+
+    Stored in :class:`IntermediatesCache` in place of PNG bytes when
+    ``render_node_preview`` raises during a preview run, so the inspector
+    can show the message inline without crashing the whole preview.
+
+    Attributes:
+        message: Human-readable rendering failure (typically the formatted
+            exception). Surfaced verbatim in the inspector's warning div.
+    """
+
+    message: str
+
+
+CachedPreview = Union[bytes, "pd.DataFrame", PreviewRenderError]
+"""Anything :meth:`IntermediatesCache.set_intermediate` may store."""
 
 
 @dataclass
@@ -39,8 +73,10 @@ class SessionData:
             :class:`GridImage`); ``None`` when nothing is loaded yet.
         image_path: Path string from which ``image`` was loaded (informational).
             ``None`` when ``image`` came from the synthetic plate fallback.
-        intermediates: ``node_id -> Image | DataFrame`` map of per-step
-            intermediates produced by the most recent preview run. Eviction
+        intermediates: ``node_id -> CachedPreview`` map of per-step
+            pre-baked previews. Each value is :class:`bytes` (PNG) for ops
+            nodes, a :class:`pandas.DataFrame` for measurement / post nodes,
+            or :class:`PreviewRenderError` when rendering failed. Eviction
             order is LRU (oldest accessed first). Maintained as an
             :class:`OrderedDict` so :meth:`set_intermediate` can move accessed
             keys to the end without copying.
@@ -48,7 +84,9 @@ class SessionData:
 
     image: Optional["Image"] = None
     image_path: Optional[str] = None
-    intermediates: "OrderedDict[str, Any]" = field(default_factory=OrderedDict)
+    intermediates: "OrderedDict[str, CachedPreview]" = field(
+        default_factory=OrderedDict
+    )
 
 
 class IntermediatesCache:
@@ -153,16 +191,19 @@ class IntermediatesCache:
             if image is None:
                 data.intermediates.clear()
 
-    def set_intermediate(self, session_id: str, node_id: str, value: Any) -> None:
-        """Store *value* as the intermediate for *node_id*.
+    def set_intermediate(
+        self, session_id: str, node_id: str, value: CachedPreview
+    ) -> None:
+        """Store *value* as the pre-baked preview for *node_id*.
 
         If *node_id* already exists, it's moved to the most-recently-used end.
 
         Args:
             session_id: Per-tab uuid.
             node_id: ``StepNode.node_id`` produced by ``_state``.
-            value: An :class:`Image` (or :class:`pd.DataFrame` for measurement
-                / post-measurement steps).
+            value: PNG :class:`bytes` (ops node), :class:`pandas.DataFrame`
+                (measurement / post node), or :class:`PreviewRenderError`
+                (rendering failure marker).
         """
 
         with self._lock:
@@ -172,7 +213,9 @@ class IntermediatesCache:
             data.intermediates[node_id] = value
             self._evict_oldest_intermediates(data)
 
-    def get_intermediate(self, session_id: str, node_id: str) -> Any:
+    def get_intermediate(
+        self, session_id: str, node_id: str
+    ) -> Optional[CachedPreview]:
         """Return the cached intermediate for *node_id*, or ``None``.
 
         Touches the LRU order so frequently-viewed nodes survive eviction.
@@ -249,4 +292,10 @@ def get_cache() -> IntermediatesCache:
         return _GLOBAL_CACHE
 
 
-__all__ = ["SessionData", "IntermediatesCache", "get_cache"]
+__all__ = [
+    "SessionData",
+    "IntermediatesCache",
+    "PreviewRenderError",
+    "CachedPreview",
+    "get_cache",
+]

--- a/tests/gui/builder/test_callbacks.py
+++ b/tests/gui/builder/test_callbacks.py
@@ -7,7 +7,11 @@ mutation surface in milliseconds.
 
 from __future__ import annotations
 
+from dash import html
+
+from phenotypic.gui._operation_registry import OperationRegistry
 from phenotypic.gui.builder._callbacks import _dispatch_state_update
+from phenotypic.gui.builder._app import create_app
 from phenotypic.gui.builder._state import (
     BuilderScope,
     BuilderState,
@@ -29,6 +33,58 @@ def _seed_state() -> dict:
         ),
     )
     return state_to_json(state)
+
+
+def test_render_views_returns_breadcrumb_children_not_nested_nav() -> None:
+    """Callback payload must update ``breadcrumb.children``, not nest another nav."""
+
+    from phenotypic.gui.builder._callbacks import _render_views
+
+    registry = OperationRegistry()
+    registry.discover()
+    app = create_app(registry=registry)
+    state = BuilderState()
+
+    with app.server.app_context():
+        breadcrumb_children, _canvas, _inspector = _render_views(state)
+
+    assert isinstance(breadcrumb_children, list)
+    assert not any(isinstance(child, html.Nav) for child in breadcrumb_children)
+
+
+def test_render_views_drilled_in_breadcrumb_returns_button_children() -> None:
+    """Drilled-in state must render ancestor buttons + separator inline, not nest a nav."""
+
+    from phenotypic.gui.builder._callbacks import _render_views
+
+    registry = OperationRegistry()
+    registry.discover()
+    app = create_app(registry=registry)
+
+    state = BuilderState(
+        root=BuilderScope(
+            nodes=[
+                StepNode(
+                    node_id="pipe1",
+                    class_name="ImagePipeline",
+                    label="Subpipeline",
+                    nested=BuilderScope(
+                        nodes=[StepNode(node_id="aaa", class_name="GaussianBlur")],
+                        name="Subpipeline",
+                    ),
+                ),
+            ],
+        ),
+        breadcrumb=[{"node_id": "pipe1", "param": None}],
+    )
+
+    with app.server.app_context():
+        breadcrumb_children, _canvas, _inspector = _render_views(state)
+
+    assert isinstance(breadcrumb_children, list)
+    assert not any(isinstance(child, html.Nav) for child in breadcrumb_children)
+    # Two-segment path → ancestor button + " / " separator + active span (3 children).
+    assert len(breadcrumb_children) >= 3
 
 
 def test_add_node_appends_and_selects() -> None:

--- a/tests/gui/builder/test_image_renderer.py
+++ b/tests/gui/builder/test_image_renderer.py
@@ -1,0 +1,220 @@
+"""Tests for :mod:`phenotypic.gui.builder._image_renderer`.
+
+Covers:
+- :func:`to_png_bytes` per channel (rgb / gray / detect_mat / objmap).
+- :func:`bytes_to_data_uri` round-trip.
+- :func:`to_data_uri` legacy compatibility wrapper.
+- :func:`to_overlay_png_bytes` overlay composition + the matplotlib fallback
+  when scikit-image is unavailable.
+- :func:`render_node_preview` per-stage dispatch (enhancer / detector /
+  refiner / corrector / nested ``ImagePipeline``).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+import numpy as np
+import pytest
+from PIL import Image as PILImage
+
+from phenotypic.data._synthetic_data import load_synth_yeast_plate
+from phenotypic.gui.builder import _image_renderer
+from phenotypic.gui.builder._image_renderer import (
+    bytes_to_data_uri,
+    render_node_preview,
+    to_data_uri,
+    to_overlay_png_bytes,
+    to_png_bytes,
+)
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.fixture(scope="module")
+def synthetic_image():
+    """A small synthetic plate, fast to load and re-use across tests."""
+    return load_synth_yeast_plate()
+
+
+@pytest.fixture(scope="module")
+def detected_image(synthetic_image):
+    """Synthetic plate with an objmap populated via OtsuDetector.
+
+    Needed to exercise overlay rendering and the objmap channel.
+    """
+    from phenotypic import ImagePipeline
+    from phenotypic.detect import OtsuDetector
+
+    pipeline = ImagePipeline(ops=[OtsuDetector()], name="overlay-fixture")
+    return pipeline.apply(synthetic_image)
+
+
+# ---------------------------------------------------------------------------
+# to_png_bytes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("channel", ["rgb", "gray", "detect_mat"])
+def test_to_png_bytes_starts_with_png_magic(synthetic_image, channel):
+    blob = to_png_bytes(synthetic_image, channel=channel)
+    assert isinstance(blob, bytes)
+    assert blob[:8] == PNG_MAGIC
+
+
+def test_to_png_bytes_objmap(detected_image):
+    blob = to_png_bytes(detected_image, channel="objmap")
+    assert blob[:8] == PNG_MAGIC
+
+
+def test_to_png_bytes_respects_max_dim(synthetic_image):
+    """The encoded PNG's longer side must not exceed ``max_dim``."""
+    blob = to_png_bytes(synthetic_image, channel="rgb", max_dim=128)
+    pil = PILImage.open(io.BytesIO(blob))
+    longer = max(pil.size)
+    assert longer <= 128, f"longer side {longer} > 128"
+
+
+def test_to_png_bytes_unknown_channel_raises(synthetic_image):
+    with pytest.raises(ValueError):
+        to_png_bytes(synthetic_image, channel="bogus")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# bytes_to_data_uri
+# ---------------------------------------------------------------------------
+
+
+def test_bytes_to_data_uri_format():
+    blob = b"hello"
+    uri = bytes_to_data_uri(blob)
+    assert uri.startswith("data:image/png;base64,")
+    decoded = base64.b64decode(uri.removeprefix("data:image/png;base64,"))
+    assert decoded == blob
+
+
+def test_bytes_to_data_uri_round_trip(synthetic_image):
+    blob = to_png_bytes(synthetic_image, channel="gray", max_dim=64)
+    uri = bytes_to_data_uri(blob)
+    head = "data:image/png;base64,"
+    assert uri.startswith(head)
+    assert base64.b64decode(uri[len(head):]) == blob
+
+
+def test_to_data_uri_wrapper_matches_split(synthetic_image):
+    """The legacy ``to_data_uri`` is a thin wrapper over the split helpers."""
+    direct = to_data_uri(synthetic_image, channel="rgb", max_dim=128)
+    composed = bytes_to_data_uri(
+        to_png_bytes(synthetic_image, channel="rgb", max_dim=128)
+    )
+    assert direct == composed
+
+
+# ---------------------------------------------------------------------------
+# to_overlay_png_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_to_overlay_png_bytes_starts_with_png_magic(detected_image):
+    blob = to_overlay_png_bytes(detected_image, max_dim=128)
+    assert blob[:8] == PNG_MAGIC
+
+
+def test_to_overlay_png_bytes_respects_max_dim(detected_image):
+    blob = to_overlay_png_bytes(detected_image, max_dim=96)
+    pil = PILImage.open(io.BytesIO(blob))
+    assert max(pil.size) <= 96
+
+
+def test_to_overlay_png_bytes_works_without_skimage(
+    monkeypatch, detected_image
+):
+    """Force the scikit-image import to fail and confirm the fallback runs."""
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "skimage.color" or name.startswith("skimage."):
+            raise ImportError("forced for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    blob = to_overlay_png_bytes(detected_image, max_dim=64)
+    assert blob[:8] == PNG_MAGIC
+
+
+def test_to_overlay_png_bytes_with_zero_labels(synthetic_image):
+    """An all-zero objmap still produces valid bytes via the label2rgb path.
+
+    The pre-detection synthetic plate has an all-zero objmap (no detections),
+    which exercises the ``bg_label=0`` path of ``label2rgb`` rather than the
+    skimage-import fallback (covered by a separate test).
+    """
+    blob = to_overlay_png_bytes(synthetic_image, max_dim=64)
+    assert blob[:8] == PNG_MAGIC
+
+
+# ---------------------------------------------------------------------------
+# render_node_preview dispatcher
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "class_name",
+    [
+        "GaussianBlur",       # Enhancer → detect_mat
+        "OtsuDetector",       # Detector → overlay
+        "ImagePipeline",      # nested pipeline → rgb
+        "DefinitelyNotAClass",  # unknown → rgb
+    ],
+)
+def test_render_node_preview_dispatch(detected_image, class_name):
+    """Every supported class_name produces valid PNG bytes."""
+    blob = render_node_preview(detected_image, class_name, max_dim=64)
+    assert isinstance(blob, bytes)
+    assert blob[:8] == PNG_MAGIC
+
+
+def test_render_node_preview_detector_uses_overlay_path(detected_image):
+    """Sanity: the detector path produces different bytes than a plain rgb
+    render of the same image (overlay alpha-blends color over gray).
+    """
+    overlay = render_node_preview(detected_image, "OtsuDetector", max_dim=64)
+    rgb = to_png_bytes(detected_image, channel="rgb", max_dim=64)
+    assert overlay != rgb
+
+
+def test_render_node_preview_enhancer_uses_detect_mat(synthetic_image):
+    """Enhancer renders should match the detect_mat single-channel render."""
+    via_dispatcher = render_node_preview(
+        synthetic_image, "GaussianBlur", max_dim=64
+    )
+    direct = to_png_bytes(synthetic_image, channel="detect_mat", max_dim=64)
+    assert via_dispatcher == direct
+
+
+# ---------------------------------------------------------------------------
+# Internal: _label_map_to_rgb fallback
+# ---------------------------------------------------------------------------
+
+
+def test_label_map_fallback_to_matplotlib(monkeypatch):
+    """Force the skimage import to fail; matplotlib path must still produce
+    a valid (H, W, 3) uint8 array.
+    """
+
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("skimage"):
+            raise ImportError("forced")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+    arr = np.zeros((10, 10), dtype=np.int32)
+    arr[2:5, 2:5] = 1
+    arr[6:9, 6:9] = 2
+    rgb = _image_renderer._label_map_to_rgb(arr)
+    assert rgb.shape == (10, 10, 3)
+    assert rgb.dtype == np.uint8

--- a/tests/gui/builder/test_point_picker_param_form.py
+++ b/tests/gui/builder/test_point_picker_param_form.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import dash_bootstrap_components as dbc
-from dash import dcc, html
 
-from phenotypic.gui._operation_registry import OperationRegistry
-from phenotypic.gui.builder._param_form import param_form
+from phenotypic.gui._operation_registry import OperationRegistry, ParamInfo
+from phenotypic.gui.builder._param_form import param_form, parse_widget_value
 
 
 def _walk(node):
@@ -32,6 +30,15 @@ def _id_types_in_form(form):
             if isinstance(t, str):
                 types.add(t)
     return types
+
+
+def _ids_in_form(form):
+    ids = []
+    for node in _walk(form):
+        nid = getattr(node, "id", None)
+        if isinstance(nid, dict):
+            ids.append(nid)
+    return ids
 
 
 def test_picker_widget_replaces_input_for_manual_point_detector():
@@ -112,3 +119,42 @@ def test_picker_store_handles_numpy_initial():
             assert list(node.data[0]) == [1.5, 2.5]
             return
     raise AssertionError("picker store not found in form")
+
+
+def test_pep604_optional_int_param_uses_numeric_widget_and_parser():
+    """``int | None`` operation params must not fall back to text handling."""
+
+    reg = OperationRegistry()
+    reg.discover()
+    info = reg.get("ImageCropper")
+
+    assert info is not None
+    left = info.parameters["left"]
+    assert left.is_optional is True
+
+    form = param_form(info, current_values={}, form_id_prefix="crop")
+    left_ids = [
+        nid
+        for nid in _ids_in_form(form)
+        if nid.get("prefix") == "crop" and nid.get("name") == "left"
+    ]
+
+    assert {"type": "param-num", "prefix": "crop", "name": "left"} in left_ids
+    assert {"type": "param-str", "prefix": "crop", "name": "left"} not in left_ids
+    assert parse_widget_value("12", left) == 12
+
+
+def test_parse_widget_value_coerces_pep604_optional_float():
+    """PEP 604 optional floats share the same coercion path as Optional[float]."""
+
+    param = ParamInfo(
+        name="sigma",
+        type_hint=float | None,
+        default=None,
+        has_default=True,
+        is_operation=False,
+        is_pipeline=False,
+        is_optional=True,
+    )
+
+    assert parse_widget_value("2.5", param) == 2.5

--- a/tests/gui/builder/test_session.py
+++ b/tests/gui/builder/test_session.py
@@ -1,0 +1,192 @@
+"""Tests for :mod:`phenotypic.gui.builder._session`.
+
+Covers the bounded LRU/FIFO behavior of :class:`IntermediatesCache` and the
+mixed payload-type contract introduced with the pre-baked PNG cache:
+:class:`bytes` (ops nodes), :class:`pandas.DataFrame` (measurement / post),
+and :class:`PreviewRenderError` (rendering failure marker).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from phenotypic.gui.builder._session import (
+    IntermediatesCache,
+    PreviewRenderError,
+    SessionData,
+    get_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction / lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_session_data_default_fields():
+    sd = SessionData()
+    assert sd.image is None
+    assert sd.image_path is None
+    assert len(sd.intermediates) == 0
+
+
+def test_get_cache_returns_singleton():
+    a = get_cache()
+    b = get_cache()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# set_image / get_image
+# ---------------------------------------------------------------------------
+
+
+def test_set_and_get_image_round_trip():
+    cache = IntermediatesCache()
+    cache.set_image("s1", object(), "/tmp/foo.png")  # type: ignore[arg-type]
+    img, path = cache.get_image("s1")
+    assert img is not None
+    assert path == "/tmp/foo.png"
+
+
+def test_get_image_unknown_session_returns_none():
+    cache = IntermediatesCache()
+    assert cache.get_image("nope") == (None, None)
+
+
+def test_clearing_image_clears_intermediates():
+    """Setting image=None must drop derived intermediates (node ids stale)."""
+    cache = IntermediatesCache()
+    cache.set_image("s1", object(), "/tmp/x.png")  # type: ignore[arg-type]
+    cache.set_intermediate("s1", "node-a", b"\x89PNGfake")
+    cache.set_image("s1", None, None)
+    assert cache.get_intermediate("s1", "node-a") is None
+
+
+# ---------------------------------------------------------------------------
+# Mixed payload contract
+# ---------------------------------------------------------------------------
+
+
+def test_intermediate_accepts_bytes_payload():
+    cache = IntermediatesCache()
+    cache.set_intermediate("s1", "node-a", b"\x89PNGfake")
+    assert cache.get_intermediate("s1", "node-a") == b"\x89PNGfake"
+
+
+def test_intermediate_accepts_dataframe_payload():
+    cache = IntermediatesCache()
+    df = pd.DataFrame({"colony": [1, 2], "Size_Area": [100, 200]})
+    cache.set_intermediate("s1", "meas-node", df)
+    got = cache.get_intermediate("s1", "meas-node")
+    assert isinstance(got, pd.DataFrame)
+    pd.testing.assert_frame_equal(got, df)
+
+
+def test_intermediate_accepts_preview_render_error():
+    cache = IntermediatesCache()
+    err = PreviewRenderError("boom")
+    cache.set_intermediate("s1", "broken-node", err)
+    got = cache.get_intermediate("s1", "broken-node")
+    assert got is err
+    assert isinstance(got, PreviewRenderError)
+    assert got.message == "boom"
+
+
+def test_mixed_payload_types_coexist():
+    cache = IntermediatesCache()
+    cache.set_intermediate("s1", "ops-node", b"\x89PNGfake")
+    cache.set_intermediate("s1", "meas-node", pd.DataFrame({"x": [1]}))
+    cache.set_intermediate("s1", "broken-node", PreviewRenderError("nope"))
+    assert isinstance(cache.get_intermediate("s1", "ops-node"), bytes)
+    assert isinstance(
+        cache.get_intermediate("s1", "meas-node"), pd.DataFrame
+    )
+    assert isinstance(
+        cache.get_intermediate("s1", "broken-node"), PreviewRenderError
+    )
+
+
+def test_preview_render_error_is_frozen():
+    err = PreviewRenderError("immutable")
+    with pytest.raises(Exception):
+        err.message = "mutated"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# LRU eviction within a session
+# ---------------------------------------------------------------------------
+
+
+def test_lru_eviction_within_session_drops_oldest():
+    cache = IntermediatesCache(max_sessions=2, max_per_session=3)
+    for i in range(4):
+        cache.set_intermediate("s1", f"node-{i}", f"png-{i}".encode())
+    assert cache.get_intermediate("s1", "node-0") is None
+    for i in range(1, 4):
+        assert cache.get_intermediate("s1", f"node-{i}") == f"png-{i}".encode()
+
+
+def test_lru_access_promotes_to_most_recently_used():
+    cache = IntermediatesCache(max_sessions=2, max_per_session=2)
+    cache.set_intermediate("s1", "a", b"a")
+    cache.set_intermediate("s1", "b", b"b")
+    # access 'a' to bump it to MRU
+    assert cache.get_intermediate("s1", "a") == b"a"
+    # now insert 'c' — 'b' (the LRU) should be evicted, 'a' survives
+    cache.set_intermediate("s1", "c", b"c")
+    assert cache.get_intermediate("s1", "a") == b"a"
+    assert cache.get_intermediate("s1", "b") is None
+    assert cache.get_intermediate("s1", "c") == b"c"
+
+
+def test_set_existing_node_id_moves_to_mru():
+    """Re-setting the same node_id should NOT count as a new entry."""
+    cache = IntermediatesCache(max_sessions=2, max_per_session=2)
+    cache.set_intermediate("s1", "a", b"v1")
+    cache.set_intermediate("s1", "b", b"b")
+    cache.set_intermediate("s1", "a", b"v2")  # update; should not evict 'b'
+    assert cache.get_intermediate("s1", "a") == b"v2"
+    assert cache.get_intermediate("s1", "b") == b"b"
+
+
+# ---------------------------------------------------------------------------
+# FIFO eviction across sessions
+# ---------------------------------------------------------------------------
+
+
+def test_fifo_eviction_across_sessions_drops_oldest_session():
+    cache = IntermediatesCache(max_sessions=2, max_per_session=4)
+    cache.set_intermediate("s1", "n", b"1")
+    cache.set_intermediate("s2", "n", b"2")
+    cache.set_intermediate("s3", "n", b"3")
+    assert cache.get_intermediate("s1", "n") is None
+    assert cache.get_intermediate("s2", "n") == b"2"
+    assert cache.get_intermediate("s3", "n") == b"3"
+
+
+def test_clear_drops_session_entirely():
+    cache = IntermediatesCache()
+    cache.set_intermediate("s1", "a", b"a")
+    cache.clear("s1")
+    assert cache.get_intermediate("s1", "a") is None
+    assert cache.get_image("s1") == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / known keys
+# ---------------------------------------------------------------------------
+
+
+def test_known_intermediate_keys_returns_insertion_order():
+    cache = IntermediatesCache()
+    cache.set_intermediate("s1", "a", b"a")
+    cache.set_intermediate("s1", "b", b"b")
+    cache.set_intermediate("s1", "c", b"c")
+    assert cache.known_intermediate_keys("s1") == ["a", "b", "c"]
+
+
+def test_known_intermediate_keys_unknown_session():
+    cache = IntermediatesCache()
+    assert cache.known_intermediate_keys("nope") == []

--- a/tests/integration/gui/test_run_preview_cache.py
+++ b/tests/integration/gui/test_run_preview_cache.py
@@ -1,0 +1,130 @@
+"""End-to-end exercise of the builder preview-cache contract.
+
+Drives :func:`phenotypic.gui.builder._callbacks._bake_preview_cache` against
+a small ``BuilderState`` (``GaussianBlur → OtsuDetector → MeasureSize``) and
+asserts:
+
+- Cache slots for ops nodes hold raw PNG :class:`bytes`.
+- Cache slots for measurement / post nodes hold a :class:`pandas.DataFrame`.
+- No :class:`Image` / :class:`GridImage` instance is referenced from the
+  cache afterward (verified via ``gc.get_referents`` walk).
+"""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+import pandas as pd
+
+from phenotypic.data._synthetic_data import load_synth_yeast_plate
+from phenotypic.gui.builder._callbacks import _bake_preview_cache
+from phenotypic.gui.builder._session import IntermediatesCache, PreviewRenderError
+from phenotypic.gui.builder._state import (
+    BuilderScope,
+    BuilderState,
+    StepNode,
+    to_pipeline,
+)
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _seed_pipeline_state() -> BuilderState:
+    """A minimal three-step state spanning ops + meas."""
+    return BuilderState(
+        root=BuilderScope(
+            nodes=[
+                StepNode(node_id="aaa", class_name="GaussianBlur",
+                         params={"sigma": 1.0}, label="GaussianBlur"),
+                StepNode(node_id="bbb", class_name="OtsuDetector",
+                         label="OtsuDetector"),
+                StepNode(node_id="ccc", class_name="MeasureSize",
+                         label="MeasureSize"),
+            ],
+            name="bake-test",
+        ),
+    )
+
+
+def test_bake_preview_cache_populates_bytes_for_ops():
+    state = _seed_pipeline_state()
+    pipeline = to_pipeline(state.root)
+    image = load_synth_yeast_plate()
+    result = pipeline.apply_with_intermediates(image)
+
+    cache = IntermediatesCache()
+    _bake_preview_cache(state, pipeline, result, "sess-1", cache)
+
+    enhancer_blob = cache.get_intermediate("sess-1", "aaa")
+    detector_blob = cache.get_intermediate("sess-1", "bbb")
+    assert isinstance(enhancer_blob, bytes)
+    assert isinstance(detector_blob, bytes)
+    assert enhancer_blob[:8] == PNG_MAGIC
+    assert detector_blob[:8] == PNG_MAGIC
+
+
+def test_bake_preview_cache_stores_dataframe_for_measurements():
+    state = _seed_pipeline_state()
+    pipeline = to_pipeline(state.root)
+    result = pipeline.apply_with_intermediates(load_synth_yeast_plate())
+
+    cache = IntermediatesCache()
+    _bake_preview_cache(state, pipeline, result, "sess-1", cache)
+
+    meas_payload = cache.get_intermediate("sess-1", "ccc")
+    assert isinstance(meas_payload, pd.DataFrame)
+    assert meas_payload.shape[0] > 0  # type: ignore[union-attr]
+
+
+def test_bake_preview_cache_holds_no_image_references():
+    """The cache must drop intermediate Images after rendering — only bytes.
+
+    Uses a weakref against each :class:`Image` produced by
+    :meth:`apply_with_intermediates`: after the cache is baked and our local
+    references are dropped, the weakrefs must dereference to ``None``. If the
+    cache (or any code reachable from it) still holds an intermediate alive,
+    the corresponding ``ref()`` returns the live object and the test fails.
+    """
+    state = _seed_pipeline_state()
+    pipeline = to_pipeline(state.root)
+    result = pipeline.apply_with_intermediates(load_synth_yeast_plate())
+
+    intermediate_refs = [
+        weakref.ref(img)
+        for img in result.intermediates.values()
+        if img is not None
+    ]
+    assert intermediate_refs, "expected at least one intermediate Image"
+
+    cache = IntermediatesCache()
+    _bake_preview_cache(state, pipeline, result, "sess-1", cache)
+
+    # Drop our local refs and force collection; only the cache could be
+    # holding them now.
+    del result
+    gc.collect()
+
+    live = [ref() for ref in intermediate_refs if ref() is not None]
+    assert not live, (
+        f"IntermediatesCache still holds {len(live)} intermediate Image(s); "
+        "pre-baking should have dropped them after PNG encoding."
+    )
+
+
+def test_bake_preview_cache_renders_independently_of_run_preview_callback():
+    """Smoke: same logic the callback invokes; no Dash app needed."""
+    state = _seed_pipeline_state()
+    pipeline = to_pipeline(state.root)
+    result = pipeline.apply_with_intermediates(load_synth_yeast_plate())
+
+    cache = IntermediatesCache()
+    _bake_preview_cache(state, pipeline, result, "sess-2", cache)
+
+    keys = cache.known_intermediate_keys("sess-2")
+    assert set(keys) == {"aaa", "bbb", "ccc"}
+    # Spot-check no PreviewRenderError leaked through on the happy path.
+    for key in keys:
+        assert not isinstance(
+            cache.get_intermediate("sess-2", key), PreviewRenderError
+        )


### PR DESCRIPTION
## Summary

The builder's Run-preview cache previously held full `Image`/`GridImage` instances per op (~50–150 MB each on a 4000×6000 plate). With 4 sessions × 16 intermediates per session, worst-case resident memory could climb to 1–2 GB even though the inspector only ever displayed a single 512px PNG.

This PR pre-bakes one PNG per intermediate at preview-run time and caches the bytes (or a `pandas.DataFrame` for measurement nodes). Worst-case cache memory drops from **~1–2 GB → ~10–15 MB**, and inspector node-switching becomes a single base64 wrap (no per-selection PIL re-encode).

### Per-stage rendering rule
- **Enhancer** → PNG of `detect_mat`
- **Detector / Refiner** → objmap overlay on `detect_mat` (`skimage.color.label2rgb` with a matplotlib tab20 fallback)
- **Corrector / nested `Pipeline` / unknown** → PNG of `rgb`

Render failures are caught per-node and stored as a `PreviewRenderError(message)` sentinel, so a single bad render surfaces inline in the inspector without voiding the rest of the preview.

### Notable changes

- **`_image_renderer.py`** — split `to_data_uri` into `to_png_bytes` + `bytes_to_data_uri`; added `to_overlay_png_bytes` and a `render_node_preview` per-stage dispatcher.
- **`_session.py`** — added `PreviewRenderError` (frozen dataclass) and a `CachedPreview = bytes | DataFrame | PreviewRenderError` alias; the cache no longer holds `Image` instances.
- **`_callbacks.py`** — extracted a testable `_bake_preview_cache(state, pipeline, result, session_id, cache)` helper from `run_preview`'s body. Inspector callback now narrows on the union and just base64-wraps bytes.
- **`gui/CLAUDE.md`** — documented the bytes-only contract under a new "Builder preview cache" section.
- Adjacent cleanup: replaced deprecated `matplotlib.cm.get_cmap("tab20", 20)` with the modern `matplotlib.colormaps["tab20"]` API.

This PR also includes a prior small fix (`fix(gui/builder): nesting breadcrumb + PEP 604 union param coercion`, commit d3952689) that was already on the branch.

## Test plan

- [x] `uv run pytest tests/gui tests/integration/gui` — **222 passed**, 1 deselected (full GUI suite green).
- [x] `uv run pytest tests/gui/builder/test_image_renderer.py tests/gui/builder/test_session.py tests/integration/gui/test_run_preview_cache.py -v` — **41 new tests** cover PNG rendering per channel, base64 round-trip, overlay rendering + skimage-fallback, the LRU/FIFO/mixed-payload cache contract, and an end-to-end `_bake_preview_cache` exercise that uses `weakref` to assert no `Image` survives in the cache.
- [x] `uv run ruff check` — clean on every touched file.
- [x] `uv run mypy src/phenotypic/gui/builder/_image_renderer.py src/phenotypic/gui/builder/_session.py src/phenotypic/gui/builder/_callbacks.py` — zero new errors.
- [ ] Manual smoke: `uv run phenotypic-gui`, build `loader → GaussianBlur → ThresholdDetector → MeasureSize`, Run preview, click each node — confirm detect_mat for the enhancer, overlay for the detector, DataFrame for the measurement.
- [ ] RSS spot-check on a 4000×6000 plate with a 6+ op pipeline against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)