### PR TITLE
fix(tests): skip Plotly PNG tests when kaleido Chrome is unavailable

### DIFF
--- a/tests/unit/cli/test_cli_output_manager_inspect.py
+++ b/tests/unit/cli/test_cli_output_manager_inspect.py
@@ -21,6 +21,37 @@ pytestmark = pytest.mark.skipif(
     reason="OutputManager uses POSIX atomic writes",
 )
 
+
+def _kaleido_chrome_available() -> bool:
+    """Return True iff choreographer can locate a Chrome executable.
+
+    kaleido >= 1 requires an external Chrome install for Plotly PNG export;
+    choreographer is the underlying browser manager. On GitHub Actions
+    ubuntu-latest/macOS runners Chrome is pre-installed and this returns
+    True. On minimal containers or Windows this returns False.
+    """
+    try:
+        from choreographer.browsers.chromium import (
+            chromium_based_browsers,
+            get_browser_path,
+        )
+        return any(
+            get_browser_path(exe) is not None
+            for info in chromium_based_browsers.values()
+            for exe in info.exe_names
+        )
+    except Exception:
+        return False
+
+
+_requires_kaleido_chrome = pytest.mark.skipif(
+    not _kaleido_chrome_available(),
+    reason=(
+        "kaleido >= 1 requires Chrome for Plotly PNG export; "
+        "install via `kaleido_get_chrome`"
+    ),
+)
+
 from phenotypic._cli._cli_output_manager import OutputManager
 
 
@@ -102,6 +133,7 @@ class TestSaveInspect:
         # PNG magic bytes
         assert expected.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
+    @_requires_kaleido_chrome
     def test_plotly_figure_writes_non_empty_png(self, tmp_path: Path) -> None:
         om = _make_output_manager(tmp_path)
         result = om.save_inspect(
@@ -157,6 +189,7 @@ class TestSaveInspect:
             for r in caplog.records
         )
 
+    @_requires_kaleido_chrome
     def test_title_at_write_time_prepends_stem_to_existing_plotly_title(
         self, tmp_path: Path,
     ) -> None:
@@ -190,6 +223,7 @@ class TestSaveInspect:
         assert captured.startswith("2024-03-14_plate_A2")
         assert "stub-title" in captured
 
+    @_requires_kaleido_chrome
     def test_title_does_not_compound_on_repeat_calls(
         self, tmp_path: Path,
     ) -> None:

--- a/tests/unit/cli/test_cli_save_inspect_integration.py
+++ b/tests/unit/cli/test_cli_save_inspect_integration.py
@@ -24,6 +24,36 @@ pytestmark = pytest.mark.skipif(
     reason="OutputManager uses POSIX atomic writes",
 )
 
+
+def _kaleido_chrome_available() -> bool:
+    """Return True iff choreographer can locate a Chrome executable.
+
+    kaleido >= 1 requires an external Chrome install for Plotly PNG export.
+    On GitHub Actions ubuntu-latest/macOS runners Chrome is pre-installed.
+    On minimal containers (like this remote execution environment) it is not.
+    """
+    try:
+        from choreographer.browsers.chromium import (
+            chromium_based_browsers,
+            get_browser_path,
+        )
+        return any(
+            get_browser_path(exe) is not None
+            for info in chromium_based_browsers.values()
+            for exe in info.exe_names
+        )
+    except Exception:
+        return False
+
+
+_requires_kaleido_chrome = pytest.mark.skipif(
+    not _kaleido_chrome_available(),
+    reason=(
+        "kaleido >= 1 requires Chrome for Plotly PNG export; "
+        "install via `kaleido_get_chrome`"
+    ),
+)
+
 from PIL import Image as PILImage
 
 from phenotypic import ImagePipeline
@@ -88,6 +118,7 @@ def _make_output_manager(
 class TestSaveInspectForwardRun:
     """``--save-inspect`` writes a PNG per measurer per image on a forward run."""
 
+    @_requires_kaleido_chrome
     def test_save_inspect_writes_png_for_symmetric_zones(
         self, temp_workspace: Path, saved_image_path: Path,
         inspect_pipeline_path: Path,
@@ -139,6 +170,7 @@ class TestSaveInspectForwardRun:
 class TestSaveInspectMeasureRerun:
     """``--save-inspect`` also fires on the ``--measure`` HDF rerun path."""
 
+    @_requires_kaleido_chrome
     def test_save_inspect_regenerates_on_hdf_rerun(
         self, temp_workspace: Path, saved_image_path: Path,
         inspect_pipeline_path: Path,


### PR DESCRIPTION
## Summary

- **Root cause:** kaleido >= 1.0 dropped its bundled browser and now requires an external Chrome install (via `choreographer`). Five `--save-inspect` tests that call `plotly_figure.write_image()` fail with `RuntimeError: Kaleido requires Google Chrome to be installed` on systems without Chrome.
- **Why CI passes:** GitHub Actions `ubuntu-latest` and `macos-14` runners have Google Chrome pre-installed; the Windows runner skips the entire file via the existing `sys.platform == "win32"` `pytestmark`. So CI has been passing "by accident."
- **Fix:** Add a `_kaleido_chrome_available()` probe (walks `choreographer.browsers.chromium.chromium_based_browsers`, calls `get_browser_path()` for each known executable) evaluated at import time. Tests that require Plotly PNG export are wrapped with `pytest.mark.skipif(not _kaleido_chrome_available(), reason="...")` so they skip with an actionable message instead of failing with an opaque `RuntimeError`.

## Affected tests (5 — previously failing, now skip when Chrome absent)

| File | Test |
|---|---|
| `test_cli_output_manager_inspect.py` | `test_plotly_figure_writes_non_empty_png` |
| `test_cli_output_manager_inspect.py` | `test_title_at_write_time_prepends_stem_to_existing_plotly_title` |
| `test_cli_output_manager_inspect.py` | `test_title_does_not_compound_on_repeat_calls` |
| `test_cli_save_inspect_integration.py` | `test_save_inspect_writes_png_for_symmetric_zones` |
| `test_cli_save_inspect_integration.py` | `test_save_inspect_regenerates_on_hdf_rerun` |

Six non-Chrome tests in the same files (matplotlib PNG, unsupported-type warning, inspect-raises guard, directory provisioning) are unaffected and continue to pass.

## Diagnosis

Ran the full unit suite (`uv sync --group dev --all-extras && pytest tests/unit/`) locally in a container without Chrome. Exactly 5 failures, all with the same traceback:

```
choreographer.browsers.chromium.ChromeNotFoundError: Kaleido v1 and later requires Chrome to be installed.
```

kaleido's `save_inspect` path catches the `RuntimeError` and returns `None`; the test then asserts `result is not None` → `AssertionError`. The two `_spy_write_image` tests let the exception propagate directly.

## Test plan

- [ ] Run `pytest tests/unit/cli/test_cli_output_manager_inspect.py tests/unit/cli/test_cli_save_inspect_integration.py` in a Chrome-free environment → 5 skipped, 6 passed, 0 failed
- [ ] CI on `ubuntu-latest` (Chrome pre-installed) → all 11 tests pass (no skips)
- [ ] Full unit suite shows 0 new failures

https://claude.ai/code/session_01NYQ6PeGPP6LCGRJJsmrpii

---
_Generated by [Claude Code](https://claude.ai/code/session_01NYQ6PeGPP6LCGRJJsmrpii)_