### PR TITLE
refactor(asymmetric-spur-trimmer): remove max_trim_fraction safety cap

### DIFF
--- a/src/phenotypic/refine/_asymmetric_spur_trimmer.py
+++ b/src/phenotypic/refine/_asymmetric_spur_trimmer.py
@@ -37,9 +37,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
       ``R_sym`` lands further from the inoculum core.
     * Per-CC segmentation localizes the decision — trimming one noisy spur
       never touches a legitimate branch on the other side of the colony.
-    * A safety cap (``max_trim_fraction``) aborts trimming for any colony
-      where the proposal would remove more than the given fraction of its
-      pixels, protecting uniformly asymmetric morphologies.
 
     Args:
         symmetry_threshold: Minimum angular coverage (fraction of
@@ -63,10 +60,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
             CC past ``R_sym`` is trimmed — the "pure R_sym" mode. When a
             float, CCs with ``(1 - euler_number) / area`` below the threshold
             are kept as legitimate linear branches.
-        max_trim_fraction: Safety cap on the fraction of a colony's pixels
-            that may be removed in a single application. If the proposal
-            exceeds this fraction, trimming is aborted for that colony.
-            Defaults to 0.25.
         min_cc_area: Minimum candidate-CC area (pixels) required to make a
             topological decision. Smaller CCs are kept unchanged because
             Euler statistics are unreliable on tiny regions. Defaults to 50.
@@ -125,7 +118,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
             smoothing_window: int = 3,
             method: Literal["distance", "intensity"] = "distance",
             beehive_threshold: float | None = None,
-            max_trim_fraction: float = 0.25,
             min_cc_area: int = 50,
             min_object_area: int = 100,
     ):
@@ -144,11 +136,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
                     "beehive_threshold must be non-negative or None; "
                     f"got {beehive_threshold}."
             )
-        if not 0.0 < max_trim_fraction <= 1.0:
-            raise ValueError(
-                    "max_trim_fraction must be in (0, 1]; "
-                    f"got {max_trim_fraction}."
-            )
 
         self.symmetry_threshold = symmetry_threshold
         self.n_angular_bins = n_angular_bins
@@ -157,7 +144,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
         self.smoothing_window = smoothing_window
         self.method = method
         self.beehive_threshold = beehive_threshold
-        self.max_trim_fraction = max_trim_fraction
         self.min_cc_area = min_cc_area
         self.min_object_area = min_object_area
 
@@ -220,8 +206,7 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
         Returns:
             A boolean array the same shape as ``obj_mask`` with ``True``
             at pixels to remove, or ``None`` when the colony is ineligible
