### PR TITLE
test(gui): de-flake run-pytest-full py3.12 lanes

### DIFF
--- a/tests/unit/gui/shell/test_session.py
+++ b/tests/unit/gui/shell/test_session.py
@@ -323,7 +323,11 @@ def test_idle_thread_does_not_release_during_active_get() -> None:
     On the buggy code, the daemon polled hundreds of times while ``slow_build``
     sat in ``Event.wait``, eventually taking the lock and tearing down the
     state the moment the build finished — so ``is_built()`` is False after
-    the getter returned.
+    the getter returned. ``idle_release_seconds`` is set well above the
+    build duration so under the *correct* code the daemon's post-get poll
+    deterministically skips (idle ≈ 50 ms ≪ 0.5 s); under the buggy code
+    ``last_access`` would still be ``0.0`` so ``idle_seconds`` resolves to
+    wall-clock-since-process-start, far exceeding 0.5 s, and release fires.
     """
     proceed = threading.Event()
     teardowns: List[str] = []
@@ -340,8 +344,8 @@ def test_idle_thread_does_not_release_during_active_get() -> None:
     sessions: list[ToolSession[object]] = [session]  # type: ignore[list-item]
     thread = start_idle_release_thread(
         sessions,
-        idle_release_seconds=0.0,
-        poll_interval_seconds=0.001,
+        idle_release_seconds=0.5,
+        poll_interval_seconds=0.01,
         stop_event=stop,
     )
     try:
@@ -358,9 +362,10 @@ def test_idle_thread_does_not_release_during_active_get() -> None:
         getter.join(timeout=2.0)
 
         # Right after get() returns, the session must still hold the state
-        # the caller just received. ``release()`` may run on a *later* poll
-        # (idle_seconds=0, so we expect that), but the immediate post-get
-        # invariant is what protects callers from racing rebuilds.
+        # the caller just received. With idle_release_seconds=0.5 and a build
+        # of ~50 ms, the daemon's next poll sees idle ≈ 0.05 < 0.5 and
+        # legitimately skips — so any teardown observed here can only come
+        # from the ordering race the fix prevents.
         assert getter_result == ["state"]
         assert teardowns == [], (
             "daemon released a session whose build had just completed; "

--- a/tests/unit/gui/test_config_and_design.py
+++ b/tests/unit/gui/test_config_and_design.py
@@ -131,17 +131,20 @@ class TestPrintLauncherBanner:
     def test_banner_contains_title_url_and_tunnel_hint(self, capsys) -> None:
         from pathlib import Path
 
+        root = Path("/tmp/sandbox")
         _config.print_launcher_banner(
             title=_config.TITLE_HUB,
             host=_config.DEFAULT_HOST,
             port=_config.DEFAULT_PORT,
-            root=Path("/tmp/sandbox"),
+            root=root,
         )
         out = capsys.readouterr().out
         assert _config.TITLE_HUB in out
         assert "http://127.0.0.1:8050/" in out
         assert "ssh -L 8050:localhost:8050" in out
-        assert "/tmp/sandbox" in out
+        # ``Path.__str__`` is platform-native (``/tmp/sandbox`` on POSIX,
+        # ``\tmp\sandbox`` on Windows) and the banner echoes it verbatim.
+        assert str(root) in out
 
     def test_extra_lines_appear_indented(self, capsys) -> None:
         from pathlib import Path


### PR DESCRIPTION
## Summary

Two single-test failures broke the `run-pytest-full` nightly / post-merge full lane on Python 3.12 ([run 25424599094](https://github.com/exfab/PhenoTypic/actions/runs/25424599094)). Both root causes are in the **tests**, not the source code — `_session.py` and `_config.py` behave correctly and are deliberately left unchanged.

## What changed

### `tests/unit/gui/shell/test_session.py` — Linux 3.12 flake

`test_idle_thread_does_not_release_during_active_get` used `idle_release_seconds=0.0`, which legitimately releases the session on the daemon's first post-get poll under the *correct* fix:

1. `get()` acquires lock, sets `_last_access = T0`, calls `slow_build()` (~50 ms).
2. Daemon polls during build: `is_built() == False` → skip. ✅
3. Build returns; lock released at `T0 + 0.05`.
4. Next daemon poll: `is_built() == True`, `idle_seconds() ≈ 0.05`. With threshold `0.0`, `0.05 < 0.0` is False → daemon legitimately releases → assertion `teardowns == []` fails.

Bumped `idle_release_seconds` to `0.5` (≫ build duration) and `poll_interval_seconds` to `0.01`. The test still catches the original ordering bug: under buggy code, `last_access` would be stuck at `0.0`, so `idle_seconds` resolves to wall-clock-since-process-start and far exceeds 0.5s — release fires exactly as the test wants to detect. Convention matches the existing `test_idle_thread_respects_touch` (also `0.5`).

### `tests/unit/gui/test_config_and_design.py` — Windows 3.12 failure

`test_banner_contains_title_url_and_tunnel_hint` asserted the literal POSIX substring `"/tmp/sandbox"` after the banner prints a `Path`. On Windows `Path("/tmp/sandbox").__str__()` is `"\\tmp\\sandbox"` — backslash separators are the platform-native, documented intent of the banner. Capture the `Path` locally and assert via `str(root)`.

## Why source code is unchanged

`_session.py:117-122` correctly sets `_last_access` *before* invoking `build` under the lock, which is the original race fix this test was written to pin. Touching it risks regressing the very fix the test exists to guard. Likewise the banner intentionally surfaces the path verbatim so users can confirm what the launcher pointed at on their platform.

## Test plan

- [x] `uv run pytest tests/unit/gui/shell/test_session.py tests/unit/gui/test_config_and_design.py -n auto` — 37/37 passed locally
- [x] 50× stress on `test_idle_thread_does_not_release_during_active_get` — 50/50 passed in 0.10–0.14s
- [ ] PR-lane `run-pytest.yml` matrix (Linux + Windows + macOS) goes green
- [ ] Post-merge `run-pytest-full.yml` Linux 3.10/3.11/3.12, macOS 3.12, Windows 3.12 all green

## Out of scope

- 48× `ValueError: I/O operation on closed file.` chatter from `execnet/gateway_base.py:1806` is xdist worker-shutdown logging, not test failures — short-test-summary in the original log confirms only the two failures fixed here.
- `mahotas/morph.py:322 SyntaxWarning` is a third-party warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)