### PR TITLE
refactor(cli): join external metadata onto mirror only, keep master clean

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,14 +183,21 @@ never derive `Literal` from runtime expressions.
 - **`num_objects` is on `Image`**, not on the `objmap` accessor: use
   `image.num_objects`.
 - **Master vs. mirror outputs:** `master_measurements.{csv,parquet}` is a
-  **clean, pre-post archive** of what per-image runs measured;
-  `measurements.{csv,parquet}` is the **post-applied mirror** the GUI
-  viewer reads/curates. Per-image parquets in `results/<ds>/measurements/`
-  are also clean — the CLI calls `pipeline.measure(image, apply_post=False)`
-  on the per-image path. Post is applied once at the end of aggregation
-  against the merged master, and the post-applied frame is what
-  `analysis.{csv,parquet}` and `measurements_by_feature/<feature>.{csv,
-  parquet}` are derived from — only the master archive stays clean.
+  **clean, pre-post, metadata-free archive** of what per-image runs
+  measured; `measurements.{csv,parquet}` is the **post-applied mirror**
+  the GUI viewer reads/curates. Per-image parquets in
+  `results/<ds>/measurements/` are also clean — the CLI calls
+  `pipeline.measure(image, apply_post=False)` on the per-image path.
+  Post is applied once at the end of aggregation against the merged
+  master, and the post-applied frame is what `analysis.{csv,parquet}`
+  and `measurements_by_feature/<feature>.{csv,parquet}` are derived
+  from. The external `--metadata` CSV inner-join also lands on the
+  post-applied frame (inside `finalize_post_master_outputs`), so the
+  mirror, per-feature splits, and `analysis.{csv,parquet}` carry the
+  metadata columns while the master archive stays both post-free and
+  metadata-free. Code paths that need to feed a frame to analysis
+  plugins or dashboards should read `measurements.parquet`, not
+  `master_measurements.*`.
 - **Finalize via `finalize_post_master_outputs` for FINAL master writes:**
   any code path that writes `master_measurements.{csv,parquet}` *as the
   run's final output* must immediately call

