### PR TITLE
Split napari into its own `napari` optional extra

### DIFF
--- a/.github/workflows/gui-checks.yml
+++ b/.github/workflows/gui-checks.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Install Playwright browsers
         run: uv run playwright install --with-deps chromium
@@ -243,7 +243,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Install Playwright browsers
         run: uv run playwright install --with-deps chromium

--- a/.github/workflows/run-pytest-full.yml
+++ b/.github/workflows/run-pytest-full.yml
@@ -98,9 +98,9 @@ jobs:
             python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
-    # Headless Qt: the napari ``gui`` extra pulls PyQt6, whose QtGui is
-    # imported by pytest-qt at configure time; ``offscreen`` lets the qtbot
-    # widget tests run on the displayless Linux runner.
+    # Headless Qt: the ``qt-test`` group (and the napari extra) pull PyQt6,
+    # whose QtGui is imported by pytest-qt at configure time; ``offscreen``
+    # lets the qtbot widget tests run on the displayless Linux runner.
     env:
       QT_QPA_PLATFORM: offscreen
     steps:
@@ -128,7 +128,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Run tests (full, slow included)
         run: |
@@ -162,7 +162,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Run tests (full, slow included)
         run: |
@@ -196,7 +196,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Run tests (full, slow included)
         run: |

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -112,8 +112,8 @@ jobs:
             python-version: "3.12"
 
     runs-on: ${{ matrix.os }}
-    # Headless Qt: the napari ``gui`` extra now pulls PyQt6, whose QtGui is
-    # imported by the pytest-qt plugin at configure time. Qt6's default xcb
+    # Headless Qt: the ``qt-test`` group (and the napari extra) pull PyQt6,
+    # whose QtGui is imported by the pytest-qt plugin at configure time. Qt6's default xcb
     # platform plugin needs a display; ``offscreen`` lets the qtbot widget
     # tests run on the displayless runner. (PyQt5 did not require this.)
     env:
@@ -144,7 +144,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv lock
-          uv sync --group dev --all-extras
+          uv sync --group dev --group qt-test --all-extras
 
       - name: Cache testmon data
         uses: actions/cache@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 - `uv run <cmd>` — run commands
 - `uv add <package>` (or `--group dev`) — add dependencies
 - `uv sync` — sync env (after checkout or in new worktrees)
-- `uv sync --group dev --group docs --extras gui` — full dev env
+- `uv sync --group dev --group qt-test --group docs --extra gui --extra napari` — full dev env
+  (`qt-test` + the `napari` extra are required for the napari/Qt widget tests)
 - `source .venv/bin/activate` — manual venv activation
 
 ### Linting & Type Checking

--- a/README.md
+++ b/README.md
@@ -46,10 +46,16 @@ to integrate new tools.
 uv add phenotypic
 ```
 
-**Interactive / GUI Install** (napari viewer, Panel dashboards, Jupyter)
+**Interactive / GUI Install** (Panel dashboards, Jupyter, Dash hub)
 
 ```bash
 uv add phenotypic --extra gui
+```
+
+**napari Desktop Viewer Install** (for `image.*.napari()`, point picker, sweep viewer)
+
+```bash
+uv add phenotypic --extra napari
 ```
 
 ## Pip
@@ -64,6 +70,12 @@ pip install phenotypic
 
 ```bash
 pip install "phenotypic[gui]"
