### PR TITLE
Add public measurement output utilities

### DIFF
--- a/src/phenotypic/__init__.py
+++ b/src/phenotypic/__init__.py
@@ -43,6 +43,7 @@ from . import (
     settings_,
     sweep,
     tools_,
+    util,
     prefab,
 )
 
@@ -63,6 +64,7 @@ __all__ = [
     "enhance",
     "nn",
     "tools_",
+    "util",
     "settings_",
     "sweep",
 ]

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
 from ._cli_types import Dataset
 from ._cli_duckdb_agg import duckdb_aggregate
+from phenotypic.util import split_measurements
 from phenotypic.tools_ import (
     DIR_RESULTS,
     DIR_MEASUREMENTS,
@@ -539,13 +540,15 @@ def finalize_post_master_outputs(
        is ``None`` or has no post ops, ``post_df`` equals the working
        frame unchanged.
     3. :func:`_seed_measurements` writes the post-applied frame.
-    4. When *pipeline* is provided: persist ``pipeline.json``, run
-       :func:`_emit_analysis_outputs` against ``post_df`` (so analysis
-       sees both post-applied and metadata-joined data), and split
-       ``post_df`` into per-feature spreadsheets so users see
+    4. Split ``post_df`` into per-feature spreadsheets based on the
+       ``MeasurementInfo`` columns present in the frame, so users see
        post-derived columns (e.g. ``Metadata_Strain`` from
        ``ExpandMetadata``) in
        ``measurements_by_feature/<feature>.{csv,parquet}``.
+    5. When *pipeline* is provided: persist ``pipeline.json``, run
+       :func:`_emit_analysis_outputs` against ``post_df`` (so analysis
+       sees both post-applied and metadata-joined data), and run QC when
+       configured.
 
     Failures inside metadata-join, split, or analysis are logged at WARNING
     and never raise; the master files remain authoritative regardless of
@@ -599,37 +602,36 @@ def finalize_post_master_outputs(
     post_df = _apply_post_to_master(working_df, pipeline)
     _seed_measurements(output_dir, post_df)
 
-    if pipeline is None:
+    if pipeline is not None:
+        _persist_pipeline_to_output_dir(output_dir, pipeline)
+        _emit_analysis_outputs(output_dir, post_df, pipeline)
+
+        # QC compute + review-progress reset. A fresh CLI run is "a different
+        # run", so the GUI-owned review_state.json is cleared regardless of
+        # whether QC then recomputes (so stale review progress never carries
+        # across a rerun). The ``qc/`` artifact is rewritten by ``run_qc`` only
+        # when QC is enabled and configured; failures are isolated so the
+        # authoritative master files are never affected.
+        _reset_qc_review_state(output_dir)
+        if not no_qc and pipeline.get_qc():
+            try:
+                # Import the submodule directly (not ``phenotypic.qc``) so QC
+                # compute is only pulled in on the path that needs it, keeping
+                # the qc package __init__ free of an eager _runner import.
+                from phenotypic.qc._runner import run_qc
+
+                run_qc(post_df.to_pandas(), pipeline, output_dir)
+            except Exception:
+                logger.warning(
+                    "QC compute failed (master/measurements still written)",
+                    exc_info=True,
+                )
+    else:
         logger.warning(
-            "Pipeline not available — skipping per-feature split, analysis, "
-            "and pipeline.json persistence (master files still written to %s)",
+            "Pipeline not available — skipping analysis, QC, and "
+            "pipeline.json persistence (master files still written to %s)",
             output_dir,
         )
-        return post_df
-
-    _persist_pipeline_to_output_dir(output_dir, pipeline)
-    _emit_analysis_outputs(output_dir, post_df, pipeline)
-
-    # QC compute + review-progress reset. A fresh CLI run is "a different
-    # run", so the GUI-owned review_state.json is cleared regardless of
-    # whether QC then recomputes (so stale review progress never carries
-    # across a rerun). The ``qc/`` artifact is rewritten by ``run_qc`` only
-    # when QC is enabled and configured; failures are isolated so the
-    # authoritative master files are never affected.
-    _reset_qc_review_state(output_dir)
-    if not no_qc and pipeline.get_qc():
-        try:
-            # Import the submodule directly (not ``phenotypic.qc``) so QC
-            # compute is only pulled in on the path that needs it, keeping
-            # the qc package __init__ free of an eager _runner import.
-            from phenotypic.qc._runner import run_qc
-
-            run_qc(post_df.to_pandas(), pipeline, output_dir)
-        except Exception:
-            logger.warning(
-                "QC compute failed (master/measurements still written)",
-                exc_info=True,
-            )
 
     try:
         # Splits operate on the post-applied frame so per-feature
@@ -678,52 +680,44 @@ def _reset_qc_review_state(output_dir: Path) -> None:
 def split_master_by_feature(
     master_df: "pl.DataFrame",
     output_dir: Path,
-    pipeline: "ImagePipeline",
+    pipeline: Optional["ImagePipeline"] = None,
 ) -> Dict[str, Path]:
-    """Write one CSV + Parquet per ``MeasureFeatures`` into *output_dir*.
+    """Write one CSV + Parquet per recognized feature into *output_dir*.
 
-    Creates ``output_dir/measurements_by_feature/`` and, for every
-    measurer key returned by :func:`_collect_feature_headers`, emits a
-    spreadsheet containing all non-feature columns (metadata, object
-    label, grid info, joined external metadata) alongside only that
-    measurer's columns. A feature whose expected columns are entirely
-    absent from the master (e.g. its operation failed for every image)
-    is skipped.
+    Creates ``output_dir/measurements_by_feature/`` and emits a spreadsheet
+    for every producer key returned by
+    :func:`phenotypic.util.split_measurements`. Each spreadsheet contains
+    all non-feature columns (metadata, object label, grid info, joined
+    external metadata) alongside only that producer's columns.
 
     Args:
         master_df: Aggregated master measurements.
         output_dir: Base output directory; the ``measurements_by_feature/``
             subdirectory is created if missing.
-        pipeline: Pipeline whose ``_meas`` dict defines the split.
+        pipeline: Retained for backward compatibility with legacy callers.
+            The split is now derived dynamically from ``MeasurementInfo``
+            columns in *master_df*.
 
     Returns:
-        Mapping of ``_meas`` key → path to the emitted CSV. Empty if
-        nothing could be split.
+        Mapping of producer key → path to the emitted CSV. Empty if nothing
+        could be split.
     """
-    headers_by_key = _collect_feature_headers(pipeline)
-    if not headers_by_key:
-        logger.info("No MeasureFeatures exposed headers -- skipping split")
+    del pipeline
+
+    split_frames = split_measurements(master_df)
+    if not split_frames:
+        logger.info("No recognized MeasurementInfo columns -- skipping split")
         return {}
-
-    all_feature_cols: set[str] = set()
-    for cols in headers_by_key.values():
-        all_feature_cols.update(cols)
-
-    non_feature_cols = [c for c in master_df.columns if c not in all_feature_cols]
 
     split_dir = measurements_by_feature_dir(output_dir)
     split_dir.mkdir(parents=True, exist_ok=True)
 
     written: Dict[str, Path] = {}
-    for key, headers in headers_by_key.items():
-        present = [c for c in headers if c in master_df.columns]
-        if not present:
-            logger.debug(
-                "Skipping split for %r: none of its columns are in master", key
-            )
-            continue
-
-        subset = master_df.select(non_feature_cols + present)
+    for key, subset_frame in split_frames.items():
+        if isinstance(subset_frame, pd.DataFrame):
+            subset = pl.from_pandas(subset_frame)
+        else:
+            subset = subset_frame
         csv_path = split_dir / f"{key}.csv"
         pq_path = split_dir / f"{key}.parquet"
 
@@ -791,13 +785,12 @@ def aggregate_measurements(
             provided, shared columns are used as join keys for an inner
             join with metadata on the left.  Only measurement rows that
             match the metadata are kept.
-        pipeline: Optional :class:`ImagePipeline` whose ``MeasureFeatures``
-            operations define how to split the aggregated master into
-            per-feature sub-spreadsheets.  When omitted, the pipeline is
+        pipeline: Optional :class:`ImagePipeline` used for post, analysis,
+            QC, and pipeline persistence.  When omitted, the pipeline is
             recovered from ``processing_state.json`` / the pipeline JSON
-            copy in *output_dir*; if it cannot be recovered, the split
-            step is skipped and a warning is logged (the master files are
-            still written).
+            copy in *output_dir*. Per-feature splits are derived from the
+            aggregated frame's ``MeasurementInfo`` columns even when the
+            pipeline cannot be recovered.
         no_qc: Forwarded to :func:`finalize_post_master_outputs` to skip
             the QC compute step. See that function for details.
 
@@ -808,11 +801,10 @@ def aggregate_measurements(
     Side effects:
         Delegates the post-master work to
         :func:`finalize_post_master_outputs`, which always seeds
-        ``measurements.{csv,parquet}`` and — when a pipeline is
-        available — persists ``pipeline.json``, runs the analysis chain
-        into ``analysis.{csv,parquet}``, and writes per-feature
-        sub-spreadsheets into ``output_dir/measurements_by_feature/``
-        (one file per :class:`MeasureFeatures` in ``pipeline._meas``).
+        ``measurements.{csv,parquet}``, writes per-feature sub-spreadsheets
+        into ``output_dir/measurements_by_feature/``, and — when a pipeline
+        is available — persists ``pipeline.json`` and runs the analysis chain
+        into ``analysis.{csv,parquet}``.
 
         ``master_measurements.{csv,parquet}`` are intentionally a clean
         (pre-post) archive of what the per-image runs measured, while

--- a/src/phenotypic/util/__init__.py
+++ b/src/phenotypic/util/__init__.py
@@ -3,6 +3,7 @@ A module for useful utility operations and functions that don't fit into a speci
 """
 
 from ._geometric_median import geometric_median
+from ._measurement_outputs import generate_output_key, split_measurements
 from ._well_pos_decoder import decode_well_position
 from .image_metrics import (
     BackgroundMetrics,
@@ -16,6 +17,8 @@ from .image_metrics import (
 
 __all__ = [
     "geometric_median",
+    "generate_output_key",
+    "split_measurements",
     # Image metrics
     "ImageMetricsCalculator",
     "THRESHOLDS",
@@ -25,5 +28,5 @@ __all__ = [
     "BackgroundMetrics",
     "QualityScores",
     # Well Decoder
-    "decode_well_position"
+    "decode_well_position",
 ]

--- a/src/phenotypic/util/_measurement_outputs.py
+++ b/src/phenotypic/util/_measurement_outputs.py
@@ -1,0 +1,249 @@
+"""Utilities for documenting and splitting measurement output tables."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, TypeAlias, TypeGuard
+
+import pandas as pd
+import polars as pl
+
+from phenotypic.schema import MeasurementInfo
+
+
+MeasurementFrame: TypeAlias = pd.DataFrame | pl.DataFrame
+
+
+@dataclass(frozen=True)
+class _MeasurementProducer:
+    """A public producer class and the ``MeasurementInfo`` enums it owns."""
+
+    output_key: str
+    primary_infos: tuple[type[MeasurementInfo], ...]
+    shared_infos: tuple[type[MeasurementInfo], ...] = ()
+
+
+def split_measurements(df: MeasurementFrame) -> dict[str, MeasurementFrame]:
+    """Split a measurements table into producer-specific data frames.
+
+    Columns backed by public ``MeasureFeatures`` and ``SetAnalyzer``
+    ``MeasurementInfo`` enums define each split. Columns that do not belong to
+    any producer-owned enum are preserved in every split as context columns.
+
+    Args:
+        df: A pandas or polars measurements DataFrame.
+
+    Returns:
+        Mapping of producer class name to a same-type DataFrame containing all
+        context columns plus that producer's recognized measurement columns.
+        Returns an empty mapping when no producer-owned measurement columns are
+        present.
+
+    Raises:
+        TypeError: If *df* is not a pandas or polars DataFrame.
+    """
+    columns = _columns(df)
+    groups = _producer_column_groups(columns)
+    if not groups:
+        return {}
+
+    producer_columns = {
+        column for group_columns in groups.values() for column in group_columns
+    }
+    context_columns = [column for column in columns if column not in producer_columns]
+
+    return {
+        output_key: _select_columns(df, context_columns + group_columns)
+        for output_key, group_columns in groups.items()
+    }
+
+
+def generate_output_key(df: MeasurementFrame) -> pd.DataFrame:
+    """Generate a column-description key for recognized output columns.
+
+    Args:
+        df: A pandas or polars measurements DataFrame.
+
+    Returns:
+        A pandas DataFrame with ``column_header`` and ``description`` columns,
+        preserving the input column order and omitting columns that are not
+        backed by a public ``MeasurementInfo`` member.
+
+    Raises:
+        TypeError: If *df* is not a pandas or polars DataFrame.
+    """
+    descriptions = _measurement_descriptions()
+    records = [
+        {"column_header": column, "description": descriptions[column]}
+        for column in _columns(df)
+        if column in descriptions
+    ]
+    return pd.DataFrame(records, columns=["column_header", "description"])
+
+
+def _columns(df: MeasurementFrame) -> list[str]:
+    """Return DataFrame columns as strings after validating the frame type."""
+    if isinstance(df, pd.DataFrame):
+        return [str(column) for column in df.columns]
+    if isinstance(df, pl.DataFrame):
+        return [str(column) for column in df.columns]
+    raise TypeError(
+        "split_measurements() and generate_output_key() require a pandas "
+        f"or polars DataFrame, got {type(df).__name__}."
+    )
+
+
+def _select_columns(df: MeasurementFrame, columns: list[str]) -> MeasurementFrame:
+    """Select *columns* while preserving the input DataFrame implementation."""
+    if isinstance(df, pd.DataFrame):
+        return df.loc[:, columns].copy()
+    if isinstance(df, pl.DataFrame):
+        return df.select(columns)
+    raise TypeError(
+        "split_measurements() requires a pandas or polars DataFrame, "
+        f"got {type(df).__name__}."
+    )
+
+
+def _producer_column_groups(columns: Iterable[str]) -> dict[str, list[str]]:
+    """Map producer class names to their present measurement columns."""
+    ordered_columns = list(columns)
+    groups: dict[str, list[str]] = {}
+
+    for producer in _discover_measurement_producers():
+        primary_headers = _headers_for_infos(producer.primary_infos)
+        shared_headers = _headers_for_infos(producer.shared_infos)
+
+        present_primary = [
+            column for column in ordered_columns if column in primary_headers
+        ]
+        if not present_primary:
+            continue
+
+        producer_headers = set(present_primary)
+        producer_headers.update(
+            column for column in ordered_columns if column in shared_headers
+        )
+        groups[producer.output_key] = [
+            column for column in ordered_columns if column in producer_headers
+        ]
+
+    return groups
+
+
+def _headers_for_infos(infos: Iterable[type[MeasurementInfo]]) -> set[str]:
+    """Return every header declared by *infos*."""
+    return {member.value for info in infos for member in info}
+
+
+@lru_cache(maxsize=1)
+def _discover_measurement_producers() -> tuple[_MeasurementProducer, ...]:
+    """Discover public measurement producers from public modules."""
+    import phenotypic.analysis as analysis_module
+    import phenotypic.measure as measure_module
+    from phenotypic.abc_ import MeasureFeatures
+    from phenotypic.analysis.abc_ import ModelFitter, QualityCheck, SetAnalyzer
+    from phenotypic.schema import MODEL_METRICS
+
+    producers: list[_MeasurementProducer] = []
+
+    for name, cls in inspect.getmembers(measure_module, inspect.isclass):
+        if name.startswith("_"):
+            continue
+        if not issubclass(cls, MeasureFeatures) or cls is MeasureFeatures:
+            continue
+        infos = _declared_info_classes(cls)
+        if infos:
+            producers.append(_MeasurementProducer(name, infos))
+
+    for name, cls in inspect.getmembers(analysis_module, inspect.isclass):
+        if name.startswith("_"):
+            continue
+        if not issubclass(cls, SetAnalyzer) or cls in (
+            SetAnalyzer,
+            ModelFitter,
+            QualityCheck,
+        ):
+            continue
+        infos = _declared_info_classes(cls)
+        if not infos:
+            continue
+        if issubclass(cls, ModelFitter):
+            primary_infos = tuple(info for info in infos if info is not MODEL_METRICS)
+            if primary_infos:
+                producers.append(
+                    _MeasurementProducer(
+                        name,
+                        primary_infos,
+                        shared_infos=(MODEL_METRICS,),
+                    )
+                )
+        else:
+            producers.append(_MeasurementProducer(name, infos))
+
+    return tuple(producers)
+
+
+def _declared_info_classes(cls: type) -> tuple[type[MeasurementInfo], ...]:
+    """Return ``MeasurementInfo`` classes declared on a producer class."""
+    infos: list[type[MeasurementInfo]] = []
+
+    single = _as_info_class(
+        cls.__dict__.get(
+            "_measurement_infoclass",
+            getattr(cls, "_measurement_infoclass", None),
+        )
+    )
+    if single is not None:
+        infos.append(single)
+
+    plural = cls.__dict__.get(
+        "_measurement_infoclasses",
+        getattr(cls, "_measurement_infoclasses", ()),
+    )
+    if isinstance(plural, (list, tuple)):
+        for item in plural:
+            info = _as_info_class(item)
+            if info is not None:
+                infos.append(info)
+
+    return tuple(dict.fromkeys(infos))
+
+
+def _as_info_class(value: object) -> type[MeasurementInfo] | None:
+    """Coerce a class/private-attr value into a ``MeasurementInfo`` class."""
+    if _is_info_class(value):
+        return value
+    default = getattr(value, "default", None)
+    if _is_info_class(default):
+        return default
+    return None
+
+
+def _is_info_class(value: object) -> TypeGuard[type[MeasurementInfo]]:
+    """Return whether *value* is a concrete ``MeasurementInfo`` subclass."""
+    return (
+        isinstance(value, type)
+        and issubclass(value, MeasurementInfo)
+        and value is not MeasurementInfo
+    )
+
+
+@lru_cache(maxsize=1)
+def _measurement_descriptions() -> dict[str, str]:
+    """Build ``column_header -> description`` from the public schema."""
+    import phenotypic.schema as schema
+
+    descriptions: dict[str, str] = {}
+    for name in getattr(schema, "__all__", ()):
+        obj = getattr(schema, name, None)
+        if not _is_info_class(obj):
+            continue
+        for member in obj:
+            descriptions.setdefault(member.value, member.desc)
+    return descriptions
+
+
+__all__ = ["generate_output_key", "split_measurements"]

--- a/tests/unit/cli/test_cli_output_manager.py
+++ b/tests/unit/cli/test_cli_output_manager.py
@@ -295,9 +295,10 @@ class TestAggregateMeasurementsAutoResolve:
         assert "Shape_Area" not in size_df.columns
         assert "Metadata_ImageFile" in size_df.columns
 
-    def test_no_state_file_keeps_master_but_skips_splits(
+    def test_no_state_file_keeps_master_and_splits_known_columns(
         self, tmp_path: Path
     ) -> None:
+        """Dynamic splits no longer require a recovered pipeline."""
         output_dir = tmp_path / "out"
         output_dir.mkdir()
 
@@ -318,4 +319,14 @@ class TestAggregateMeasurementsAutoResolve:
 
         assert master_path is not None
         assert master_path.exists()
-        assert not measurements_by_feature_dir(output_dir).exists()
+        split_dir = measurements_by_feature_dir(output_dir)
+        assert split_dir.is_dir()
+        size_csv = split_dir / "MeasureSize.csv"
+        assert size_csv.exists()
+        size_df = pl.read_csv(size_csv)
+        assert size_df.columns == [
+            "Metadata_Dataset",
+            "Metadata_ImageFile",
+            "Object_Label",
+            "Size_Area",
+        ]

--- a/tests/unit/util/test_measurement_outputs.py
+++ b/tests/unit/util/test_measurement_outputs.py
@@ -1,0 +1,153 @@
+"""Tests for public measurement-output utilities."""
+
+from __future__ import annotations
+
+import pandas as pd
+import polars as pl
+
+import phenotypic
+from phenotypic.schema import (
+    ColorHSV,
+    ColorLab,
+    LINEAR_SOFTPLUS_MODEL,
+    MODEL_METRICS,
+    OBJECT,
+    SHAPE,
+    SIZE,
+)
+from phenotypic.util import generate_output_key, split_measurements
+
+
+def _base_measurements() -> pd.DataFrame:
+    """Build a small mixed measurement table for split tests."""
+    return pd.DataFrame(
+        {
+            "Metadata_Dataset": ["ds1", "ds1"],
+            str(OBJECT.LABEL): [1, 2],
+            "Custom_Note": ["a", "b"],
+            str(SIZE.AREA): [10.0, 20.0],
+            str(SIZE.INTEGRATED_INTENSITY): [100.0, 200.0],
+            str(SHAPE.AREA): [11.0, 21.0],
+            str(SHAPE.PERIMETER): [12.0, 22.0],
+        }
+    )
+
+
+def test_util_subpackage_is_public() -> None:
+    """``phenotypic.util`` exposes the measurement-output helpers."""
+    assert hasattr(phenotypic, "util")
+    assert callable(split_measurements)
+    assert callable(generate_output_key)
+
+
+def test_split_measurements_groups_pandas_columns_without_pipeline() -> None:
+    """Feature columns split by discovered ``MeasureFeatures`` classes."""
+    frame = _base_measurements()
+
+    splits = split_measurements(frame)
+
+    assert set(splits) == {"MeasureSize", "MeasureShape"}
+    size_df = splits["MeasureSize"]
+    shape_df = splits["MeasureShape"]
+    assert isinstance(size_df, pd.DataFrame)
+    assert list(size_df.columns) == [
+        "Metadata_Dataset",
+        str(OBJECT.LABEL),
+        "Custom_Note",
+        str(SIZE.AREA),
+        str(SIZE.INTEGRATED_INTENSITY),
+    ]
+    assert list(shape_df.columns) == [
+        "Metadata_Dataset",
+        str(OBJECT.LABEL),
+        "Custom_Note",
+        str(SHAPE.AREA),
+        str(SHAPE.PERIMETER),
+    ]
+
+
+def test_split_measurements_preserves_polars_input_type() -> None:
+    """Polars input returns polars split frames."""
+    frame = pl.from_pandas(_base_measurements())
+
+    splits = split_measurements(frame)
+
+    assert set(splits) == {"MeasureSize", "MeasureShape"}
+    assert isinstance(splits["MeasureSize"], pl.DataFrame)
+    assert splits["MeasureSize"].columns == [
+        "Metadata_Dataset",
+        str(OBJECT.LABEL),
+        "Custom_Note",
+        str(SIZE.AREA),
+        str(SIZE.INTEGRATED_INTENSITY),
+    ]
+
+
+def test_split_measurements_groups_plural_measure_color_infoclasses() -> None:
+    """``MeasureColor`` owns columns from every color ``MeasurementInfo`` enum."""
+    frame = pd.DataFrame(
+        {
+            "Metadata_Dataset": ["ds1"],
+            str(OBJECT.LABEL): [1],
+            str(ColorLab.L_STAR_MEAN): [55.0],
+            str(ColorHSV.HUE_MEAN): [0.2],
+        }
+    )
+
+    splits = split_measurements(frame)
+
+    assert set(splits) == {"MeasureColor"}
+    assert list(splits["MeasureColor"].columns) == [
+        "Metadata_Dataset",
+        str(OBJECT.LABEL),
+        str(ColorLab.L_STAR_MEAN),
+        str(ColorHSV.HUE_MEAN),
+    ]
+
+
+def test_split_measurements_groups_model_metrics_with_linear_softplus() -> None:
+    """Shared model metrics are included with a present model-specific split."""
+    frame = pd.DataFrame(
+        {
+            "Metadata_Strain": ["WT", "KO"],
+            str(LINEAR_SOFTPLUS_MODEL.v): [1.1, 1.2],
+            str(LINEAR_SOFTPLUS_MODEL.s0): [0.1, 0.2],
+            str(MODEL_METRICS.RMSE): [0.01, 0.02],
+            str(MODEL_METRICS.R2): [0.99, 0.98],
+        }
+    )
+
+    splits = split_measurements(frame)
+
+    assert set(splits) == {"LinearSoftplus"}
+    assert list(splits["LinearSoftplus"].columns) == list(frame.columns)
+
+
+def test_generate_output_key_returns_known_measurement_descriptions() -> None:
+    """Only ``MeasurementInfo`` columns appear in input-column order."""
+    frame = pd.DataFrame(
+        {
+            "Custom_Note": ["a"],
+            str(OBJECT.LABEL): [1],
+            str(SIZE.AREA): [10.0],
+            str(LINEAR_SOFTPLUS_MODEL.v): [1.1],
+            str(MODEL_METRICS.RMSE): [0.01],
+        }
+    )
+
+    key = generate_output_key(frame)
+
+    assert list(key.columns) == ["column_header", "description"]
+    assert key["column_header"].tolist() == [
+        str(OBJECT.LABEL),
+        str(SIZE.AREA),
+        str(LINEAR_SOFTPLUS_MODEL.v),
+        str(MODEL_METRICS.RMSE),
+    ]
+    descriptions = dict(zip(key["column_header"], key["description"]))
+    assert descriptions[str(OBJECT.LABEL)] == OBJECT.LABEL.desc
+    assert descriptions[str(SIZE.AREA)] == SIZE.AREA.desc
+    assert descriptions[str(LINEAR_SOFTPLUS_MODEL.v)] == (
+        LINEAR_SOFTPLUS_MODEL.v.desc
+    )
+    assert descriptions[str(MODEL_METRICS.RMSE)] == MODEL_METRICS.RMSE.desc


### PR DESCRIPTION
## Summary
- Add public `phenotypic.util.split_measurements()` and `generate_output_key()` helpers for pandas/polars measurement tables.
- Refactor CLI per-feature split writing to use dynamic `MeasurementInfo` column discovery instead of requiring a recovered pipeline.
- Add utility and CLI regression coverage, including model metric grouping for `LinearSoftplus`.

## Test Plan
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/unit/util/test_measurement_outputs.py tests/unit/cli/test_cli_output_manager.py -q`
- `uv run ruff check src/phenotypic/util/_measurement_outputs.py src/phenotypic/util/__init__.py src/phenotypic/__init__.py src/phenotypic/_cli/_cli_output_manager.py tests/unit/util/test_measurement_outputs.py tests/unit/cli/test_cli_output_manager.py`
- `uv run mypy src/phenotypic/util/_measurement_outputs.py --follow-imports=skip`
- `uv run mypy src/phenotypic` currently fails on the existing repo baseline: 475 errors in 128 files.