### PR TITLE
fix(tests): skip chmod permission tests as root; skip SAM2 when download blocked

### DIFF
--- a/tests/integration/gui/test_runs_blueprint.py
+++ b/tests/integration/gui/test_runs_blueprint.py
@@ -144,8 +144,8 @@ def test_missing_file_returns_404(sandbox: SandboxRoot) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="chmod-based permission test is POSIX-specific",
+    sys.platform == "win32" or os.getuid() == 0,
+    reason="chmod-based permission test is POSIX-specific and meaningless as root",
 )
 def test_permission_denied_returns_403(sandbox: SandboxRoot) -> None:
     f = sandbox.root / "locked.txt"
@@ -219,8 +219,8 @@ def test_touch_not_called_on_rejected_request(
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="chmod-based permission test is POSIX-specific",
+    sys.platform == "win32" or os.getuid() == 0,
+    reason="chmod-based permission test is POSIX-specific and meaningless as root",
 )
 def test_touch_not_called_on_403(
     sandbox: SandboxRoot, viewer_session: ToolSession[str]

--- a/tests/unit/gui/shell/test_classifier.py
+++ b/tests/unit/gui/shell/test_classifier.py
@@ -162,8 +162,8 @@ def test_broken_symlink_returns_empty(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="chmod-based permission test is POSIX-specific",
+    sys.platform == "win32" or os.getuid() == 0,
+    reason="chmod-based permission test is POSIX-specific and meaningless as root",
 )
 def test_permission_denied_directory(tmp_path: Path) -> None:
     locked = tmp_path / "locked"

--- a/tests/unit/gui/shell/test_sandbox.py
+++ b/tests/unit/gui/shell/test_sandbox.py
@@ -183,8 +183,8 @@ def test_list_children_outside_root_raises(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="chmod-based permission test is POSIX-specific",
+    sys.platform == "win32" or os.getuid() == 0,
+    reason="chmod-based permission test is POSIX-specific and meaningless as root",
 )
 def test_list_children_permission_error_propagates(tmp_path: Path) -> None:
     """``list_children`` does not swallow PermissionError.

--- a/tests/unit/nn/test_sam2_detector.py
+++ b/tests/unit/nn/test_sam2_detector.py
@@ -152,9 +152,35 @@ class TestSam2DetectorSerialization:
 # ---------------------------------------------------------------------------
 
 
+def _sam2_tiny_available() -> bool:
+    """True if the tiny SAM2 checkpoint is cached locally or the download host is reachable.
+
+    The download host (dl.fbaipublicfiles.com) is blocked in some CI environments
+    (network policy returns 403 host_not_allowed). Tests skip rather than fail when
+    neither the cache nor the network is available.
+    """
+    if not SAM2_AVAILABLE:
+        return False
+    from phenotypic.nn._checkpoint_manager import Sam2CheckpointManager
+    if Sam2CheckpointManager.is_cached("tiny"):
+        return True
+    import urllib.error
+    import urllib.request
+    try:
+        req = urllib.request.Request(
+            Sam2CheckpointManager.BASE_URL
+            + Sam2CheckpointManager.MODELS["tiny"]["filename"],
+            method="HEAD",
+        )
+        with urllib.request.urlopen(req, timeout=3):
+            return True
+    except Exception:
+        return False
+
+
 @pytest.mark.skipif(
-    not SAM2_AVAILABLE,
-    reason="Requires phenotypic[torch] (sam2 + torch)",
+    not SAM2_AVAILABLE or not _sam2_tiny_available(),
+    reason="Requires phenotypic[torch] and a cached or downloadable SAM2 tiny checkpoint",
 )
 class TestSam2DetectorFunctional:
     """Functional tests that load a model and run inference."""


### PR DESCRIPTION
## Summary

The full pytest suite (`run-pytest-full.yml`, triggered on push to main) had 7 failures in two distinct groups. This PR fixes both.

---

### Failure group 1 — Root-user bypass (4 tests, 3 files)

**Root cause:** The CI/remote-execution container runs as `uid=0` (root). `chmod 0o000` on a file or directory has no effect for root — the kernel bypasses DAC permission checks. All four tests that `chmod` a path to mode-0 and then expect a `PermissionError` (or a `bad_perms=True` / 403 response derived from one) assert behavior that can never fire as root.

**Affected tests:**
- `tests/unit/gui/shell/test_classifier.py::test_permission_denied_directory`
- `tests/unit/gui/shell/test_sandbox.py::test_list_children_permission_error_propagates`
- `tests/integration/gui/test_runs_blueprint.py::test_permission_denied_returns_403`
- `tests/integration/gui/test_runs_blueprint.py::test_touch_not_called_on_403`

**Fix:** Each test already has `@pytest.mark.skipif(sys.platform == "win32", ...)`. Extended the condition to `sys.platform == "win32" or os.getuid() == 0`. The `or` short-circuits on Windows so `os.getuid()` (POSIX-only) is never called there.

**Empirical validation:**
```
$ id -u
0
$ python -c "import os; os.mkdir('/tmp/t'); open('/tmp/t/f','wb'); os.chmod('/tmp/t',0o000); open('/tmp/t/f')"
# → succeeds (no PermissionError) — root bypasses mode bits
```

---

### Failure group 2 — SAM2 download host blocked (3 tests)

**Root cause:** `dl.fbaipublicfiles.com` returns `HTTP 403 host_not_allowed` in restricted execution environments with outbound network policies. `TestSam2DetectorFunctional` calls `Sam2Detector.apply()` → `_ensure_model_loaded()` → `Sam2CheckpointManager.download()` → `torch.hub.download_url_to_file(url, ...)`, which raises `HTTPError: HTTP Error 403: Forbidden`.

**Affected tests:**
- `tests/unit/nn/test_sam2_detector.py::TestSam2DetectorFunctional::test_apply_produces_objects`
- `tests/unit/nn/test_sam2_detector.py::TestSam2DetectorFunctional::test_objmask_objmap_consistency`
- `tests/unit/nn/test_sam2_detector.py::TestSam2DetectorFunctional::test_pipeline_apply`

**Fix:** Added `_sam2_tiny_available()` — returns `True` if the tiny checkpoint is already on disk (`Sam2CheckpointManager.is_cached("tiny")`), or if a HEAD request to the download URL succeeds within 3 s. The class-level `skipif` now checks both `SAM2_AVAILABLE` and this helper.

On GitHub-hosted runners (where `dl.fbaipublicfiles.com` is accessible), the HEAD succeeds and the tests run normally. In restricted environments the HEAD returns 403 immediately and the tests skip cleanly.

**Empirical validation:**
```
$ curl -sI "https://dl.fbaipublicfiles.com/segment_anything_2/092824/sam2.1_hiera_tiny.pt"
HTTP/2 403
x-deny-reason: host_not_allowed   ← environment-level block, not a bad URL
```

---

## Test plan

- [x] All 7 previously-failing tests now **skip** (not fail) in the restricted environment
- [x] 89 surrounding tests in the same files still pass, 0 regressions
- [x] `_sam2_tiny_available()` returns `True` when the checkpoint is cached, so the functional tests still exercise real inference on machines where the checkpoint is present
- [x] On GitHub Actions (open network), the HEAD check succeeds → tests run as before

https://claude.ai/code/session_014G2r9B9UA5tZT31FMvc4vH

---
_Generated by [Claude Code](https://claude.ai/code/session_014G2r9B9UA5tZT31FMvc4vH)_