### PR TITLE
Fix GUI screenshot capture CLI invocation

### DIFF
--- a/scripts/capture_gui_tutorial_screenshots.py
+++ b/scripts/capture_gui_tutorial_screenshots.py
@@ -9,7 +9,7 @@ The script:
 1. Builds a synthetic 3-plate yeast dataset under
    ``docs/source/_static/gui_images/_dataset/``.
 2. Runs the CLI once against that dataset to produce real CLI output
-   (master parquet + ``results/`` + ``dashboard.html``).
+   (``deliverables/`` + ``results/``).
 3. Boots ``phenotypic-gui --root <dataset_parent>`` on a free port.
 4. Drives a headless Chromium browser through every tutorial workflow
    and saves PNGs into ``docs/source/_static/gui_images/<workflow>/``.
@@ -155,12 +155,12 @@ def build_tutorial_dataset(force: bool = False) -> None:
 def run_cli_once() -> None:
     """Invoke ``python -m phenotypic`` to produce real CLI output.
 
-    The output (parquet + per-image overlays + dashboard.html) is what the
-    "Viewing Results" walkthrough screenshots capture. Skip if the output
-    already exists — re-running this is expensive (~minutes on a real
-    pipeline; ~seconds on the synthetic dataset but still avoidable).
+    The output (deliverables + per-image overlays) is what the "Viewing
+    Results" walkthrough screenshots capture. Skip if the output already
+    exists — re-running this is expensive (~minutes on a real pipeline;
+    ~seconds on the synthetic dataset but still avoidable).
     """
-    if (OUTPUT_DIR / "master_measurements.parquet").exists():
+    if (OUTPUT_DIR / "deliverables" / "master_measurements.parquet").exists():
         print(
             f"[cli] reusing existing CLI output at {OUTPUT_DIR.relative_to(REPO_ROOT)}")
         return
@@ -171,7 +171,9 @@ def run_cli_once() -> None:
         sys.executable,
         "-m",
         "phenotypic",
+        "--pipeline",
         str(PIPELINE_JSON),
+        "--input",
         str(PLATES_DIR),
         "-o",
         str(OUTPUT_DIR),


### PR DESCRIPTION
## Summary
- Update the GUI tutorial screenshot capture script to call the main CLI with `--pipeline` and `--input`.
- Update the capture script reuse check to look for `deliverables/master_measurements.parquet`, matching the current output layout.
- Refresh the script description to match the deliverables/results split.

## Root Cause
The failing `Smoke-regenerate tutorial screenshots` action was still invoking `python -m phenotypic <pipeline.json> <plates> -o ...`. After PR #114, positional pipeline/input args are rejected, so the capture script continued without CLI output and the later standalone results viewer never came up.

## Test Plan
- `uv run ruff check --fix scripts/capture_gui_tutorial_screenshots.py`
- `uv run python scripts/check_workflows_md.py`
- Mocked `run_cli_once()` probe confirming argv contains `--pipeline <pipeline> --input <plates> -o <results>`