--- a/src/phenotypic/_cli/_cli_checkpoint_handler.py
+++ b/src/phenotypic/_cli/_cli_checkpoint_handler.py
@@ -18,7 +18,7 @@ from ._cli_file_locking import FileLockTimeout, file_lock
 from ._cli_utils import load_job_metadata
 from phenotypic.tools_ import (
     DIR_PROGRESS,
-    MASTER_MEASUREMENTS_CSV,
+    MEASUREMENTS_PARQUET,
     PROCESSING_EVENTS_LOG,
     JobMetadataKey,
     checkpoint_lock_filename,
@@ -157,13 +157,17 @@ def _run_finalize(output_dir: Path, progress_dir: Path) -> None:
 
     import polars as pl
 
-    master_path = output_dir / MASTER_MEASUREMENTS_CSV
+    # Analysis plugins consume the post-applied mirror (which carries the
+    # external metadata join) so dashboard sidecars match what the GUI
+    # viewer and per-feature splits see. The master archive is intentionally
+    # metadata-free and would regress plugin grouping if used here.
+    mirror_path = output_dir / MEASUREMENTS_PARQUET
     merged_df: Optional[pl.DataFrame] = None
-    if master_path.exists():
+    if mirror_path.exists():
         try:
-            merged_df = pl.read_csv(master_path)
+            merged_df = pl.read_parquet(mirror_path)
         except Exception:
-            logger.warning("Failed to read master CSV for analysis plugins")
+            logger.warning("Failed to read measurements mirror for analysis plugins")
     _run_analysis_plugins(output_dir, progress_dir, merged_df)
 
     # Regenerate dashboard

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -136,24 +136,30 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
         job_meta = load_job_metadata(progress_dir)
         csv_str = job_meta.get(JobMetadataKey.METADATA_CSV) if job_meta else None
         metadata_csv = Path(csv_str) if csv_str else None
+        # External metadata is intentionally kept out of the master archive,
+        # which stays a clean snapshot of what the workers measured. The
+        # join is computed in memory only for mid-run analysis-plugin
+        # dispatch so dashboard sidecars can still group by metadata
+        # columns; the on-disk mirror with the join lands at final
+        # aggregation via ``finalize_post_master_outputs``.
         combined_with_metadata = combined
         if metadata_csv is not None:
             try:
                 combined_with_metadata = join_metadata(combined, metadata_csv)
             except Exception:
                 logger.warning(
-                    "Metadata join failed, writing CSV without metadata",
+                    "Metadata join failed; analysis plugins will run without metadata",
                     exc_info=True,
                 )
                 combined_with_metadata = combined
 
         _atomic_write(
             output_dir / MASTER_MEASUREMENTS_CSV,
-            lambda p: combined_with_metadata.write_csv(p),  # type: ignore[union-attr]
+            lambda p: combined.write_csv(p),
         )
         _atomic_write(
             output_dir / MASTER_MEASUREMENTS_PARQUET,
-            lambda p: combined_with_metadata.write_parquet(  # type: ignore[union-attr]
+            lambda p: combined.write_parquet(
                 p, compression="zstd", compression_level=3
             ),
         )

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -505,6 +505,7 @@ def finalize_post_master_outputs(
     output_dir: Path,
     master_df: "pl.DataFrame",
     pipeline: Optional["ImagePipeline"],
+    metadata_csv: Optional[Path] = None,
 ) -> "pl.DataFrame":
     """Run every CLI side effect that follows a freshly written master file.
 
@@ -526,35 +527,55 @@ def finalize_post_master_outputs(
        :data:`~phenotypic.tools_.MEASUREMENTS_PARQUET`.
        When *pipeline* is ``None`` or has no post ops, ``post_df`` is the
        clean master unchanged.
-    2. :func:`_seed_measurements` writes the post-applied frame.
-    3. When *pipeline* is provided: persist ``pipeline.json``, run
+    2. If *metadata_csv* is provided, inner-join its rows onto ``post_df``
+       via :func:`join_metadata`. The join lands here — not on the master —
+       so ``master_measurements.{csv,parquet}`` stays a clean, op-free
+       archive of what the workers measured, and every downstream artifact
+       derived from ``post_df`` (mirror, per-feature splits,
+       ``analysis.{csv,parquet}``) inherits the external metadata columns.
+    3. :func:`_seed_measurements` writes the post-applied (and optionally
+       metadata-joined) frame.
+    4. When *pipeline* is provided: persist ``pipeline.json``, run
        :func:`_emit_analysis_outputs` against ``post_df`` (so analysis sees
        post-applied data), and split the post-applied frame into
        per-feature spreadsheets so users see post-derived columns
        (e.g. ``Metadata_Strain`` from ``ExpandMetadata``) in
        ``measurements_by_feature/<feature>.{csv,parquet}``.
 
-    Failures inside split or analysis are logged at WARNING and never raise;
-    the master files remain authoritative regardless of what happens here.
+    Failures inside metadata-join, split, or analysis are logged at WARNING
+    and never raise; the master files remain authoritative regardless of
+    what happens here.
 
     Args:
         output_dir: Output root that already contains
             :data:`~phenotypic.tools_.MASTER_MEASUREMENTS_PARQUET` (and the
             CSV counterpart).
-        master_df: The clean (post-free) aggregated master.
+        master_df: The clean (post-free, metadata-free) aggregated master.
         pipeline: Recovered pipeline, or ``None`` when it can't be
             located (the SLURM sentinel may run before any pipeline.json
             is persisted).
+        metadata_csv: Optional external metadata CSV. When provided, its
+            columns are inner-joined onto the post-applied frame before
+            seeding the mirror, so only the mirror (and its derivatives)
+            carry external metadata — never the master archive.
 
     Returns:
-        The post-applied frame. Callers that run additional side effects
-        downstream (e.g. analysis-plugin dispatch in the recompile
+        The post-applied frame (with external metadata joined when
+        *metadata_csv* is provided). Callers that run additional side
+        effects downstream (e.g. analysis-plugin dispatch in the recompile
         worker) should pass this to those steps so plugins see the same
         post-applied data the GUI viewer and analysis chain see, rather
         than the clean master. Equal to *master_df* when no post ops
-        are configured.
+        are configured and no metadata CSV is supplied.
     """
     post_df = _apply_post_to_master(master_df, pipeline)
+    if metadata_csv is not None:
+        try:
+            post_df = join_metadata(post_df, metadata_csv)
+        except Exception as e:
+            logger.warning(
+                "Failed to join metadata CSV: %s: %s", type(e).__name__, e
+            )
     _seed_measurements(output_dir, post_df)
 
     if pipeline is None:
@@ -773,13 +794,6 @@ def aggregate_measurements(
     if "filename" in master_df.columns:
         master_df = master_df.drop("filename")
 
-    # -- Join metadata -------------------------------------------------
-    if metadata_csv is not None:
-        try:
-            master_df = join_metadata(master_df, metadata_csv)
-        except Exception as e:
-            logger.warning("Failed to join metadata CSV: %s: %s", type(e).__name__, e)
-
     # -- Write master CSV and Parquet ----------------------------------
     master_csv_path = output_dir / MASTER_MEASUREMENTS_CSV
     master_pq_path = output_dir / MASTER_MEASUREMENTS_PARQUET
@@ -808,7 +822,9 @@ def aggregate_measurements(
     )
 
     resolved_pipeline = pipeline if pipeline is not None else _load_pipeline_from_output_dir(output_dir)
-    finalize_post_master_outputs(output_dir, master_df, resolved_pipeline)
+    finalize_post_master_outputs(
+        output_dir, master_df, resolved_pipeline, metadata_csv=metadata_csv
+    )
 
     return master_csv_path
 

--- a/src/phenotypic/_cli/_cli_recompile_worker.py
+++ b/src/phenotypic/_cli/_cli_recompile_worker.py
@@ -270,7 +270,7 @@ def _run_finalizer_task(output_dir: Path, task: dict[str, Any]) -> None:
             f"{len(failed_measurements)} measurement shard task(s) failed"
         )
 
-    merged_df = _write_master_outputs_from_shards(output_dir, task)
+    merged_df = _write_master_outputs_from_shards(output_dir)
     _run_post_master_steps(output_dir, progress_dir, task, merged_df)
 
 
@@ -313,13 +313,11 @@ def _read_expected_non_finalizer_statuses(
     return statuses
 
 
-def _write_master_outputs_from_shards(
-    output_dir: Path, task: dict[str, Any]
-) -> Any | None:
+def _write_master_outputs_from_shards(output_dir: Path) -> Any | None:
     """Concatenate shard Parquets and write master CSV/Parquet outputs."""
     import polars as pl
 
-    from ._cli_output_manager import _atomic_write, join_metadata
+    from ._cli_output_manager import _atomic_write
 
     shard_dir = output_dir / DIR_PROGRESS / DIR_RECOMPILE / DIR_RECOMPILE_SHARDS
     shard_files = sorted(shard_dir.glob("shard_*.parquet"))
@@ -329,15 +327,10 @@ def _write_master_outputs_from_shards(
     frames = [pl.read_parquet(path) for path in shard_files]
     master_df = pl.concat(frames, how="diagonal_relaxed")
 
-    metadata_csv_str = task.get(JobMetadataKey.METADATA_CSV)
-    if metadata_csv_str:
-        try:
-            master_df = join_metadata(master_df, Path(str(metadata_csv_str)))
-        except Exception as exc:
-            logger.warning(
-                "Failed to join metadata CSV during recompile finalization: %s",
-                exc,
-            )
+    # External metadata join is applied to the mirror in
+    # ``finalize_post_master_outputs`` (via ``_run_post_master_steps``), not
+    # to the master archive. The master stays a clean, op-free record of
+    # what the per-image workers measured.
 
     try:
         _atomic_write(output_dir / MASTER_MEASUREMENTS_CSV, master_df.write_csv)
@@ -383,14 +376,19 @@ def _run_post_master_steps(
     plugin_df: Any | None = merged_df
     if merged_df is not None:
         # Single canonical post-master finalize: applies post to a copy of
-        # the clean master, seeds ``measurements.{csv,parquet}`` with the
-        # post-applied frame, persists ``pipeline.json``, emits analysis,
-        # and writes per-feature splits — same path the forward CLI takes.
-        # Reuse the returned post-applied frame for analysis-plugin
-        # dispatch so plugins see the same data the analysis chain and
-        # the GUI viewer see.
+        # the clean master, joins the external metadata CSV (when given)
+        # onto the post-applied frame, seeds ``measurements.{csv,parquet}``,
+        # persists ``pipeline.json``, emits analysis, and writes per-feature
+        # splits — same path the forward CLI takes. Reuse the returned
+        # post-applied (and metadata-joined) frame for analysis-plugin
+        # dispatch so plugins see the same data the analysis chain and the
+        # GUI viewer see.
         pipeline = _load_pipeline_from_output_dir(output_dir)
-        plugin_df = finalize_post_master_outputs(output_dir, merged_df, pipeline)
+        metadata_csv_str = task.get(JobMetadataKey.METADATA_CSV)
+        metadata_csv = Path(str(metadata_csv_str)) if metadata_csv_str else None
+        plugin_df = finalize_post_master_outputs(
+            output_dir, merged_df, pipeline, metadata_csv=metadata_csv
+        )
 
     try:
         _run_analysis_plugins(output_dir, progress_dir, plugin_df)

--- a/src/phenotypic/_cli/_dashboard/_generator.py
+++ b/src/phenotypic/_cli/_dashboard/_generator.py
@@ -1028,9 +1028,10 @@ def _build_body(execution_mode: str, logo_data_uri: str = "",
 
         <input type="hidden" id="dl-cutdirs" value="N">
 
-        <p class="download-section-title">1. Master measurements (CSV)</p>
+        <p class="download-section-title">1. Measurements (CSV)</p>
         <p style="font-size:var(--text-sm);color:var(--color-muted)">
-          Single file with all colony measurements across datasets:</p>
+          Post-applied measurements with external metadata joined,
+          across all datasets:</p>
         <div class="download-cmd" id="cmd-csv"></div>
 
         <p class="download-section-title">2. Overlay images only</p>
@@ -1157,7 +1158,7 @@ def _build_js(execution_mode: str, plugins: list | None = None) -> str:
       if (user) auth = ' --user=' + user + (pass ? " --password='" + pass + "'" : '');
 
       document.getElementById('cmd-csv').textContent =
-        'wget' + auth + ' ' + base + 'master_measurements.csv';
+        'wget' + auth + ' ' + base + 'measurements.csv';
       document.getElementById('cmd-png').textContent =
         'wget -r -np -nH -e robots=off --cut-dirs=' + cutDirs + ' -A "*.png"' + auth + ' ' + base + 'results/';
       document.getElementById('cmd-full').textContent =
@@ -1624,7 +1625,7 @@ def _build_analysis_js(plugins: list) -> str:
     function loadSharedParquet() {
       if (sharedParquetState.loaded) return Promise.resolve();
       if (sharedParquetState.loading) return sharedParquetState.loading;
-      sharedParquetState.loading = _loadParquetFile('master_measurements.parquet')
+      sharedParquetState.loading = _loadParquetFile('measurements.parquet')
         .then(function() {
           sharedParquetState.loaded = true;
           sharedParquetState.loading = null;

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -186,7 +186,7 @@ from phenotypic.tools_ import (
     DIR_RECOMPILE,
     JOB_METADATA_JSON,
     PROCESSING_STATE_JSON,
-    MASTER_MEASUREMENTS_CSV,
+    MEASUREMENTS_PARQUET,
     RECOMPILE_TASK_MANIFEST_JSON,
     JobMetadataKey,
     dashboard_html_path,
@@ -1740,13 +1740,18 @@ def _handle_recompile(
     try:
         import polars as pl
 
+        # Plugins consume the post-applied mirror (which carries the
+        # external metadata join) so dashboard sidecars match what the
+        # GUI viewer and per-feature splits see. The master archive is
+        # intentionally metadata-free.
+        mirror_path = output_dir / MEASUREMENTS_PARQUET
         merged_df: Optional[pl.DataFrame] = None
-        if master_path and Path(master_path).exists():
+        if mirror_path.exists():
             try:
-                merged_df = pl.read_csv(master_path)
+                merged_df = pl.read_parquet(mirror_path)
             except Exception:
                 logger.warning(
-                    "Failed to read master CSV for analysis plugins",
+                    "Failed to read measurements mirror for analysis plugins",
                     exc_info=True,
                 )
         _run_analysis_plugins(output_dir, progress_dir, merged_df)

--- a/tests/unit/cli/test_cli_recompile.py
+++ b/tests/unit/cli/test_cli_recompile.py
@@ -120,14 +120,23 @@ class TestRecompileCliRouting:
 class TestHandleRecompile:
     """``_handle_recompile`` uses the finalizer analysis-plugin pattern."""
 
-    def test_dispatches_run_analysis_plugins_from_master_csv(
+    def test_dispatches_run_analysis_plugins_from_mirror_parquet(
         self, tmp_path: Path
     ) -> None:
+        import polars as pl
+
         output_dir = _make_fake_results(tmp_path)
 
         def _fake_aggregate(**_kwargs: object) -> Path:
+            # ``aggregate_measurements`` writes both the clean master archive
+            # and the post-applied mirror (via ``finalize_post_master_outputs``).
+            # Analysis plugins consume the mirror so they see the post-applied
+            # frame plus any joined external metadata.
             master = output_dir / "master_measurements.csv"
             master.write_text("col_a\n1\n", encoding="utf-8")
+            pl.DataFrame({"col_a": [1], "Metadata_Strain": ["WT"]}).write_parquet(
+                output_dir / "measurements.parquet"
+            )
             return master
 
         with (
@@ -166,6 +175,9 @@ class TestHandleRecompile:
         assert merged_df is not None
         assert merged_df.height == 1
         assert "col_a" in merged_df.columns
+        # Plugins must see metadata-joined columns from the mirror, not
+        # the clean master.
+        assert "Metadata_Strain" in merged_df.columns
 
         mock_manifest.assert_called_once()
         mock_dashboard.assert_called_once()

--- a/tests/unit/cli/test_cli_v2.py
+++ b/tests/unit/cli/test_cli_v2.py
@@ -1689,11 +1689,16 @@ class TestAggregateMeasurements:
         )
 
         assert result is not None
+        # Master archive stays clean: no external metadata columns join here.
         master = pd.read_csv(result)
-        assert "treatment" in master.columns
+        assert "treatment" not in master.columns
         assert len(master) == 3
-        assert list(master.loc[master["plate"] == "A", "treatment"].unique()) == ["control"]
-        assert list(master.loc[master["plate"] == "B", "treatment"].unique()) == ["drug_X"]
+        # Mirror carries the joined external metadata.
+        mirror = pd.read_csv(temp_output_dir / "measurements.csv")
+        assert "treatment" in mirror.columns
+        assert len(mirror) == 3
+        assert list(mirror.loc[mirror["plate"] == "A", "treatment"].unique()) == ["control"]
+        assert list(mirror.loc[mirror["plate"] == "B", "treatment"].unique()) == ["drug_X"]
 
     def test_aggregate_measurements_metadata_no_common_columns(self, temp_output_dir):
         """No shared columns produces warning, master CSV unchanged."""
@@ -1750,12 +1755,16 @@ class TestAggregateMeasurements:
         )
 
         assert result is not None
+        # Master archive is unfiltered: all source rows preserved, no metadata.
         master = pd.read_csv(result)
-        # Plate C dropped — no matching metadata
-        assert len(master) == 2
-        assert "treatment" in master.columns
-        assert set(master["plate"].tolist()) == {"A", "B"}
-        assert master["treatment"].notna().all()
+        assert "treatment" not in master.columns
+        assert set(master["plate"].tolist()) == {"A", "B", "C"}
+        # Mirror reflects the inner join: plate C dropped, treatment present.
+        mirror = pd.read_csv(temp_output_dir / "measurements.csv")
+        assert len(mirror) == 2
+        assert "treatment" in mirror.columns
+        assert set(mirror["plate"].tolist()) == {"A", "B"}
+        assert mirror["treatment"].notna().all()
 
     def test_aggregate_measurements_metadata_duplicate_keys_warns(self, temp_output_dir, caplog):
         """Duplicate keys in metadata CSV inflate rows and produce a warning."""
@@ -1783,9 +1792,13 @@ class TestAggregateMeasurements:
             )
 
         assert result is not None
+        # Master archive stays at the original row count (no join applied).
         master = pd.read_csv(result)
-        # Row count inflated from 1 to 2
-        assert len(master) == 2
+        assert len(master) == 1
+        assert "treatment" not in master.columns
+        # Mirror reflects the duplicate-key inflation.
+        mirror = pd.read_csv(temp_output_dir / "measurements.csv")
+        assert len(mirror) == 2
         assert "duplicate keys" in caplog.text
 
     def test_aggregate_measurements_metadata_dtype_mismatch(self, temp_output_dir):
@@ -1814,11 +1827,15 @@ class TestAggregateMeasurements:
         )
 
         assert result is not None
+        # Master archive stays clean — no metadata-join side effects.
         master = pd.read_csv(result)
         assert len(master) == 2
-        assert "treatment" in master.columns
-        # Both rows should match (no NaN in treatment)
-        assert master["treatment"].notna().all()
+        assert "treatment" not in master.columns
+        # Mirror carries the join even across int/str dtype mismatch on the key.
+        mirror = pd.read_csv(temp_output_dir / "measurements.csv")
+        assert len(mirror) == 2
+        assert "treatment" in mirror.columns
+        assert mirror["treatment"].notna().all()
 
     def test_aggregate_measurements_parquet_with_duckdb(self, temp_output_dir):
         """Standard .parquet files aggregate correctly via DuckDB."""


### PR DESCRIPTION
## Summary

- Move the external `--metadata` CSV inner-join out of `master_measurements.{csv,parquet}` and into `finalize_post_master_outputs`, so only the post-applied mirror (`measurements.{csv,parquet}`) and its derivatives (per-feature splits, `analysis.{csv,parquet}`) carry external metadata. The master archive stays a clean, post-free, **metadata-free** record of what per-image workers measured.
- Apply the change at every master-writer site: forward CLI (`aggregate_measurements`), recompile worker (`_run_post_master_steps`), and the mid-run chunk writer (`_aggregate_chunks_locked` keeps an in-memory join solely for analysis-plugin dispatch — master snapshots are written clean).
- Switch every analysis-plugin consumer to read the mirror so dashboard sidecars keep metadata grouping: SLURM finalizer (`_cli_checkpoint_handler._run_finalize`), local `--recompile` (`_handle_recompile`), and the recompile worker already-routed-through-finalize path.
- Dashboard "Download CSV" wget command and the clientside `loadSharedParquet()` loader now point at `measurements.{csv,parquet}` instead of the master, so users browsing the dashboard see the metadata-joined frame.
- `CLAUDE.md` "Master vs. mirror outputs" gotcha updated to reflect that the master is now metadata-free and to direct downstream readers to the mirror.

## Test plan

- [x] `uv run pytest tests/unit/cli` — 226 passed, including four `TestAggregateMeasurements` cases updated to assert master is clean and mirror carries the join (happy path, partial match, duplicate-key inflation, dtype mismatch) and a recompile test updated to assert plugins receive metadata-joined data from the mirror.
- [x] `uv run ruff check` on every edited file — no new errors (4 pre-existing dead-import warnings in `phenotypicCLI.py` are unchanged from main).
- [ ] End-to-end smoke (reviewer-suggested manual check): run `uv run python -m phenotypic <images> --metadata <metadata.csv> -o <out>` and confirm `master_measurements.parquet` has no external metadata columns while `measurements.parquet`, `measurements_by_feature/*.parquet`, and `analysis.parquet` do.
- [ ] Recompile smoke: `uv run python -m phenotypic --recompile <out> --metadata <metadata.csv>` produces the same master/mirror shapes as the forward path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)