### PR TITLE
fix(tests): skip Plotly PNG tests when kaleido Chrome is unavailable

### DIFF
--- a/tests/unit/cli/_kaleido_utils.py
+++ b/tests/unit/cli/_kaleido_utils.py
@@ -1,0 +1,35 @@
+"""Shared pytest utilities for tests that require Kaleido + Chrome.
+
+kaleido >= 1.0 dropped its bundled browser and now requires an external
+Chrome/Chromium install (managed by ``choreographer``).  Tests that call
+``plotly_figure.write_image()`` therefore need a Chrome check at collection
+time so they skip rather than fail on minimal containers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _kaleido_chrome_available() -> bool:
+    """Return True iff choreographer can locate a Chrome-family executable.
+
+    Uses ``Chromium.find_browser(skip_local=False)`` — the same code path
+    kaleido 1.x uses internally — so the probe matches the actual runtime
+    requirement.  Falls back to False on any import or runtime error.
+    """
+    try:
+        from choreographer.browsers.chromium import Chromium
+
+        return Chromium.find_browser(skip_local=False) is not None
+    except Exception:
+        return False
+
+
+requires_kaleido_chrome = pytest.mark.skipif(
+    not _kaleido_chrome_available(),
+    reason=(
+        "kaleido >= 1 requires Chrome for Plotly PNG export; "
+        "install Chrome or run `plotly_get_chrome`"
+    ),
+)

--- a/tests/unit/cli/test_cli_output_manager_inspect.py
+++ b/tests/unit/cli/test_cli_output_manager_inspect.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit.cli._kaleido_utils import requires_kaleido_chrome
+
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
     reason="OutputManager uses POSIX atomic writes",
@@ -102,6 +104,7 @@ class TestSaveInspect:
         # PNG magic bytes
         assert expected.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
+    @requires_kaleido_chrome
     def test_plotly_figure_writes_non_empty_png(self, tmp_path: Path) -> None:
         om = _make_output_manager(tmp_path)
         result = om.save_inspect(
@@ -157,6 +160,7 @@ class TestSaveInspect:
             for r in caplog.records
         )
 
+    @requires_kaleido_chrome
     def test_title_at_write_time_prepends_stem_to_existing_plotly_title(
         self, tmp_path: Path,
     ) -> None:
@@ -190,6 +194,7 @@ class TestSaveInspect:
         assert captured.startswith("2024-03-14_plate_A2")
         assert "stub-title" in captured
 
+    @requires_kaleido_chrome
     def test_title_does_not_compound_on_repeat_calls(
         self, tmp_path: Path,
     ) -> None:

--- a/tests/unit/cli/test_cli_save_inspect_integration.py
+++ b/tests/unit/cli/test_cli_save_inspect_integration.py
@@ -19,6 +19,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.unit.cli._kaleido_utils import requires_kaleido_chrome
+
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32",
     reason="OutputManager uses POSIX atomic writes",
@@ -88,6 +90,7 @@ def _make_output_manager(
 class TestSaveInspectForwardRun:
     """``--save-inspect`` writes a PNG per measurer per image on a forward run."""
 
+    @requires_kaleido_chrome
     def test_save_inspect_writes_png_for_symmetric_zones(
         self, temp_workspace: Path, saved_image_path: Path,
         inspect_pipeline_path: Path,
@@ -139,6 +142,7 @@ class TestSaveInspectForwardRun:
 class TestSaveInspectMeasureRerun:
     """``--save-inspect`` also fires on the ``--measure`` HDF rerun path."""
 
+    @requires_kaleido_chrome
     def test_save_inspect_regenerates_on_hdf_rerun(
         self, temp_workspace: Path, saved_image_path: Path,
         inspect_pipeline_path: Path,


### PR DESCRIPTION
## Summary

- **Root cause:** kaleido >= 1.0 dropped its bundled Chromium and now requires an external Chrome install managed by `choreographer`. Five `--save-inspect` tests that call `plotly_figure.write_image()` fail with `RuntimeError: Kaleido requires Google Chrome to be installed` on Chrome-free systems (minimal containers, CI environments without pre-installed Chrome).
- **Why CI currently passes:** GitHub Actions `ubuntu-latest` and `macos-14` runners have Google Chrome pre-installed at `/usr/bin/google-chrome`; `choreographer.Chromium.find_browser()` finds it. The Windows runner skips these files entirely via the existing `sys.platform == "win32"` `pytestmark`. So CI has been green — but the tests fail locally in Chrome-free containers.
- **Bug in existing PR #103:** That PR's `_kaleido_chrome_available()` probe calls `get_browser_path(exe)` with individual exe-name strings. `get_browser_path` forwards to `browser_which(executable_names: Sequence[str])`, so passing `"google-chrome"` causes it to iterate over characters (`'g'`, `'o'`, `'o'`, …) rather than searching for the binary — the probe always returns `False` and all 5 tests are silently skipped even on CI, losing test coverage.
- **This fix:** Extracts the probe to `tests/unit/cli/_kaleido_utils.py` and uses `Chromium.find_browser(skip_local=False)` — the same internal method kaleido 1.x uses — which correctly returns `None` on Chrome-free hosts and the binary path on GitHub Actions runners.

## Changes

| File | Change |
|---|---|
| `tests/unit/cli/_kaleido_utils.py` | New — shared `requires_kaleido_chrome` mark using `Chromium.find_browser()` |
| `tests/unit/cli/test_cli_output_manager_inspect.py` | Import shared mark; decorate 3 Plotly-PNG tests |
| `tests/unit/cli/test_cli_save_inspect_integration.py` | Import shared mark; decorate 2 Plotly-PNG tests |

## Affected tests (5 — skip when Chrome absent, run+pass on CI)

| File | Test |
|---|---|
| `test_cli_output_manager_inspect.py` | `test_plotly_figure_writes_non_empty_png` |
| `test_cli_output_manager_inspect.py` | `test_title_at_write_time_prepends_stem_to_existing_plotly_title` |
| `test_cli_output_manager_inspect.py` | `test_title_does_not_compound_on_repeat_calls` |
| `test_cli_save_inspect_integration.py` | `test_save_inspect_writes_png_for_symmetric_zones` |
| `test_cli_save_inspect_integration.py` | `test_save_inspect_regenerates_on_hdf_rerun` |

Six non-Chrome tests (matplotlib PNG, unsupported-type warning, inspect-raises guard, directory provisioning) are unaffected and continue to pass in all environments.

## Test plan

- [x] Chrome-free container: `pytest tests/unit/cli/test_cli_output_manager_inspect.py tests/unit/cli/test_cli_save_inspect_integration.py` → **6 passed, 5 skipped, 0 failed**
- [x] Full CLI unit suite (`pytest tests/unit/cli/`) → **232 passed, 5 skipped, 0 failed**
- [ ] CI on `ubuntu-latest` (Chrome pre-installed) → all 11 tests in those files pass (no skips)

https://claude.ai/code/session_01FxebPV2BGieSxYVWXscjun

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxebPV2BGieSxYVWXscjun)_