-            (no asymmetric region, degenerate geometry, or proposal trips
-            the safety cap).
+            (no asymmetric region or degenerate geometry).
         """
         # 1. Centroid (local bbox coords). Distance-transform peak is a safe
         # fallback; intensity mode uses it when the intensity is all zero and
@@ -328,19 +313,6 @@ class AsymmetricSpurTrimmer(ObjectRefiner):
                 to_remove |= cc_mask
 
         if not to_remove.any():
-            return None
-
-        # 6. Safety cap.
-        total_area = int(obj_mask.sum())
-        if total_area <= 0:
-            return None
-        trim_fraction = to_remove.sum() / float(total_area)
-        if trim_fraction > self.max_trim_fraction:
-            _log.debug(
-                    "AsymmetricSpurTrimmer aborted label %d: trim fraction "
-                    "%.3f exceeds max_trim_fraction %.3f.",
-                    prop.label, trim_fraction, self.max_trim_fraction,
-            )
             return None
 
         return to_remove

--- a/tests/unit/refine/test_asymmetric_spur_trimmer.py
+++ b/tests/unit/refine/test_asymmetric_spur_trimmer.py
@@ -173,35 +173,12 @@ class TestWebNoiseTrimmedBeehiveMode:
     def test_web_removed(self, web_noise_colony: Image) -> None:
         refined = AsymmetricSpurTrimmer(
                 beehive_threshold=0.002,
-                max_trim_fraction=0.9,  # lift the safety cap for this synthetic
         ).apply(web_noise_colony)
 
         # The web lives at cols 160-340 ish. After trim, little should survive there.
         web_cols_after = (refined.objmap[:, 180:330] > 0).sum()
         assert web_cols_after < 200, (
             "Web noise should be largely removed"
-        )
-
-
-class TestUniformlyAsymmetricSafetyCap:
-    """A mostly-asymmetric single colony trips the safety cap → no trim."""
-
-    def test_thin_ellipse_untouched(self) -> None:
-        objmap = np.zeros((200, 200), dtype=np.int32)
-        rr, cc = np.indices(objmap.shape)
-        # Thin horizontal ellipse: semi-major=80, semi-minor=8.
-        ellipse = ((rr - 100) / 8.0) ** 2 + ((cc - 100) / 80.0) ** 2 <= 1.0
-        objmap[ellipse] = 1
-        image = _make_image(objmap)
-
-        before = image.objmap[:].copy()
-        refined = AsymmetricSpurTrimmer().apply(image)
-
-        # Safety cap or a non-trivially-large preservation expected.
-        trimmed = int((before > 0).sum()) - int((refined.objmap[:] > 0).sum())
-        original = int((before > 0).sum())
-        assert trimmed / max(original, 1) <= 0.25 + 1e-9, (
-            "Safety cap was not respected"
         )
 
 
@@ -242,35 +219,13 @@ class TestMultiColonyIndependent:
             self, two_colonies_one_spurred: Image
     ) -> None:
         before = two_colonies_one_spurred.objmap[:].copy()
-        refined = AsymmetricSpurTrimmer(max_trim_fraction=0.9).apply(
-                two_colonies_one_spurred
-        )
+        refined = AsymmetricSpurTrimmer().apply(two_colonies_one_spurred)
         after = refined.objmap[:]
 
         # Label-1 disk (no spur) must be byte-for-byte identical.
         np.testing.assert_array_equal(after == 1, before == 1)
         # Label 2's spur region must have lost pixels.
         assert (after == 2).sum() < (before == 2).sum()
-
-
-class TestMaxTrimFractionSafety:
-    """A small colony with a big spur must not be eaten past max_trim_fraction."""
-
-    def test_safety_cap_respected(self) -> None:
-        objmap = np.zeros((150, 500), dtype=np.int32)
-        _stamp_disk(objmap, centre=(75, 50), radius=15, label=1)
-        # Spur dominating the colony by pixel count.
-        _stamp_rect(objmap, start=(73, 80), end=(77, 480), label=1)
-        image = _make_image(objmap)
-
-        original_area = int((image.objmap[:] == 1).sum())
-        refined = AsymmetricSpurTrimmer(max_trim_fraction=0.25).apply(image)
-        after_area = int((refined.objmap[:] == 1).sum())
-
-        trimmed_fraction = (original_area - after_area) / max(original_area, 1)
-        assert trimmed_fraction <= 0.25 + 1e-9, (
-            f"Safety cap violated: trimmed {trimmed_fraction:.2%}"
-        )
 
 
 class TestBeehiveThresholdMonotonic:
@@ -283,7 +238,6 @@ class TestBeehiveThresholdMonotonic:
             img = _make_image(web_noise_colony.objmap[:].copy())
             refined = AsymmetricSpurTrimmer(
                     beehive_threshold=threshold,
-                    max_trim_fraction=0.9,
             ).apply(img)
             trimmed_counts.append(
                     originals - int((refined.objmap[:] > 0).sum())
@@ -302,7 +256,6 @@ class TestJsonRoundtrip:
         trimmer = AsymmetricSpurTrimmer(
                 symmetry_threshold=0.4,
                 beehive_threshold=0.003,
-                max_trim_fraction=0.3,
                 min_cc_area=75,
                 min_object_area=120,
                 method="intensity",
@@ -316,7 +269,6 @@ class TestJsonRoundtrip:
         assert isinstance(restored_trimmer, AsymmetricSpurTrimmer)
         assert restored_trimmer.symmetry_threshold == 0.4
         assert restored_trimmer.beehive_threshold == 0.003
-        assert restored_trimmer.max_trim_fraction == 0.3
         assert restored_trimmer.min_cc_area == 75
         assert restored_trimmer.min_object_area == 120
         assert restored_trimmer.method == "intensity"
@@ -383,10 +335,6 @@ class TestInvalidConstructorArgs:
     def test_negative_beehive_threshold(self) -> None:
         with pytest.raises(ValueError):
             AsymmetricSpurTrimmer(beehive_threshold=-0.01)
-
-    def test_max_trim_fraction_zero(self) -> None:
-        with pytest.raises(ValueError):
-            AsymmetricSpurTrimmer(max_trim_fraction=0.0)
 
     def test_invalid_method(self) -> None:
         with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Removes the `max_trim_fraction` kill switch from `AsymmetricSpurTrimmer`. Trimming is now governed solely by the radial symmetry envelope (`R_sym`) and the optional beehive topology gate (`beehive_threshold`).
- Pixels at or inside `R_sym` remain mathematically untouched (verified: `to_remove ⊆ obj_mask & (dist_map > r_sym)`); only the per-colony fraction-based veto is gone.
- Heavily asymmetric morphologies (e.g. very elongated colonies, dominant single spurs) are no longer auto-protected — callers wanting that behaviour should rely on `beehive_threshold` or upstream filtering.

## Changes
- `src/phenotypic/refine/_asymmetric_spur_trimmer.py`: drop the docstring bullet, Args entry, `__init__` parameter + validation + attribute, and the "Safety cap" block in `_trim_mask_for_object`. Updated the helper's Returns docstring accordingly.
- `tests/unit/refine/test_asymmetric_spur_trimmer.py`: remove `TestUniformlyAsymmetricSafetyCap`, `TestMaxTrimFractionSafety`, and `test_max_trim_fraction_zero`; strip `max_trim_fraction=...` kwargs from `test_web_removed`, `test_only_spurred_colony_trimmed`, `test_monotonic_decrease`, and the JSON-roundtrip test (and its corresponding assertion).

## Test plan
- [x] `uv run pytest tests/unit/refine/test_asymmetric_spur_trimmer.py` (16 passed)
- [ ] Spot-check a real filamentous-fungi plate downstream of `FilamentousFungiDetector` to confirm trimming is acceptable without the safety cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)