### PR TITLE
Prune stale autosummary stubs before docs build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -564,5 +564,46 @@ def generate_downloadables_rst(app):
     print(f"Generated {output_file}")
 
 
+def _prune_generated_api_stubs(api_dir: str) -> int:
+    """Delete autosummary-generated ``.rst`` stubs from *api_dir*.
+
+    ``docs/source/api_reference/api/`` is fully autosummary-generated and
+    gitignored. autosummary regenerates stubs for currently-referenced
+    members but never deletes stubs for modules that were renamed or
+    removed (e.g. the ``tools_`` -> ``sdk_`` rename). Those orphans then
+    abort the next build with ``ModuleNotFoundError: No module named
+    'phenotypic.tools_'`` before any page renders. Wiping the stubs before
+    generation makes the build robust to renames; the cost is a full
+    regeneration each build.
+
+    Returns the number of stubs removed.
+    """
+    import glob
+    import os
+
+    removed = 0
+    for path in glob.glob(os.path.join(api_dir, "*.rst")):
+        os.remove(path)
+        removed += 1
+    return removed
+
+
+def prune_stale_api_stubs(app, config):
+    """``config-inited`` hook: clear stale autosummary stubs before generation.
+
+    Runs at ``config-inited`` so it precedes autosummary's own stub
+    generation (connected at ``builder-inited``).
+    """
+    import os
+
+    api_dir = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "api_reference", "api"
+    )
+    removed = _prune_generated_api_stubs(api_dir)
+    if removed:
+        print(f"[conf] pruned {removed} stale autosummary stub(s) in {api_dir}")
+
+
 def setup(app):
+    app.connect("config-inited", prune_stale_api_stubs)
     app.connect("builder-inited", generate_downloadables_rst)


### PR DESCRIPTION
## Problem

`docs/source/api_reference/api/` is fully autosummary-generated and gitignored. `autosummary_generate=True` regenerates stubs for currently-referenced members but never deletes orphan stubs for modules that were **renamed or removed**. After the `phenotypic.tools_` → `phenotypic.sdk_` rename, ~170+ stale `phenotypic.tools_.*.rst` stubs survive in any working tree that built docs before the rename, and the next build aborts fatally:

```
WARNING/ERROR: [autosummary] failed to import phenotypic.tools_
ModuleNotFoundError: No module named 'phenotypic.tools_'
```

before any content page renders. A fresh CI clone is unaffected (no stale stubs), so this bites local/dev rebuilds, not CI — but it's a recurring papercut on every module rename.

## Fix

Add a `config-inited` hook in `conf.py` that wipes the generated stub dir before autosummary's own generation (which runs at `builder-inited`). The dir is 100% generated + gitignored (0 tracked files), so wiping is safe; autosummary regenerates the current stubs each build. Cost: full stub regeneration per build.

## Verification

Planted a stale `phenotypic.tools_.ZzzStaleProbe.rst`, ran `sphinx-build`: the hook logged `pruned 433 stale autosummary stub(s)`, the probe was gone afterward (not regenerated, since unreferenced), and the build proceeded past the reading phase that previously crashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)