### PR TITLE
ci(full-lane): drop post-merge push trigger, run nightly at 07:00 PST

### DIFF
--- a/.github/workflows/run-pytest-full.yml
+++ b/.github/workflows/run-pytest-full.yml
@@ -1,11 +1,10 @@
 name: run-pytest-full
-# Nightly + post-merge full lane. Runs the cross-platform matrix and includes
+# Nightly full lane. Runs the cross-platform matrix and includes
 # slow-marked tests, which are excluded from the PR lane in run-pytest.yml.
 #
 # Triggers:
-#   * schedule (07:00 UTC nightly)         — catch flakes and time-sensitive regressions
-#   * push: branches: [main] (post-merge)  — gated by check-freshness skip guard
-#   * workflow_dispatch                    — manual full run on any ref
+#   * schedule (15:00 UTC = 07:00 PST nightly) — catch flakes and time-sensitive regressions
+#   * workflow_dispatch                         — manual full run on any ref
 #
 # Matrix:
 #   * Linux x Python {3.10, 3.11, 3.12}
@@ -22,70 +21,22 @@ name: run-pytest-full
 
 on:
   schedule:
-    - cron: '0 7 * * *'      # 07:00 UTC nightly
-  push:
-    branches: [main]          # post-merge full-matrix verification
+    # 15:00 UTC = 07:00 PST. GitHub cron is UTC-only and never observes
+    # DST, so this fires at 08:00 Pacific while PDT (Mar-Nov) is in effect.
+    - cron: '0 15 * * *'
   workflow_dispatch:
 
-# Never cancel a running nightly: a fresh push that arrives mid-run shouldn't
-# abort the in-flight slow-test sweep. Both runs will complete on their own.
+# Never cancel a running nightly: a scheduled or manual run that starts
+# mid-sweep shouldn't abort an in-flight slow-test run. Both will complete.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
-  check-freshness:
-    runs-on: ubuntu-latest
-    outputs:
-      skip: ${{ steps.set-output.outputs.skip }}
-    steps:
-      - name: Check for successful manual full-lane run on this SHA
-        if: github.event_name == 'push'
-        id: check
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const headSha = context.sha;
-
-            // Look for a successful workflow_dispatch run of THIS workflow
-            // on the merged SHA. If one exists (developer pre-flighted the
-            // full matrix before merging), skip the post-merge run.
-            const { data: runs } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: '.github/workflows/run-pytest-full.yml',
-              event: 'workflow_dispatch',
-              head_sha: headSha,
-              status: 'success',
-              per_page: 1,
-            });
-
-            if (runs.workflow_runs.length > 0) {
-              const manualRun = runs.workflow_runs[0];
-              core.setOutput('skip', 'true');
-              core.info(`Skipping full lane: workflow_dispatch run #${manualRun.id} already covered ${headSha}`);
-              return;
-            }
-
-            core.setOutput('skip', 'false');
-
-      - name: Set output
-        id: set-output
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "skip=${{ steps.check.outputs.skip }}" >> $GITHUB_OUTPUT
-          else
-            # schedule + workflow_dispatch always run
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
   tests-linux-full:
-    needs: check-freshness
-    if: needs.check-freshness.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -136,8 +87,7 @@ jobs:
           pytest -n auto -o "addopts=--verbose --capture=no" --durations=20
 
   tests-macos-full:
-    needs: check-freshness
-    if: needs.check-freshness.outputs.skip != 'true' && github.event.repository.visibility == 'public'
+    if: github.event.repository.visibility == 'public'
     strategy:
       fail-fast: false
       matrix:
@@ -170,8 +120,6 @@ jobs:
           pytest -n auto -o "addopts=--verbose --capture=no" --durations=20
 
   tests-windows-full:
-    needs: check-freshness
-    if: needs.check-freshness.outputs.skip != 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -2,7 +2,7 @@ name: run-pytest
 # Fast PR lane. Goal: ~10-15 min wall-clock for PR-time signal.
 #
 # Matrix: Linux x Python {3.10 (floor), 3.12 (ceiling)}. Windows, macOS, and
-# Python 3.11 move to the nightly + post-merge full lane in
+# Python 3.11 move to the nightly full lane in
 # ``run-pytest-full.yml``. Slow tests are excluded by default via
 # ``addopts = "-m 'not slow'"`` in pyproject.toml.
 #
@@ -105,7 +105,7 @@ jobs:
       matrix:
         include:
           # Ubuntu: floor (3.10) + ceiling (3.12). Python 3.11 moves to the
-          # nightly + post-merge full lane in run-pytest-full.yml.
+          # nightly full lane in run-pytest-full.yml.
           - os: ubuntu-latest
             python-version: "3.10"
           - os: ubuntu-latest

--- a/tests/unit/core/test_image_hdf_roundtrip.py
+++ b/tests/unit/core/test_image_hdf_roundtrip.py
@@ -22,7 +22,7 @@ from phenotypic.tools_.constants_ import GAMMA_ENCODINGS
 
 # Module-level slow marker: full HDF5 schema and back-compat matrix. The
 # companion binary-roundtrip suite in tests/unit/core/ stays on the fast lane
-# as the smoke check; this file moves to the nightly + post-merge full lane.
+# as the smoke check; this file moves to the nightly full lane.
 pytestmark = pytest.mark.slow
 
 

--- a/tests/unit/test_pickleable.py
+++ b/tests/unit/test_pickleable.py
@@ -5,7 +5,7 @@ from unit.test_fixtures import _public
 
 # Module-level slow marker: this is a coverage probe that walks the entire
 # phenotypic public namespace. The walk is heavy and the matrix doesn't move
-# under typical PRs, so we run it on the nightly + post-merge full lane only.
+# under typical PRs, so we run it on the nightly full lane only.
 pytestmark = pytest.mark.slow
 
 # Filter out CLI objects that aren't meant to be serialized


### PR DESCRIPTION
## Summary

Retunes the `run-pytest-full` lane (the cross-platform + slow-test nightly matrix) per request:

- **Removed the `push: branches: [main]` (post-merge) trigger.** The full lane now runs only on the nightly `schedule` and manual `workflow_dispatch`.
- **Retimed the nightly cron** from `0 7 * * *` (07:00 UTC) to `0 15 * * *` (**15:00 UTC = 07:00 PST**). GitHub cron is UTC-only and does not observe DST, so during PDT (Mar–Nov) it fires at 08:00 Pacific — documented inline.

## Follow-on cleanup

Removing the push trigger made the `check-freshness` job dead code: its only purpose was deduping post-merge runs against a manual pre-flight on the same SHA, and it only did work on `push` events (for `schedule`/`workflow_dispatch` it always set `skip=false`). So this PR also:

- Deletes the `check-freshness` job and the now-vestigial `needs: check-freshness` / `if: …skip != 'true'` guards on the three test jobs (macOS keeps its `repository.visibility == 'public'` gate).
- Drops the `actions: read` permission that only `check-freshness` needed.
- Updates stale "nightly + post-merge full lane" comments in `run-pytest.yml` and the two slow-marked test modules (`test_pickleable.py`, `test_image_hdf_roundtrip.py`) to "nightly full lane".

## Verification

- Both workflow YAMLs parse cleanly; `run-pytest-full` triggers are now `schedule` + `workflow_dispatch`, jobs are the three `tests-*-full` matrices, cron is `0 15 * * *`.
- No behavior change to the PR lane (`run-pytest.yml`) beyond comment text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)