### PR TITLE
Add to_json/from_json file serialization to operations and ColorCheckerProfile

### DIFF
--- a/src/phenotypic/abc_/_base_operation.py
+++ b/src/phenotypic/abc_/_base_operation.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 from typing import Any
 
 import importlib.util
+import json
 import logging
 import tracemalloc
 from abc import ABC
+from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from phenotypic.tools_._docstring_params import apply_docstring_descriptions
+from phenotypic.tools_._json_io import read_json_source
 
 # Check for optional dependencies
 PYMPLER_AVAILABLE = importlib.util.find_spec("pympler") is not None
@@ -211,6 +214,102 @@ class BaseOperation(BaseModel, ABC):
             tracemalloc.start()
             self._tracemalloc_started = True
             self._logger.debug("Tracemalloc started for memory logging")
+
+    def to_json(self, filepath: str | Path | None = None) -> str | None:
+        """Serialize this operation to JSON.
+
+        Captures the operation as a ``{"class", "params"}`` envelope: ``params``
+        is ``model_dump(mode="json")`` (every declared field, including nested
+        operations and raw arrays; ``PrivateAttr`` state such as loggers and
+        timing is excluded automatically), and ``class`` records the concrete
+        class name so :meth:`from_json` can rebuild the right subclass. This
+        mirrors :meth:`ImagePipeline.to_json`.
+
+        Args:
+            filepath: Optional path to write the JSON to. When None, the JSON
+                string is returned instead. Accepts a ``str`` or ``Path``.
+
+        Returns:
+            The JSON string when ``filepath`` is None, otherwise None.
+
+        Example:
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from phenotypic.detect import OtsuDetector
+            >>> with tempfile.TemporaryDirectory() as d:
+            ...     p = Path(d) / "op.json"
+            ...     OtsuDetector(ignore_zeros=True).to_json(p)
+            ...     loaded = OtsuDetector.from_json(p)
+            >>> loaded.ignore_zeros
+            True
+        """
+        envelope = {
+            "class": type(self).__name__,
+            "params": self.model_dump(mode="json"),
+        }
+        json_str = json.dumps(envelope, indent=2)
+        if filepath is not None:
+            Path(filepath).write_text(json_str)
+            return None
+        return json_str
+
+    @classmethod
+    def from_json(cls, json_data: str | Path | dict) -> "BaseOperation":
+        """Reconstruct an operation from JSON written by :meth:`to_json`.
+
+        Accepts a JSON string, a path to a JSON file, or a pre-parsed envelope
+        dict (same input handling as :meth:`ImagePipeline.from_json`).
+        Polymorphic: ``ImageOperation.from_json(path)`` returns whatever concrete
+        operation the file holds. When called on a narrower subclass, the
+        resolved class must be a subclass of it, else a :class:`TypeError` is
+        raised.
+
+        Args:
+            json_data: A JSON string, path to a JSON file, or envelope dict.
+
+        Returns:
+            The reconstructed operation instance.
+
+        Raises:
+            AttributeError: If the recorded class cannot be resolved in the
+                ``phenotypic`` namespace.
+            TypeError: If called on a concrete subclass and the file holds a
+                class that is not a subclass of it.
+
+        Example:
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from phenotypic.abc_ import ImageOperation
+            >>> from phenotypic.detect import OtsuDetector
+            >>> with tempfile.TemporaryDirectory() as d:
+            ...     p = Path(d) / "op.json"
+            ...     OtsuDetector().to_json(p)
+            ...     loaded = ImageOperation.from_json(p)  # polymorphic
+            >>> type(loaded).__name__
+            'OtsuDetector'
+        """
+        # Lazy import: ``_serializable_pipeline`` imports ``phenotypic.abc_`` at
+        # module top (see _serializable_pipeline.py), so a top-level import here
+        # would create a cycle.
+        from phenotypic._core._pipeline_parts._serializable_pipeline import (
+            SerializablePipeline,
+        )
+
+        envelope = read_json_source(json_data)
+        class_name = envelope["class"]
+        op_class = SerializablePipeline._find_class_in_phenotypic(class_name)
+        if op_class is None:
+            raise AttributeError(
+                f"Class '{class_name}' not found in the phenotypic namespace. "
+                f"Ensure it is exported from its submodule's __init__.py."
+            )
+        if cls is not BaseOperation and not issubclass(op_class, cls):
+            raise TypeError(
+                f"{cls.__name__}.from_json() got a '{class_name}', which is not "
+                f"a subclass of {cls.__name__}. Use BaseOperation.from_json() "
+                f"or a compatible class."
+            )
+        return op_class.model_validate(envelope.get("params", {}) or {})
 
     def _log_memory_usage(
             self,

--- a/src/phenotypic/correction/_color_correction/_color_checker_profile.py
+++ b/src/phenotypic/correction/_color_correction/_color_checker_profile.py
@@ -8,6 +8,7 @@ providing serializable diagnostics for quality assessment.
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple
 
 import colour
@@ -22,6 +23,7 @@ from pydantic import (
     model_validator,
 )
 
+from phenotypic.tools_._json_io import read_json_source
 from phenotypic.tools_.typing_ import NdArrayField
 
 from ._capture_metadata import CaptureMetadata
@@ -350,6 +352,57 @@ class ColorCheckerProfile(BaseModel):
         if outlier_sigma <= 0:
             raise ValueError(f"outlier_sigma must be > 0, got {outlier_sigma}")
         return outlier_sigma
+
+    # -- serialisation ------------------------------------------------------
+
+    def to_json(self, filepath: str | Path | None = None) -> str | None:
+        """Serialize this profile to JSON.
+
+        Serializes via :meth:`~pydantic.BaseModel.model_dump_json`: the fitted
+        ``correction_matrix`` is emitted as a nested list, ``capture_metadata``
+        as a nested object, and the transient ``rois`` / ``_image`` fields are
+        excluded. Mirrors :meth:`ImagePipeline.to_json`.
+
+        Args:
+            filepath: Optional path to write the JSON to. When None, the JSON
+                string is returned instead. Accepts a ``str`` or ``Path``.
+
+        Returns:
+            The JSON string when ``filepath`` is None, otherwise None.
+
+        Example:
+            >>> import tempfile
+            >>> from pathlib import Path
+            >>> from phenotypic.correction import ColorCheckerProfile
+            >>> with tempfile.TemporaryDirectory() as d:
+            ...     p = Path(d) / "profile.json"
+            ...     ColorCheckerProfile(degree=3).to_json(p)
+            ...     loaded = ColorCheckerProfile.from_json(p)
+            >>> loaded.degree
+            3
+        """
+        json_str = self.model_dump_json(indent=2)
+        if filepath is not None:
+            Path(filepath).write_text(json_str)
+            return None
+        return json_str
+
+    @classmethod
+    def from_json(cls, json_data: str | Path | dict) -> ColorCheckerProfile:
+        """Reconstruct a profile from JSON written by :meth:`to_json`.
+
+        Accepts a JSON string, a path to a JSON file, or a pre-parsed dict (same
+        input handling as :meth:`ImagePipeline.from_json`). Validation runs the
+        :meth:`_drop_legacy_fields` hook, so profiles saved before a field was
+        removed still load.
+
+        Args:
+            json_data: A JSON string, path to a JSON file, or a parsed dict.
+
+        Returns:
+            The reconstructed profile instance.
+        """
+        return cls.model_validate(read_json_source(json_data))
 
     # -- high-level fitting -------------------------------------------------
 

--- a/src/phenotypic/tools_/_json_io.py
+++ b/src/phenotypic/tools_/_json_io.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Union
+
+
+def read_json_source(json_data: Union[str, Path, dict]) -> Any:
+    """Coerce a JSON source to a Python object.
+
+    Shared front-door for the ``from_json`` classmethods on operations,
+    pipelines, and profiles so they accept the same inputs. Mirrors
+    :meth:`SerializablePipeline.from_json` input handling: a ``dict`` passes
+    through unchanged; a ``str``/``Path`` is read as a file when it looks like a
+    path and exists on disk (the ``< 256`` length guard avoids ``stat``-ing long
+    JSON strings); otherwise the value is parsed as a JSON string.
+
+    Args:
+        json_data: A pre-parsed dict, a path to a JSON file, or a JSON string.
+
+    Returns:
+        The parsed Python object (typically a dict).
+
+    Raises:
+        ValueError: If the value is not a dict and cannot be parsed as JSON.
+
+    Example:
+        >>> read_json_source('{"a": 1}')
+        {'a': 1}
+        >>> read_json_source({"a": 1})
+        {'a': 1}
+    """
+    if isinstance(json_data, dict):
+        return json_data
+    text = str(json_data)
+    try:
+        path = Path(json_data)
+        # Only read as a file if it looks like a path and exists. The length
+        # guard prevents stat-ing very long JSON strings.
+        if len(text) < 256 and path.exists() and path.is_file():
+            text = path.read_text()
+    except (OSError, ValueError):
+        # If Path operations fail, fall through and treat as a JSON string.
+        pass
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON data: {e}")

--- a/tests/smoke/test_serialization.py
+++ b/tests/smoke/test_serialization.py
@@ -8,8 +8,9 @@ import pytest
 
 import phenotypic
 from phenotypic import ImagePipeline
+from phenotypic.abc_ import BaseOperation, ImageOperation
 from phenotypic.correction import ImagePadder
-from phenotypic.detect import OtsuDetector
+from phenotypic.detect import CompositeDetector, OtsuDetector, TriangleDetector
 from phenotypic.enhance import GaussianBlur
 from phenotypic.measure import MeasureShape
 from phenotypic.prefab import HeavyOtsuPipeline
@@ -263,3 +264,104 @@ def test_file_roundtrip():
         assert loaded.name == "file_test"
         assert len(loaded._ops) == 2
         assert len(loaded._meas) == 1
+
+
+# ---------------------------------------------------------------------------
+# Operation-level to_json/from_json (BaseOperation)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.smoke
+@timeit
+def test_operation_to_json_returns_string():
+    """``to_json()`` with no filepath returns a ``{"class", "params"}`` envelope."""
+    json_str = OtsuDetector(ignore_zeros=True).to_json()
+
+    assert isinstance(json_str, str)
+    envelope = json.loads(json_str)
+    assert envelope["class"] == "OtsuDetector"
+    assert isinstance(envelope["params"], dict)
+    assert envelope["params"]["ignore_zeros"] is True
+
+
+@pytest.mark.smoke
+@timeit
+def test_operation_to_json_from_json_file_roundtrip():
+    """An operation written to file is recovered with its params intact."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "op.json"
+        OtsuDetector(ignore_zeros=True).to_json(filepath)
+
+        assert filepath.exists()
+        loaded = OtsuDetector.from_json(filepath)
+        assert isinstance(loaded, OtsuDetector)
+        assert loaded.ignore_zeros is True
+
+
+@pytest.mark.smoke
+@timeit
+def test_operation_from_json_accepts_string():
+    """``from_json`` accepts a JSON string, not only a file path."""
+    json_str = OtsuDetector(ignore_zeros=True).to_json()
+
+    loaded = OtsuDetector.from_json(json_str)
+    assert isinstance(loaded, OtsuDetector)
+    assert loaded.ignore_zeros is True
+
+
+@pytest.mark.smoke
+@timeit
+def test_operation_polymorphic_from_json_via_base():
+    """``ImageOperation.from_json`` resolves the concrete subclass in the file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "op.json"
+        OtsuDetector().to_json(filepath)
+
+        loaded = ImageOperation.from_json(filepath)
+        assert type(loaded).__name__ == "OtsuDetector"
+        assert isinstance(loaded, ImageOperation)
+
+
+@pytest.mark.smoke
+@timeit
+def test_operation_from_json_subclass_mismatch_raises():
+    """Loading via a sibling subclass rejects a non-matching class."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "op.json"
+        OtsuDetector().to_json(filepath)
+
+        with pytest.raises(TypeError):
+            TriangleDetector.from_json(filepath)
+
+
+@pytest.mark.smoke
+@timeit
+def test_operation_from_json_measurement_via_image_op_raises():
+    """A measurement file cannot be loaded through ``ImageOperation.from_json``."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "meas.json"
+        MeasureShape().to_json(filepath)
+
+        # MeasureFeatures is a sibling of ImageOperation under BaseOperation.
+        with pytest.raises(TypeError):
+            ImageOperation.from_json(filepath)
+        # ...but BaseOperation.from_json resolves it fine.
+        assert type(BaseOperation.from_json(filepath)).__name__ == "MeasureShape"
+
+
+@pytest.mark.smoke
+@timeit
+def test_nested_op_to_json_from_json_roundtrip():
+    """A nested ``OperationField`` (CompositeDetector.detectors) round-trips."""
+    composite = CompositeDetector(
+            detectors=[OtsuDetector(ignore_zeros=True), TriangleDetector()],
+    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        filepath = Path(tmpdir) / "composite.json"
+        composite.to_json(filepath)
+
+        loaded = CompositeDetector.from_json(filepath)
+        assert isinstance(loaded, CompositeDetector)
+        assert len(loaded.detectors) == 2
+        assert isinstance(loaded.detectors[0], OtsuDetector)
+        assert loaded.detectors[0].ignore_zeros is True
+        assert isinstance(loaded.detectors[1], TriangleDetector)

--- a/tests/unit/correction/test_color_corrector.py
+++ b/tests/unit/correction/test_color_corrector.py
@@ -717,6 +717,55 @@ class TestColorCorrectorSerialization:
         assert restored.capture_metadata is None
         assert restored.is_fitted is True
 
+    def test_profile_to_json_returns_string(self):
+        """``to_json()`` with no filepath returns JSON; transient ``rois`` excluded."""
+        json_str = ColorCheckerProfile(degree=3, outlier_sigma=1.5).to_json()
+        assert isinstance(json_str, str)
+        data = json.loads(json_str)
+        assert data["degree"] == 3
+        assert data["outlier_sigma"] == 1.5
+        assert "rois" not in data  # field-level exclude=True
+
+    def test_profile_to_json_from_json_file_roundtrip(self, tmp_path):
+        """An unfitted profile written to file is recovered with params intact."""
+        filepath = tmp_path / "profile.json"
+        ColorCheckerProfile(degree=3, outlier_sigma=1.5).to_json(filepath)
+
+        assert filepath.exists()
+        loaded = ColorCheckerProfile.from_json(filepath)
+        assert loaded.degree == 3
+        assert loaded.outlier_sigma == 1.5
+        assert loaded.is_fitted is False
+
+    def test_fitted_profile_to_json_from_json_roundtrip(self, fitted_profile, tmp_path):
+        """A fitted profile round-trips its correction matrix exactly via file."""
+        filepath = tmp_path / "fitted_profile.json"
+        fitted_profile.to_json(filepath)
+
+        loaded = ColorCheckerProfile.from_json(filepath)
+        np.testing.assert_array_almost_equal(
+            loaded.correction_matrix,
+            fitted_profile.correction_matrix,
+        )
+        assert loaded.is_fitted is True
+        assert loaded.degree == fitted_profile.degree
+
+    def test_profile_from_json_with_exif(self, fitted_profile_with_exif, tmp_path):
+        """capture_metadata survives the file round-trip."""
+        filepath = tmp_path / "exif_profile.json"
+        fitted_profile_with_exif.to_json(filepath)
+
+        loaded = ColorCheckerProfile.from_json(filepath)
+        assert loaded.capture_metadata == fitted_profile_with_exif.capture_metadata
+        assert loaded.capture_metadata.camera_model == "EOS R100"
+        assert loaded.capture_metadata.iso == 800
+
+    def test_profile_from_json_accepts_string(self):
+        """``from_json`` accepts a JSON string, not only a file path."""
+        json_str = ColorCheckerProfile(degree=4).to_json()
+        loaded = ColorCheckerProfile.from_json(json_str)
+        assert loaded.degree == 4
+
 
 # ===========================================================================
 # TestCaptureMetadata

--- a/tests/unit/tools_/test_json_io.py
+++ b/tests/unit/tools_/test_json_io.py
@@ -1,0 +1,46 @@
+"""Unit tests for ``phenotypic.tools_._json_io.read_json_source``."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from phenotypic.tools_._json_io import read_json_source
+
+
+def test_dict_passthrough():
+    """A dict is returned unchanged (identity)."""
+    payload = {"class": "OtsuDetector", "params": {"ignore_zeros": True}}
+    assert read_json_source(payload) is payload
+
+
+def test_parses_json_string():
+    """A JSON string is parsed to a Python object."""
+    assert read_json_source('{"a": 1, "b": [2, 3]}') == {"a": 1, "b": [2, 3]}
+
+
+def test_reads_existing_file(tmp_path):
+    """An existing file path is read and parsed."""
+    filepath = tmp_path / "data.json"
+    filepath.write_text(json.dumps({"degree": 3}))
+    assert read_json_source(filepath) == {"degree": 3}
+
+
+def test_reads_existing_file_from_str_path(tmp_path):
+    """A str pointing at an existing file is read and parsed."""
+    filepath = tmp_path / "data.json"
+    filepath.write_text(json.dumps({"degree": 4}))
+    assert read_json_source(str(filepath)) == {"degree": 4}
+
+
+def test_invalid_json_raises_value_error():
+    """A non-JSON, non-path string raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid JSON data"):
+        read_json_source("not valid json {")
+
+
+def test_nonexistent_path_string_treated_as_json():
+    """A short string that is not an existing file is parsed as JSON, not stat-looped."""
+    # Valid JSON scalar that also is not a file → parsed as JSON.
+    assert read_json_source("42") == 42


### PR DESCRIPTION
## Summary

Extends the `to_json(filepath)` / `from_json(json_data)` API that `ImagePipeline` already provides to the two other serializable model families, so all three share one uniform JSON file-I/O surface (no new `save`/`load` names; the pipeline is left untouched).

- **`tools_/_json_io.py`** *(new)* — `read_json_source(json_data)`, a shared front-door accepting a dict / file path / JSON string, mirroring the pipeline's input coercion. Lives in `tools_` so `abc_` can import it without a cycle.
- **`BaseOperation.to_json` / `from_json`** — every operation (detectors, enhancers, refiners, `MeasureFeatures`, …) inherits them. `to_json` writes a `{"class", "params"}` envelope byte-identical to the pipeline's per-op shape; `from_json` resolves the concrete class via the existing `_find_class_in_phenotypic` (lazy-imported to avoid the `abc_`→`_core` cycle) and is polymorphic — `ImageOperation.from_json(path)` returns the concrete op, and a cross-tree/sibling mismatch raises `TypeError`.
- **`ColorCheckerProfile.to_json` / `from_json`** — `model_dump_json` / `model_validate`; the existing `_drop_legacy_fields` validator keeps pre-migration files loadable.
- **`ImagePipeline`** — unchanged (already exposes `to_json`/`from_json`).

```python
op.to_json("detector.json");      OtsuDetector.from_json("detector.json")
profile.to_json("profile.json");  ColorCheckerProfile.from_json("profile.json")
pipe.to_json("pipeline.json");    ImagePipeline.from_json("pipeline.json")   # unchanged
```

## Tests

- **Operations** (`tests/smoke/test_serialization.py`): string + file round-trips, polymorphic base load, subclass-mismatch `TypeError`, nested `OperationField` (`CompositeDetector`) round-trip.
- **Profile** (`tests/unit/correction/test_color_corrector.py`): fitted correction-matrix and EXIF `capture_metadata` round-trips, string round-trip.
- **Helper** (`tests/unit/tools_/test_json_io.py`): dict passthrough, JSON string, file read, invalid-JSON `ValueError`.

## Verification

- `tests/smoke/test_serialization.py` + `test_color_corrector.py` + `test_json_io.py` → **181 passed, 11 pre-existing skips**
- Pipeline-serialization regression (`tests/unit/core/test_pipeline_serialization.py`) → **49 passed**
- `mypy` on the 3 source files → clean
- `ruff check` on sources + tests → clean
- Import sanity → no circular import

🤖 Generated with [Claude Code](https://claude.com/claude-code)