### PR TITLE
chore(deps): default to polars[rtcompat] for cross-ISA HPCC nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,11 +260,19 @@ the gate:
 - **HPCC SLURM CPU heterogeneity (polars build):** the cluster has pre-AVX2 nodes
   (`abu_dhabi` = c01–30, `ivy` = h01–06). The stock `polars` wheel bakes AVX2 into its
   baseline with no runtime fallback, so it SIGILLs ("Illegal instruction (core dumped)")
-  there. We therefore **ship `polars-lts-cpu` by default** (baseline-ISA build, runs
-  everywhere). numpy/scipy use runtime SIMD dispatch and are fine on those nodes. On
-  AVX2-capable machines you can swap in the faster stock `polars` build (same
-  `import polars` API) — see `docs/source/how_to/pages/polars_cpu_build.md`. Pinning
-  jobs to AVX2 partitions/constraints is an alternative if you prefer the stock build.
+  there. We therefore **ship `polars[rtcompat]` by default** — the runtime-compat build
+  that ships both ISA variants (`polars-runtime-32` + `polars-runtime-compat`) and
+  picks the right `.so` at import time, so the same install runs on pre-AVX2 and modern
+  nodes alike (it supersedes the old `polars-lts-cpu` single-wheel workaround). numpy/scipy
+  use runtime SIMD dispatch and are fine on those nodes. The `import polars` API is
+  identical — see `docs/source/how_to/pages/polars_cpu_build.md`. Pinning jobs to AVX2
+  partitions/constraints is an alternative if you prefer a single-ISA stock build.
+  - **Gotcha — partial/corrupt extract:** `polars[rtcompat]` is a thin `polars` shim
+    package over the runtime wheels. An interrupted install can leave `polars/` missing
+    its own `__init__.py`, so Python treats it as a namespace package and
+    `import polars` yields `polars.__file__ == None` / `AttributeError: module 'polars'
+    has no attribute 'DataFrame'`. Fix: `uv pip install --reinstall polars` (or
+    `uv sync`). It's an environmental extract failure, not a code bug.
 - **Operations are keyword-only constructed:** `OtsuDetector(ignore_zeros=True)`, not
   `OtsuDetector(True)` — pydantic models take no positional args. Unknown kwargs and
   invalid values raise `pydantic.ValidationError`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,6 @@ dependencies = [
     "threadpoolctl>=3.6.0",
     "pympler>=1.0.1",
     "exifread>=3.5.1",
-    # polars-lts-cpu is the baseline-instruction-set build (no AVX2/AVX512
-    # required), so the default install runs on the cluster's pre-AVX2 nodes
-    # (e.g. abu_dhabi/ivy) without SIGILL. On AVX2-capable machines, swap in the
-    # faster stock `polars` build (same `import polars` API) -- see
-    # docs/source/how_to/pages/polars_cpu_build.md.
-    "polars-lts-cpu>=1.0.0",
     "click>=8.3.0",
     "bm3d>=4.0.3",
     "wand>=0.6.13",
@@ -77,10 +71,11 @@ dependencies = [
     "dash-bootstrap-components>=2.0.4",
     "pydantic>=2.12.5",
     "python-lucide>=0.2.24",
+    "polars[rtcompat]>=1.41.2",
 ]
 
 [project.urls]
-Repository = "https://github.com/Wheeldon-Lab/PhenoTypic"
+Repository = "https://github.com/exfab/PhenoTypic"
 
 [project.optional-dependencies]
 

--- a/uv.lock
+++ b/uv.lock
@@ -3804,7 +3804,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pillow" },
     { name = "plotly" },
-    { name = "polars-lts-cpu" },
+    { name = "polars", extra = ["rtcompat"] },
     { name = "pooch" },
     { name = "psutil" },
     { name = "pyarrow" },
@@ -3944,7 +3944,7 @@ requires-dist = [
     { name = "phenotypic", extras = ["torch"], marker = "extra == 'foundation'" },
     { name = "pillow" },
     { name = "plotly", specifier = ">=6.0.0" },
-    { name = "polars-lts-cpu", specifier = ">=1.0.0" },
+    { name = "polars", extras = ["rtcompat"], specifier = ">=1.41.2" },
     { name = "pooch", specifier = ">=1.8" },
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'tune'", specifier = ">=3.1" },
@@ -4235,17 +4235,52 @@ wheels = [
 ]
 
 [[package]]
-name = "polars-lts-cpu"
-version = "1.33.1"
+name = "polars"
+version = "1.41.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f4/93/a0c4200a5e0af2eee31ea79330cb1f5f4c58f604cb3de352f654e2010c81/polars_lts_cpu-1.33.1.tar.gz", hash = "sha256:0a5426d95ec9eec937a56d3e7cf7911a4b5486c42f4dbbcc9512aa706039322c", size = 4822741, upload-time = "2025-09-09T08:37:51.491Z" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/f9/aeda46259b0669247a160315d2d51269de9504b9dd2f70acadbcb22f46b7/polars-1.41.2.tar.gz", hash = "sha256:256d6731162371b77f3f29a55eacb8c0fc740ddb1a293a01d2ef5b5393c5c708", size = 737996, upload-time = "2026-05-29T17:39:15.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/9b/75916636b33724afabe820b0993f60dc243793421d6f680d5fcb531fe170/polars_lts_cpu-1.33.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5db75d1b424bd8aa34c9a670a901592f1931cc94d9fb32bdd428dbaad8c33761", size = 38908638, upload-time = "2025-09-09T08:37:02.258Z" },
-    { url = "https://files.pythonhosted.org/packages/81/e2/dc77b81650ba0c631c06f05d8e81faacee87730600fceca372273facf77b/polars_lts_cpu-1.33.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:37cf3a56cf447c69cfb3f9cd0e714d5b0c754705d7b497b9ab86cbf56e36b3e7", size = 35638895, upload-time = "2025-09-09T08:37:07.575Z" },
-    { url = "https://files.pythonhosted.org/packages/27/fb/4dcff801d71dfa02ec682d6b32fd0ce5339de48797f663698d5f8348ffe7/polars_lts_cpu-1.33.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:656b530a672fe8fbd4c212b2a8481099e5cef63e84970975619ea7c25faeb833", size = 39585825, upload-time = "2025-09-09T08:37:11.631Z" },
-    { url = "https://files.pythonhosted.org/packages/54/31/0474c14dce2c0507bea40069daafb848980ba7c351ad991908e51ac895fb/polars_lts_cpu-1.33.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:64574c784380b37167b3db3a7cfdb9839cd308e89b8818859d2ffb34a9c896b2", size = 36685020, upload-time = "2025-09-09T08:37:15.597Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/0a/5ebba9b145388ffbbd09fa84ac3cd7d336b922e34256b1417abf0a1c2fb9/polars_lts_cpu-1.33.1-cp39-abi3-win_amd64.whl", hash = "sha256:6b849e0e1485acb8ac39bf13356d280ea7c924c2b41cd548ea6e4d102d70be77", size = 39191650, upload-time = "2025-09-09T08:37:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/ad/bf3db68d30ac798ca31c80624709a0c03aa890e2e20e5ca987d7e55fcfc2/polars_lts_cpu-1.33.1-cp39-abi3-win_arm64.whl", hash = "sha256:c99ab56b059cee6bcabe9fb89e97f5813be1012a2251bf77f76e15c2d1cba934", size = 35445244, upload-time = "2025-09-09T08:37:22.97Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/22/28f62d24f7db56ac4343588f9362d49b7b4177e55ac47a466fe696b0099b/polars-1.41.2-py3-none-any.whl", hash = "sha256:23ce9a2910b6e3e8d4258770bf44aa17170958df7af6e85feedf4458a04d8d29", size = 833445, upload-time = "2026-05-29T17:37:05.576Z" },
+]
+
+[package.optional-dependencies]
+rtcompat = [
+    { name = "polars-runtime-compat" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/56/54e3ea0e9b64f327179049e4742241cc6b1d3e8fa414b05a057dd26df367/polars_runtime_32-1.41.2.tar.gz", hash = "sha256:7af09ec1ab053da2c9669e8d15f809a4083a29be05db57111688b8051062af56", size = 2989474, upload-time = "2026-05-29T17:39:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/9b/fe72a3811c0357cdb06c67bdc7695fa1623ad47948fc523195f5ac31037f/polars_runtime_32-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:95a08346dac337357cdb825c8076df7d36da54c4caa59a5cb41d0a30691c5edd", size = 52265283, upload-time = "2026-05-29T17:37:09.407Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/93/fab9da803fd80d9e83ef88c20932f637a10bc611b20415fc322eec84bc44/polars_runtime_32-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dedfaeec2c7f995298da7319dd9431d662e5dd1d0ec51b1459df4a0234ceff52", size = 46571222, upload-time = "2026-05-29T17:37:13.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2a/8843f34a8ac57acd058a39b87b03b580dd352a490e9dae0415e02033bdd4/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:18eea22c5cc34e27f8a60950458ad81e6a9ea75e89363ca1367e14e7e7f781fc", size = 50409372, upload-time = "2026-05-29T17:37:17.875Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c6/92b352fe88cf51bd0a19fb99e1c0cbe46aa26c14dcf7995b89869cd932ae/polars_runtime_32-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2630540dfdfb0f36f9b04a07c7c2e3f50bf2ad384113263c1c812007ee9141e0", size = 56405484, upload-time = "2026-05-29T17:37:22.684Z" },
+    { url = "https://files.pythonhosted.org/packages/74/c4/bae3174c3b02f6b441d2e58594387abcd509f67a098f682a83b195f08966/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:20e969e08f9b137e233c04cc04de73d9795f89eb77d34854e40a025965a43763", size = 50603512, upload-time = "2026-05-29T17:37:27.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ed/f2d26ae02d92c2689056838ed59e2a626326ad23c2831d58637d25f6c82a/polars_runtime_32-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e7016a3deb641b64a31447abbbee0f34bd020a6a9ae34ee6b743837def15e2a4", size = 54328561, upload-time = "2026-05-29T17:37:32.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c4/9c3831cc885dc7769e59abf8f583821a5fb4403fd0e4eba0ccc6d47a3d4b/polars_runtime_32-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:1e5e5377c315e0dcafdfb2a31adc546abbaeb3f9cb1864e6536523d2af473265", size = 51978643, upload-time = "2026-05-29T17:37:37.443Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c6/79e9f3f270270d7ed5575d92b7bfef49f01abd9275447161275b23b553a8/polars_runtime_32-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:843d96f69d18eca53429c1198e58891db7f18111f83b9c419bb45ad9d73eaed5", size = 46006901, upload-time = "2026-05-29T17:37:42.522Z" },
+]
+
+[[package]]
+name = "polars-runtime-compat"
+version = "1.41.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/3c/a274ecfeb1f39231e166d3b7df87674865211abc00dc42c2c57e9709dd80/polars_runtime_compat-1.41.2.tar.gz", hash = "sha256:cdd12ca3d79cc9748b6217dc969f8b3a3b282effa1b088aab00595ed86947f09", size = 2990973, upload-time = "2026-05-29T17:39:21.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/b9/f6d13337327c6a6aecb9eb615bafc09cee1c7fb02bdeecb838e14f7bae68/polars_runtime_compat-1.41.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c9646fc527ac8167adc681b17b78370e3064ef7ff3fe6a4253626fbef76bf3ea", size = 52212192, upload-time = "2026-05-29T17:38:32.948Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ce/b94ebe08e916a9478a1b99eb31616d70a4e28999cfb85e611d1c658e1302/polars_runtime_compat-1.41.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:84c4b9629fa43fe0627149d539424573a51f7b3e6450e4f33e6de474739d4d4d", size = 46431731, upload-time = "2026-05-29T17:38:38.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/217be7207d7da90f744be26ad17658ff6251d6d8212c15df590b3fd6aed5/polars_runtime_compat-1.41.2-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad7042bf2d33a98b913e545705552f916fc95c508962a0b4f29dc25aeab247e4", size = 50273757, upload-time = "2026-05-29T17:38:43.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/da/50bc1943028fd56c59d82a6e1185dd1076f312326aa24040027ba9f623fc/polars_runtime_compat-1.41.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:16f80d5f171c8ba1b2d351d0462f4d99a911aa5cb7c17833e01a1589de272837", size = 56049955, upload-time = "2026-05-29T17:38:52.841Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/f5/51a9ed2baa9d65cbc4c97210c690a0bd5ac29432684a78c19c3bd00e49fc/polars_runtime_compat-1.41.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:50576d8d190effd7167a81361060993d00f7a90ef58b5b1c2a71b241f5771580", size = 50443852, upload-time = "2026-05-29T17:38:57.709Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5d/928656351ce28c13559b1126ba64dcb266f93022b98838c6fc396f3167c3/polars_runtime_compat-1.41.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:33e46cf96175794827a85ec010826b04f54d074ea4f9bb37af572982be0f0e76", size = 53939413, upload-time = "2026-05-29T17:39:02.908Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e6/7c64efd7ec8c39e9a7a6bee4798caac0bf46a5398278f1957c180f480c8e/polars_runtime_compat-1.41.2-cp310-abi3-win_amd64.whl", hash = "sha256:42c207b8319e85f861eb673c2ca18260a0159161a2aaa997ef2754af56a81586", size = 51852978, upload-time = "2026-05-29T17:39:07.83Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d2/d13ff429824e9ec0c5d4cad9540b90b3c529f33e9f7004abd7eec9b987b8/polars_runtime_compat-1.41.2-cp310-abi3-win_arm64.whl", hash = "sha256:fb28837bec86a064ebe49907bbcbdc365919c80c99b920f2ad9ebc1ceed9ea3a", size = 45900408, upload-time = "2026-05-29T17:39:12.945Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Replaces the `polars-lts-cpu` single-wheel workaround with the **`polars[rtcompat]`** runtime-compat build. `rtcompat` ships both ISA variants (`polars-runtime-32` + `polars-runtime-compat`) and selects the right binary at import time, so one install runs on the cluster's pre-AVX2 nodes (`abu_dhabi`/`ivy`) and modern nodes alike. The `import polars` API is unchanged.

## Changes

- `pyproject.toml`: drop `polars-lts-cpu>=1.0.0`, add `polars[rtcompat]>=1.41.2`
- `uv.lock`: relock
- `CLAUDE.md`: update the HPCC polars-build gotcha, and document the partial-extract failure mode — an interrupted install leaves `polars/` without its `__init__.py`, so Python treats it as a namespace package and `import polars` raises `AttributeError: module 'polars' has no attribute 'DataFrame'`. Fix: `uv pip install --reinstall polars`.

## Note

This commit also carries the `Repository` URL change (`Wheeldon-Lab` → `exfab`) that was already in the working tree, since it lives in the same `pyproject.toml`. Flag if it should be split out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)