+```
+
+**napari Desktop Viewer Install**
+
+```bash
+pip install "phenotypic[napari]"
 ```
 
 Note: may not always be the latest version. Install from repo when latest update is

--- a/docs/source/tutorials/getting_started.rst
+++ b/docs/source/tutorials/getting_started.rst
@@ -46,14 +46,20 @@ Optional Extras
 
 PhenoTypic provides optional extras for different use cases:
 
-- ``[gui]`` — Full interactive environment including napari viewer, Panel dashboards,
-  and Jupyter integration. Required for ``image.rgb.napari()`` and related viewer methods.
+- ``[gui]`` — Browser-based GUI hub: Panel dashboards, Dash apps, and Jupyter
+  integration. Does **not** include napari.
+- ``[napari]`` — The interactive napari desktop viewers (pulls napari + PyQt6).
+  Required for ``image.rgb.napari()`` and related viewer methods, the point
+  picker, and the napari sweep viewer (``python -m phenotypic.gui.sweep``).
 - ``[torch]`` — PyTorch + SAM2 for ``Sam2Detector`` (Linux/macOS only).
 
 .. code-block:: bash
 
-   # Full interactive / GUI environment (napari, Panel, Jupyter)
+   # Browser GUI hub (Panel, Dash, Jupyter)
    uv add "phenotypic[gui]"
+
+   # napari desktop viewers
+   uv add "phenotypic[napari]"
 
    # SAM2 GPU detector (Linux/macOS)
    uv add "phenotypic[torch]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,6 @@ Repository = "https://github.com/Wheeldon-Lab/PhenoTypic"
 [project.optional-dependencies]
 
 gui = [
-    # Napari visualization
-    "napari[optional,pyqt6]",
     # Panel GUI components
     "panel>=1.3",
     "param>=2.0",
@@ -91,6 +89,12 @@ gui = [
     "ipywidgets>=8.1.7",
     "jupyter>=1.1.1",
     "pyvips>=2.2", # optional fast path for DZI tile generation
+]
+
+napari = [
+    # Interactive desktop viewers (image.*.napari(), point picker, pipeline
+    # viewer, sweep viewer). Pulls PyQt6 via the [pyqt6] extra.
+    "napari[optional,pyqt6]",
 ]
 
 torch = [
@@ -121,7 +125,6 @@ dev = [
     "ruff>=0.14.7",
     "scipy-stubs>=1.15.3.0",
     "pytest-testmon>=2.2.0",
-    "pytest-qt>=4.5.0",
     "pytest-memray>=1.7.0;sys_platform!='win32'",
     # Phase 0 of GUI hub roll-out (see GUI_SPEC_V1.md). Browser E2E suite is
     # gated on the ``PLAYWRIGHT=1`` env var locally and on CI path filters.
@@ -133,6 +136,13 @@ dev = [
     "pandas-stubs>=2.3.3.260113",
     "types-tqdm>=4.67.3.20260518",
     "types-psutil>=7.2.2.20260518",
+]
+qt-test = [
+    # Qt/napari widget tests. pytest-qt imports a Qt binding (PyQt6) at
+    # configure time, so both must be present whenever these tests run.
+    # The napari extra also pulls pyqt6 via napari[pyqt6]; uv dedupes the
+    # overlap. This group keeps the Qt test deps installable without napari.
+    "pytest-qt>=4.5.0",
     "pyqt6>=6.9.1",
 ]
 docs = [

--- a/src/phenotypic/_core/_image_parts/_image_plot_handler.py
+++ b/src/phenotypic/_core/_image_parts/_image_plot_handler.py
@@ -62,7 +62,7 @@ class ImagePlotHandler(ImageObjectsHandler):
         if not _HAS_NAPARI:
             raise ImportError(
                     "napari is required for interactive visualization. "
-                    "Install with: pip install phenotypic[gui]"
+                    "Install with: pip install phenotypic[napari]"
             )
 
         first = True

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base.py
@@ -98,7 +98,7 @@ class ImageAccessorBase(AccessorDashHandler):
 
         Raises:
             ImportError: If napari is not installed. Install with
-                ``pip install phenotypic[gui]``.
+                ``pip install phenotypic[napari]``.
 
         Examples:
             View multiple image transformations in one viewer:
@@ -132,7 +132,7 @@ class ImageAccessorBase(AccessorDashHandler):
         if not _HAS_NAPARI:
             raise ImportError(
                 "napari is required for interactive visualization. "
-                "Install with: pip install phenotypic[gui]"
+                "Install with: pip install phenotypic[napari]"
             )
         import napari as _napari
 

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_napari_labels_mixin.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_napari_labels_mixin.py
@@ -246,7 +246,7 @@ class NapariLabelsMixin:
         if not _HAS_NAPARI:
             raise ImportError(
                 "napari is required for interactive visualization. "
-                "Install with: pip install phenotypic[gui]"
+                "Install with: pip install phenotypic[napari]"
             )
         import napari as _napari
 

--- a/src/phenotypic/_core/_image_parts/accessors/_grid_accessor.py
+++ b/src/phenotypic/_core/_image_parts/accessors/_grid_accessor.py
@@ -1372,7 +1372,7 @@ class GridAccessor:
         if not _HAS_NAPARI:
             raise ImportError(
                 "napari is required for interactive visualization. "
-                "Install with: pip install phenotypic[gui]"
+                "Install with: pip install phenotypic[napari]"
             )
         import napari as _napari
 

--- a/src/phenotypic/_core/_pipeline_parts/_napari_pipeline_viewer.py
+++ b/src/phenotypic/_core/_pipeline_parts/_napari_pipeline_viewer.py
@@ -109,7 +109,7 @@ class NapariPipelineViewer(ImagePipelineCore):
         if not _HAS_NAPARI:
             raise ImportError(
                 "napari is required for interactive visualization. "
-                "Install with: pip install phenotypic[gui]"
+                "Install with: pip install phenotypic[napari]"
             )
 
         import napari as _napari

--- a/src/phenotypic/gui/sweep/_napari_sweep_viewer.py
+++ b/src/phenotypic/gui/sweep/_napari_sweep_viewer.py
@@ -9,6 +9,9 @@ from typing import List, Optional, get_args
 
 import numpy as np
 
+from phenotypic._core._image_parts.accessor_abstracts._image_accessor_base import (
+    _HAS_NAPARI,
+)
 from phenotypic.gui._config import ChannelName
 
 from ._sweep_data_model import (
@@ -55,6 +58,11 @@ class NapariSweepViewer:
         Returns:
             The :class:`napari.Viewer` instance.
         """
+        if not _HAS_NAPARI:
+            raise ImportError(
+                "napari is required for the sweep viewer. "
+                "Install with: pip install phenotypic[napari]"
+            )
         import napari
 
         self._data = SweepOutputScanner.scan(self._sweep_dir)
@@ -842,6 +850,11 @@ def launch_sweep_viewer(sweep_dir: Path) -> None:
     Args:
         sweep_dir: Root of the sweep output directory.
     """
+    if not _HAS_NAPARI:
+        raise ImportError(
+            "napari is required for the sweep viewer. "
+            "Install with: pip install phenotypic[napari]"
+        )
     import napari
 
     viewer_obj = NapariSweepViewer(sweep_dir)

--- a/src/phenotypic/tools_/napari_/_point_picker_widget.py
+++ b/src/phenotypic/tools_/napari_/_point_picker_widget.py
@@ -40,7 +40,7 @@ class PointPickerWidget:
         if not _HAS_NAPARI:
             raise ImportError(
                 "napari is required for interactive visualization. "
-                "Install with: pip install phenotypic[gui]"
+                "Install with: pip install phenotypic[napari]"
             )
         import napari
 

--- a/uv.lock
+++ b/uv.lock
@@ -3848,11 +3848,13 @@ gui = [
     { name = "jinja2" },
     { name = "jupyter" },
     { name = "jupyter-bokeh" },
-    { name = "napari", version = "0.4.16", source = { registry = "https://pypi.org/simple" }, extra = ["optional"], marker = "platform_machine == 'x86_64' and sys_platform == 'win32'" },
-    { name = "napari", version = "0.6.6", source = { registry = "https://pypi.org/simple" }, extra = ["optional", "pyqt6"], marker = "platform_machine != 'x86_64' or sys_platform != 'win32'" },
     { name = "panel" },
     { name = "param" },
     { name = "pyvips" },
+]
+napari = [
+    { name = "napari", version = "0.4.16", source = { registry = "https://pypi.org/simple" }, extra = ["optional"], marker = "platform_machine == 'x86_64' and sys_platform == 'win32'" },
+    { name = "napari", version = "0.6.6", source = { registry = "https://pypi.org/simple" }, extra = ["optional", "pyqt6"], marker = "platform_machine != 'x86_64' or sys_platform != 'win32'" },
 ]
 torch = [
     { name = "sam2", marker = "sys_platform != 'win32'" },
@@ -3872,13 +3874,10 @@ dev = [
     { name = "playwright", marker = "sys_platform != 'win32'" },
     { name = "pre-commit" },
     { name = "pympler", version = "1.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'win32'" },
-    { name = "pyqt6", version = "6.9.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "pyqt6", version = "6.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-memray", marker = "sys_platform != 'win32'" },
     { name = "pytest-playwright", marker = "sys_platform != 'win32'" },
-    { name = "pytest-qt" },
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -3906,6 +3905,11 @@ docs = [
     { name = "sphinxawesome-theme" },
     { name = "sphinxcontrib-napoleon" },
 ]
+qt-test = [
+    { name = "pyqt6", version = "6.9.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
+    { name = "pyqt6", version = "6.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "pytest-qt" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -3929,7 +3933,7 @@ requires-dist = [
     { name = "kaleido", specifier = ">=1.2.0" },
     { name = "mahotas" },
     { name = "mmh3" },
-    { name = "napari", extras = ["optional", "pyqt6"], marker = "extra == 'gui'" },
+    { name = "napari", extras = ["optional", "pyqt6"], marker = "extra == 'napari'" },
     { name = "numba", specifier = ">=0.62.1" },
     { name = "numpy" },
     { name = "opencv-python" },
@@ -3961,7 +3965,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0.0" },
     { name = "wand", specifier = ">=0.6.13" },
 ]
-provides-extras = ["gui", "torch"]
+provides-extras = ["gui", "napari", "torch"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3974,12 +3978,10 @@ dev = [
     { name = "playwright", marker = "sys_platform != 'win32'", specifier = ">=1.45.0" },
     { name = "pre-commit", specifier = ">=3.7.0" },
     { name = "pympler", marker = "sys_platform != 'win32'", specifier = ">=1.0.1" },
-    { name = "pyqt6", specifier = ">=6.9.1" },
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-cov" },
     { name = "pytest-memray", marker = "sys_platform != 'win32'", specifier = ">=1.7.0" },
     { name = "pytest-playwright", marker = "sys_platform != 'win32'", specifier = ">=0.5.0" },
-    { name = "pytest-qt", specifier = ">=4.5.0" },
     { name = "pytest-testmon", specifier = ">=2.2.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.7" },
@@ -4002,6 +4004,10 @@ docs = [
     { name = "sphinx-togglebutton", specifier = ">=0.3.2" },
     { name = "sphinxawesome-theme" },
     { name = "sphinxcontrib-napoleon" },
+]
+qt-test = [
+    { name = "pyqt6", specifier = ">=6.9.1" },
+    { name = "pytest-qt", specifier = ">=4.5.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Context

napari was bundled inside the `gui` optional-dependency group, so the browser-based Dash/Panel GUI hub dragged in napari + the whole Qt stack even when a user only wanted the web GUI. napari is only needed for the interactive **desktop** viewers (`image.*.napari()`, the point picker, the pipeline viewer, and the napari sweep viewer).

This PR carves napari into its own `napari` extra so it installs independently (`pip install phenotypic[napari]`), fully removed from `gui` (now Dash/Panel/Jupyter-only, no Qt).

## Changes

**Packaging (`pyproject.toml`)**
- New `napari = ["napari[optional,pyqt6]"]` extra; napari **removed** from `gui`.
- New `qt-test` dependency group holds `pytest-qt` + `pyqt6` (moved out of `dev`) so the Qt test deps are installable without napari.
- `uv.lock` regenerated.

**Defensive imports**
- The codebase was already defensive everywhere via the central `_HAS_NAPARI` flag; the only gap was the sweep viewer. Added the guard to both entry points in `_napari_sweep_viewer.py` so they raise a friendly `ImportError` instead of a bare `ModuleNotFoundError`.

**Install hints / docs**
- Repointed all 7 napari `ImportError` messages/docstrings from `phenotypic[gui]` → `phenotypic[napari]` (the two Panel/Dash hints correctly keep `[gui]`).
- `README.md`, `docs/source/tutorials/getting_started.rst`, and `CLAUDE.md` document the new extra.

**CI**
- Added `--group qt-test` to the install step in `run-pytest.yml`, `run-pytest-full.yml` (3×), and `gui-checks.yml` (2×) so the napari/Qt tests still run (`--all-extras` picks up the new extra automatically); refreshed stale comments. `docs.yml` unchanged.

## Verification

- `uv lock` + `uv sync --group dev --group qt-test --extra napari --extra gui` resolve; napari 0.6.6 + PyQt6 installed, `_HAS_NAPARI` True.
- `gui` extra no longer pulls napari/pyqt6 (`uv tree --extra gui`); lock confirms napari sits under `extra == 'napari'`.
- Sweep viewer raises `ImportError: ... pip install phenotypic[napari]` when napari is absent (both entry points).
- **135 napari/Qt tests pass** (`test_napari_pipeline_viewer`, `test_point_picker_*`, `test_manual_*`, `test_manual_selector`, `test_sweep_viewer`, `test_grouped_layer_widget`).
- ruff clean; mypy introduces **0 new errors** (the 30 in the sweep viewer are pre-existing `Optional`-narrowing issues, confirmed identical on the stashed original).
- grep audit: only the two intended Panel/Dash sites still reference `phenotypic[gui]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)