### PR TITLE
feat(detect/nn): per-model input layer + protected batch hooks

### DIFF
--- a/src/phenotypic/_cli/_cli_staged_workers.py
+++ b/src/phenotypic/_cli/_cli_staged_workers.py
@@ -105,9 +105,9 @@ def stage2_detect_core(
     hdf = dataset_hdf_dir(output_dir, dataset_name) / f"{image_stem}.h5"
     image = image_cls.load_hdf5(hdf)  # read-only use; never re-saved here
     array = getattr(image, detector.input_layer)[:]
-    sample = detector.preprocess(array)
-    batch = detector.collate([sample])
-    result = detector.infer_batch(batch)[0]
+    sample = detector._preprocess(array)
+    batch = detector._collate([sample])
+    result = detector._infer_batch(batch)[0]
     write_sidecar(output_dir, dataset_name, image_stem, result)
 
 

--- a/src/phenotypic/abc_/_gpu_detector.py
+++ b/src/phenotypic/abc_/_gpu_detector.py
@@ -21,13 +21,15 @@ class GpuDetector(ObjectDetector, ABC):
     (e.g., deep-learning foundation models like SAM2 or micro-sam).
 
     GpuDetector provides a concrete ``_operate`` built from a small set of
-    overridable hooks — ``preprocess`` (raw ``input_layer`` array → model-ready
-    sample), ``collate`` (samples → batch), ``infer_batch`` (batch → per-sample
-    results), and ``_write_object_output`` (result → ``objmap``/``objmask``).
-    The single-image notebook path and the batched CLI engine drive the *same*
-    hooks, so a detector implemented once runs in both. Capability is declared
-    via three fields — ``input_layer`` (``rgb``/``gray``/``detect_mat``),
-    ``supports_batching``, and ``output_kind`` (``instance``/``semantic``).
+    protected, overridable hooks — ``_preprocess`` (raw ``input_layer`` array →
+    model-ready sample), ``_collate`` (samples → batch), ``_infer_batch``
+    (batch → per-sample results), and ``_write_object_output`` (result →
+    ``objmap``/``objmask``). The single-image notebook path and the batched CLI
+    engine drive the *same* hooks, so a detector implemented once runs in both.
+    Capability is declared via three fields — ``input_layer``
+    (``rgb``/``gray``/``detect_mat``; defaults to the layer the model was
+    trained on), ``supports_batching``, and ``output_kind``
+    (``instance``/``semantic``).
 
     When a pipeline contains a GpuDetector, the CLI enforces:
 
@@ -82,9 +84,9 @@ class GpuDetector(ObjectDetector, ABC):
                 # ... build model ...
 
             def _infer_one(self, sample):
-                # ``sample`` is a preprocessed (H, W, 3) array. Return a uint16
-                # labeled objmap (output_kind="instance") or a bool mask
-                # (output_kind="semantic"). The base _operate/infer_batch wire
+                # ``sample`` is a preprocessed (H, W, 3) uint8 array. Return a
+                # uint16 labeled objmap (output_kind="instance") or a bool mask
+                # (output_kind="semantic"). The base _operate/_infer_batch wire
                 # this into the image; do NOT override _operate.
                 # ... run inference ...
                 return objmap
@@ -92,9 +94,9 @@ class GpuDetector(ObjectDetector, ABC):
     Notes:
         ``_operate`` is concrete here and should not be overridden. Non-batchable
         subclasses (SAM2, micro-sam) implement just ``_ensure_model_loaded`` +
-        ``_infer_one``; the default ``infer_batch`` loops ``_infer_one`` and is
+        ``_infer_one``; the default ``_infer_batch`` loops ``_infer_one`` and is
         the sole caller of ``_ensure_model_loaded``. Batchable subclasses
-        (Spec 2 foundation models) instead override ``infer_batch`` with a true
+        (Spec 2 foundation models) instead override ``_infer_batch`` with a true
         ``(N, C, H, W)`` forward — no engine changes needed. The class also lets
         the CLI make informed GPU resource-allocation decisions.
     """
@@ -110,27 +112,37 @@ class GpuDetector(ObjectDetector, ABC):
     def _ensure_model_loaded(self) -> None:
         """Build/load the GPU model on first use (idempotent)."""
 
-    def preprocess(self, array: np.ndarray) -> Any:
-        """Turn a raw ``input_layer`` array into a model-ready sample (CPU).
+    def _preprocess(self, array: np.ndarray) -> Any:
+        """Turn a raw ``input_layer`` array into a model-ready ``uint8`` sample.
 
-        Default: a single-channel 2D layer (``gray``/``detect_mat``) is stacked
-        into an ``(H, W, 3)`` block so 3-channel models (SAM/DINO ViT) consume
-        it unchanged; ``rgb`` passes through untouched. Subclasses may override
-        for model-specific normalization (e.g. uint8 coercion).
+        Single-channel 2D layers (``gray``/``detect_mat``) are stacked into an
+        ``(H, W, 3)`` block so 3-channel models (SAM/DINO ViT) consume them
+        unchanged; ``rgb`` keeps its three channels. The result is then coerced
+        to ``uint8`` — float ``[0, 1]`` (``gray``/``detect_mat``) and ``uint16``
+        (16-bit ``rgb``) layers are max-normalized to ``0..255``, while an
+        already-``uint8`` ``rgb`` array passes through byte-identical — so every
+        layer reaches the model through this one shared conversion. Subclasses
+        rarely need to override this.
         """
         if array.ndim == 2:
-            return np.stack([array, array, array], axis=-1)
+            array = np.stack([array, array, array], axis=-1)
+        if array.dtype != np.uint8:
+            max_val = array.max()
+            if max_val > 0:
+                array = (array / max_val * 255).astype(np.uint8)
+            else:
+                array = np.zeros(array.shape, dtype=np.uint8)
         return array
 
-    def collate(self, samples: List[Any]) -> Any:
-        """Merge per-sample ``preprocess`` outputs into a batch.
+    def _collate(self, samples: List[Any]) -> Any:
+        """Merge per-sample ``_preprocess`` outputs into a batch.
 
         Default returns the list unchanged (consumed by the looped
-        ``infer_batch``). Batchable subclasses override to stack into a tensor.
+        ``_infer_batch``). Batchable subclasses override to stack into a tensor.
         """
         return samples
 
-    def infer_batch(self, batch: Any) -> List[np.ndarray]:
+    def _infer_batch(self, batch: Any) -> List[np.ndarray]:
         """Run inference over a collated batch; return one result per sample.
 
         Each result is a uint16 labeled map (``output_kind="instance"``) or a
@@ -166,13 +178,13 @@ class GpuDetector(ObjectDetector, ABC):
         """Run GPU detection on one image (notebook / single-image path).
 
         Reads the declared ``input_layer``, preprocesses, runs a one-element
-        batch through ``collate`` + ``infer_batch``, and writes the result via
+        batch through ``_collate`` + ``_infer_batch``, and writes the result via
         ``output_kind``. The batched CLI engine drives the same
-        ``preprocess``/``collate``/``infer_batch`` methods over many images.
+        ``_preprocess``/``_collate``/``_infer_batch`` methods over many images.
         """
         array = getattr(image, self.input_layer)[:]
-        sample = self.preprocess(array)
-        batch = self.collate([sample])
-        results = self.infer_batch(batch)
+        sample = self._preprocess(array)
+        batch = self._collate([sample])
+        results = self._infer_batch(batch)
         self._write_object_output(image, results[0])
         return image

--- a/src/phenotypic/detect/nn/_dinosam2_detector.py
+++ b/src/phenotypic/detect/nn/_dinosam2_detector.py
@@ -188,6 +188,10 @@ class DinoSam2Detector(GpuDetector):
             mask generator).  Default 100.
         device: PyTorch device for inference.  ``"auto"`` probes accelerators
             and raises ``RuntimeError`` if none is found.
+        input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
+            layer the SAM2/DINO backbones were trained on), ``"gray"``, or
+            ``"detect_mat"``.  Single-channel layers are stacked to 3 channels
+            and coerced to uint8 by ``_preprocess``.
 
     Returns:
         Image: Input image with ``objmap`` set to a labelled instance map and
@@ -318,7 +322,7 @@ class DinoSam2Detector(GpuDetector):
     # ------------------------------------------------------------------
 
     def _infer_one(self, sample: Any) -> "np.ndarray":
-        """Run the SAM2-proposals + DINO-scoring recipe on one RGB sample.
+        """Run the SAM2-proposals + DINO-scoring recipe on one preprocessed sample.
 
         Returns a uint16 labelled objmap. SAM2 proposals are scored by cosine
         similarity of their pooled DINO feature to the foreground prototype
@@ -329,7 +333,7 @@ class DinoSam2Detector(GpuDetector):
 
         self._ensure_model_loaded()
 
-        rgb = self._to_uint8(sample)
+        rgb = sample
         raw = self._generator.generate(rgb)  # type: ignore[attr-defined]
         if not raw:
             return np.zeros(rgb.shape[:2], dtype=np.uint16)
@@ -356,20 +360,6 @@ class DinoSam2Detector(GpuDetector):
             similarity_thresh=self.similarity_thresh,
             merge_iou_thresh=self.merge_iou_thresh,
         )
-
-    @staticmethod
-    def _to_uint8(sample: "np.ndarray") -> "np.ndarray":
-        """Coerce an ``(H, W, 3)`` sample to uint8 for SAM2 / the DINO processor."""
-        import numpy as np
-
-        rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-        return rgb
 
     @staticmethod
     def _foreground_prototype(

--- a/src/phenotypic/detect/nn/_fssdino_detector.py
+++ b/src/phenotypic/detect/nn/_fssdino_detector.py
@@ -304,6 +304,10 @@ class FssDinoDetector(GpuDetector):
             0.15.
         device: PyTorch device for inference. ``"auto"`` probes accelerators and
             raises ``RuntimeError`` if none is found.
+        input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
+            layer the DINOv2 backbone was trained on), ``"gray"``, or
+            ``"detect_mat"``. Single-channel layers are stacked to 3 channels
+            and coerced to uint8 by ``_preprocess``.
 
     Returns:
         Image: Input image with ``objmask`` set to the semantic foreground mask
@@ -517,7 +521,7 @@ class FssDinoDetector(GpuDetector):
         """Score a query against the fg/bg classes → boolean objmask (tiled)."""
 
         self._ensure_model_loaded()
-        rgb = self._to_uint8(sample)
+        rgb = sample
 
         from phenotypic.detect.nn._tiling import (
             _plan_tiles,
@@ -581,20 +585,6 @@ class FssDinoDetector(GpuDetector):
         ]
         maps.append(gram_score_map(dense, gram))
         return combine_score_maps(maps)
-
-    @staticmethod
-    def _to_uint8(sample: "np.ndarray") -> "np.ndarray":
-        """Coerce an ``(H, W, 3)`` sample to uint8 for the DINO processor."""
-        import numpy as np
-
-        rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-        return rgb
 
 
 # Expose the class docstring on .apply() for Sphinx autodoc

--- a/src/phenotypic/detect/nn/_insid3_detector.py
+++ b/src/phenotypic/detect/nn/_insid3_detector.py
@@ -191,6 +191,10 @@ class Insid3Detector(GpuDetector):
             0.15.
         device: PyTorch device for inference. ``"auto"`` probes accelerators and
             raises ``RuntimeError`` if none is found.
+        input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
+            layer the DINOv3 backbone was trained on), ``"gray"``, or
+            ``"detect_mat"``. Single-channel layers are stacked to 3 channels
+            and coerced to uint8 by ``_preprocess``.
 
     Returns:
         Image: Input image with ``objmask`` set to the semantic foreground mask
@@ -381,7 +385,7 @@ class Insid3Detector(GpuDetector):
         """
 
         self._ensure_model_loaded()
-        rgb = self._to_uint8(sample)
+        rgb = sample
 
         from phenotypic.detect.nn._tiling import (
             _plan_tiles,
@@ -419,21 +423,6 @@ class Insid3Detector(GpuDetector):
             thresh=self.similarity_thresh,
             out_shape=(rgb.shape[0], rgb.shape[1]),
         )
-
-    @staticmethod
-    def _to_uint8(sample: "np.ndarray") -> "np.ndarray":
-        """Coerce an ``(H, W, 3)`` sample to uint8 for the DINO processor."""
-        import numpy as np
-
-        rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-        return rgb
-
 
 # Expose the class docstring on .apply() for Sphinx autodoc
 Insid3Detector.apply.__doc__ = Insid3Detector.__doc__

--- a/src/phenotypic/detect/nn/_microsam_detector.py
+++ b/src/phenotypic/detect/nn/_microsam_detector.py
@@ -9,6 +9,7 @@ from phenotypic.detect.nn._checkpoint_manager import (
     Device,
     MicroSamModelType,
 )
+from phenotypic.sdk_.typing_ import GpuInputLayer
 
 
 class MicroSamDetector(GpuDetector):
@@ -49,6 +50,11 @@ class MicroSamDetector(GpuDetector):
             Habana HPU, then raises if none found. Pass ``"cpu"`` to force
             CPU inference (very slow). Any valid PyTorch device string is
             accepted.
+        input_layer: Image layer fed to the model -- one of ``"rgb"``,
+            ``"gray"``, or ``"detect_mat"``. Defaults to ``"gray"`` because
+            micro-sam's light-microscopy weights are grayscale-native.
+            Single-channel layers are stacked to 3 channels and coerced to
+            uint8 by ``_preprocess`` before inference.
 
     Returns:
         Image: Input image with ``objmask`` set to a binary colony mask
@@ -101,11 +107,11 @@ class MicroSamDetector(GpuDetector):
         deserialization the internal ``_predictor`` is rebuilt
         transparently on the next :meth:`apply` call.
 
-        **RGB input.** MicroSamDetector reads ``image.rgb[:]`` directly
-        (not ``detect_mat``). SAM models were trained on colour images;
-        the classical enhancement pipeline targets thresholding, not
-        foundation models. If the image has higher-than-8-bit dynamic
-        range it is rescaled to uint8 before inference.
+        **Input layer.** ``input_layer`` selects which image layer micro-sam
+        consumes and defaults to ``"gray"`` because the light-microscopy
+        models are grayscale-native (set ``"rgb"`` or ``"detect_mat"`` to
+        override). The chosen layer is stacked to 3 channels and rescaled to
+        uint8 by ``_preprocess`` before inference.
 
         **Checkpoint caching.** micro-sam manages its own cache via
         ``platformdirs`` (respects the ``MICROSAM_CACHEDIR`` environment
@@ -155,6 +161,7 @@ class MicroSamDetector(GpuDetector):
 
     model_type: MicroSamModelType = "vit_b_lm"
     device: Device = "auto"
+    input_layer: GpuInputLayer = "gray"
 
     # Lazy micro-sam predictor/segmenter — PrivateAttr, skipped by serialization.
     _predictor: object = PrivateAttr(default=None)
@@ -189,7 +196,7 @@ class MicroSamDetector(GpuDetector):
         )
 
     def _infer_one(self, sample):
-        """Segment colonies in one preprocessed RGB sample via micro-sam AIS.
+        """Segment colonies in one preprocessed sample via micro-sam AIS.
 
         Returns a uint16 labeled objmap.
         """
@@ -199,13 +206,6 @@ class MicroSamDetector(GpuDetector):
         )
 
         rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-
         labeled = automatic_instance_segmentation(
             predictor=self._predictor,
             segmenter=self._segmenter,

--- a/src/phenotypic/detect/nn/_sam2_detector.py
+++ b/src/phenotypic/detect/nn/_sam2_detector.py
@@ -11,6 +11,7 @@ from phenotypic.detect.nn._checkpoint_manager import (
     Device,
     Sam2ModelSize,
 )
+from phenotypic.sdk_.typing_ import GpuInputLayer
 
 
 def build_sam2_generator(
@@ -94,10 +95,10 @@ class Sam2Detector(GpuDetector):
     applies non-maximum suppression to produce a final set of
     non-overlapping instance masks.
 
-    Because SAM2 operates on **RGB input** (not ``detect_mat``), classical
-    enhancement operations placed before this detector in a pipeline are
-    ignored.  The model sees the original colour image regardless of any
-    preceding enhancers.
+    SAM2 was trained on **RGB input**, so ``input_layer`` defaults to
+    ``"rgb"`` and preceding classical enhancers (which target ``detect_mat``)
+    are ignored by default.  Set ``input_layer="detect_mat"`` (or ``"gray"``)
+    to instead feed that layer, which ``_preprocess`` stacks to three channels.
 
     The model is loaded lazily on the first call to
     :meth:`~phenotypic.abc_.ImageOperation.apply` (not during construction),
@@ -142,6 +143,10 @@ class Sam2Detector(GpuDetector):
             Required when *checkpoint* points to a non-standard model.
             When *None* and *checkpoint* is set, the config for
             *model_size* is used as a fallback.
+        input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
+            layer SAM2 was trained on), ``"gray"``, or ``"detect_mat"``.
+            Single-channel layers are stacked to 3 channels and coerced to
+            uint8 by ``_preprocess`` before inference.
 
     Returns:
         Image: Input image with ``objmask`` set to a binary colony mask
@@ -220,6 +225,7 @@ class Sam2Detector(GpuDetector):
     device: Device = "auto"
     checkpoint: str | Path | None = None
     config: str | None = None
+    input_layer: GpuInputLayer = "rgb"
 
     # Lazy SAM2 mask generator — PrivateAttr -> skipped by serialization.
     _generator: object = PrivateAttr(default=None)
@@ -248,7 +254,7 @@ class Sam2Detector(GpuDetector):
         )
 
     def _infer_one(self, sample):
-        """Segment colonies in one preprocessed RGB sample via SAM2 AMG.
+        """Segment colonies in one preprocessed sample via SAM2 AMG.
 
         Returns a uint16 labeled objmap (largest-first painting preserves
         small-colony identity at overlaps).
@@ -256,13 +262,6 @@ class Sam2Detector(GpuDetector):
         import numpy as np
 
         rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-
         masks = self._generator.generate(rgb)  # type: ignore[attr-defined]
 
         h, w = rgb.shape[:2]

--- a/src/phenotypic/detect/nn/_sam3_detector.py
+++ b/src/phenotypic/detect/nn/_sam3_detector.py
@@ -145,6 +145,10 @@ class Sam3Detector(GpuDetector):
             structural, not tuned.
         device: PyTorch device for inference.  ``"auto"`` probes accelerators
             and raises ``RuntimeError`` if none is found.
+        input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
+            layer SAM3 was trained on), ``"gray"``, or ``"detect_mat"``.
+            Single-channel layers are stacked to 3 channels and coerced to
+            uint8 by ``_preprocess``.
 
     Returns:
         Image: Input image with ``objmap`` set to a labelled instance map
@@ -253,24 +257,6 @@ class Sam3Detector(GpuDetector):
         self._processor = Sam3Processor.from_pretrained(repo_id)
 
     # ------------------------------------------------------------------
-    # uint8 coercion (mirror Sam2Detector._infer_one normalisation)
-    # ------------------------------------------------------------------
-
-    @staticmethod
-    def _to_uint8(sample: "np.ndarray") -> "np.ndarray":
-        """Coerce an ``(H, W, 3)`` sample to uint8 for the SAM3 processor."""
-        import numpy as np
-
-        rgb = sample
-        if rgb.dtype != np.uint8:
-            max_val = rgb.max()
-            if max_val > 0:
-                rgb = (rgb / max_val * 255).astype(np.uint8)
-            else:
-                rgb = np.zeros(rgb.shape, dtype=np.uint8)
-        return rgb
-
-    # ------------------------------------------------------------------
     # Per-tile forward + objmap painting
     # ------------------------------------------------------------------
 
@@ -348,7 +334,7 @@ class Sam3Detector(GpuDetector):
     # True-batch inference with fixed geometric tiling (C4)
     # ------------------------------------------------------------------
 
-    def infer_batch(self, batch: Any) -> List["np.ndarray"]:
+    def _infer_batch(self, batch: Any) -> List["np.ndarray"]:
         """Run SAM3 over a collated batch; one uint16 objmap per sample.
 
         Each sample is tiled into fixed ~:attr:`tile_px` crops; all crops from
@@ -360,14 +346,14 @@ class Sam3Detector(GpuDetector):
 
         self._ensure_model_loaded()
 
-        # Plan tiles per sample; collect every crop into one flat batch. The
-        # uint8 coercion happens once per sample here (the later loops only need
-        # the full-image shape) to avoid re-allocating large plate images.
+        # Plan tiles per sample; collect every crop into one flat batch
+        # (samples arrive already uint8 from _preprocess; the later loops only
+        # need the full-image shape, so no re-allocation of large plate images).
         plans: list[list[_Tile]] = []
         full_shapes: list[tuple[int, int]] = []
         flat_crops: list[np.ndarray] = []
         for sample in batch:
-            arr = self._to_uint8(sample)
+            arr = sample
             full_shapes.append((arr.shape[0], arr.shape[1]))
             tiles = _plan_tiles(
                 (arr.shape[0], arr.shape[1]), self.tile_px, self.tile_overlap

--- a/tests/unit/abc_/test_gpu_detector_interface.py
+++ b/tests/unit/abc_/test_gpu_detector_interface.py
@@ -38,38 +38,53 @@ class TestCapabilityFields:
 
 
 class TestPreprocess:
-    def test_2d_layer_stacked_to_3_channels(self):
+    def test_2d_float_layer_stacked_and_uint8_normalized(self):
+        # gray/detect_mat arrive as 2D float [0,1]; _preprocess stacks them to
+        # (H,W,3) and max-normalizes to uint8 through one shared path.
         det = Sam2Detector()
-        gray = np.zeros((4, 5), dtype=np.float32)
-        out = det.preprocess(gray)
+        gray = np.linspace(0.0, 1.0, 20, dtype=np.float32).reshape(4, 5)
+        out = det._preprocess(gray)
         assert out.shape == (4, 5, 3)
+        assert out.dtype == np.uint8
+        assert out.max() == 255  # float [0,1] max-normalized to 0..255
+        np.testing.assert_array_equal(out[..., 0], out[..., 1])
+        np.testing.assert_array_equal(out[..., 0], out[..., 2])
 
-    def test_rgb_passthrough(self):
+    def test_rgb_uint8_passthrough(self):
         det = Sam2Detector()
         rgb = np.zeros((4, 5, 3), dtype=np.uint8)
-        out = det.preprocess(rgb)
+        rgb[1, 2] = (10, 20, 30)
+        out = det._preprocess(rgb)
         assert out.shape == (4, 5, 3)
-        assert out is rgb  # no copy for already-3-channel input
+        assert out.dtype == np.uint8
+        assert out is rgb  # already uint8 3-channel -> no copy/coercion
+
+    def test_all_zero_layer_returns_zero_uint8(self):
+        det = Sam2Detector()
+        out = det._preprocess(np.zeros((4, 5), dtype=np.float32))
+        assert out.shape == (4, 5, 3)
+        assert out.dtype == np.uint8
+        assert out.max() == 0
 
 
 class TestInferBatchDefault:
     def test_collate_passthrough(self):
         det = _FakeGpuDetector()
         samples = [np.zeros((2, 2, 3)), np.ones((2, 2, 3))]
-        assert det.collate(samples) == samples
+        assert det._collate(samples) == samples
 
     def test_infer_batch_loops_infer_one(self):
         det = _FakeGpuDetector(output_kind="instance")
         a = np.zeros((3, 3, 3), dtype=np.float32)
         a[1, 1, :] = 1.0
-        results = det.infer_batch([a, a])
+        results = det._infer_batch([a, a])
         assert len(results) == 2
         assert results[0].dtype == np.uint16
         assert results[0].max() == 1  # one labeled blob
 
     def test_infer_batch_loads_model(self):
         det = _FakeGpuDetector()
-        det.infer_batch([np.zeros((2, 2, 3))])
+        det._infer_batch([np.zeros((2, 2, 3))])
         assert det._loaded is True
 
 
@@ -92,6 +107,37 @@ class TestOperateRoutes:
         image = load_synth_yeast_plate()
         det = _FakeGpuDetector(input_layer="detect_mat", output_kind="instance",
                                threshold=0.3)
-        # detect_mat is 2D -> preprocess stacks to (H,W,3); must not raise
+        # detect_mat is 2D -> _preprocess stacks to (H,W,3); must not raise
         out = det.apply(image, inplace=False)
         assert out.objmap[:].shape == image.shape[:2]
+
+
+class TestDefaultInputLayer:
+    """Each nn detector defaults to the layer its model was trained on.
+
+    All six wrapped models are RGB-input ViTs, so the default is ``"rgb"`` —
+    except micro-sam, whose light-microscopy weights are grayscale-native and
+    so default to ``"gray"``. Constructing every detector is torch-free (lazy
+    model loading), so this runs on CPU.
+    """
+
+    def test_defaults_match_trained_layer(self):
+        from phenotypic.detect.nn import (
+            DinoSam2Detector,
+            FssDinoDetector,
+            Insid3Detector,
+            MicroSamDetector,
+            Sam2Detector,
+            Sam3Detector,
+        )
+
+        expected = {
+            Sam2Detector: "rgb",
+            Sam3Detector: "rgb",
+            DinoSam2Detector: "rgb",
+            Insid3Detector: "rgb",
+            FssDinoDetector: "rgb",
+            MicroSamDetector: "gray",
+        }
+        for cls, layer in expected.items():
+            assert cls().input_layer == layer, cls.__name__

--- a/tests/unit/detect/nn/test_microsam_detector.py
+++ b/tests/unit/detect/nn/test_microsam_detector.py
@@ -48,7 +48,7 @@ class TestMicroSamDetectorConstruction:
 
     def test_capability_fields(self):
         det = MicroSamDetector()
-        assert det.input_layer == "rgb"
+        assert det.input_layer == "gray"  # grayscale-native microscopy default
         assert det.output_kind == "instance"
         assert det.supports_batching is False
 

--- a/tests/unit/detect/nn/test_sam3_detector.py
+++ b/tests/unit/detect/nn/test_sam3_detector.py
@@ -172,7 +172,7 @@ class TestSam3TilingBatchInteraction:
         n_large = len(_plan_tiles((3000, 3000), 1008, 0.15))
         assert n_small == 1 and n_large > 1  # different tile counts
 
-        results = det.infer_batch([small, large])
+        results = det._infer_batch([small, large])
 
         # One result per input image, each in that image's full shape.
         assert len(results) == 2


### PR DESCRIPTION
## Context

The `phenotypic.detect.nn` detectors already had the *plumbing* for input-layer
selection — a serialized `input_layer: Literal["rgb","gray","detect_mat"]` field
on the `GpuDetector` base, dispatched via `getattr(image, self.input_layer)[:]`
in both the notebook path (`abc_/_gpu_detector.py::_operate`) and the staged-CLI
path (`_cli/_cli_staged_workers.py::stage2_detect_core`). But every detector
pinned it to `"rgb"`, the three batch hooks were public, and the float→uint8
conversion was copy-pasted per-detector. This PR completes the feature.

## Changes

- **Protected batch hooks** — `preprocess`/`collate`/`infer_batch` →
  `_preprocess`/`_collate`/`_infer_batch` (subclass-overridable internals, not
  public API). Updates the base, the `Sam3Detector` override, and the CLI
  `stage2_detect_core` call sites.
- **Centralized layer→uint8 in `_preprocess`** — the base hook now stacks a 2D
  layer to `(H,W,3)` **and** coerces to model-ready uint8 (max-normalizing
  float `[0,1]` / uint16; an already-uint8 `rgb` passes through unchanged), so
  every layer reaches the model through one shared conversion. Removed the six
  duplicated `_to_uint8` copies (4 static + 2 inlined).
- **Per-model defaults** (web-confirmed: all six are RGB-input ViTs) — `rgb` for
  `Sam2`/`Sam3`/`DinoSam2`/`Insid3`/`FssDino`; **`gray` for `MicroSamDetector`**
  (its light-microscopy weights are grayscale-native, and `gray` is always
  derivable whereas `rgb` raises `NoArrayError` on grayscale-only images). Users
  can override to `gray`/`detect_mat`, which flows through `_preprocess`.
- **Docs + tests** — documented `input_layer` in each detector's `Args`; added a
  table-driven default-layer regression test and uint8 `_preprocess` tests.

## Design decisions

- Kept the field name `input_layer` (no rename to `layer`) — avoids a
  `from_json` back-compat break since it shipped on `main`.
- `GpuInputLayer` Literal alias and `TestTypingAliases` unchanged.
- nn detectors are outside the tune annotation-coverage gate, and `input_layer`
  is non-numeric, so no annotation needed.

## Verification (CPU-only, no GPU required)

- `tests/unit/abc_/test_gpu_detector_interface.py` — 14 passed
- `tests/unit/detect/nn` — **154 passed, 4 skipped** (SAM2 + DINOv2 *functional*
  tests downloaded weights and ran real inference through the new `_preprocess`)
- `tests/integration/cli/test_staged_gpu_local.py` — 10 passed
- `tests/smoke/test_serialization.py` — 116 passed (micro-sam round-trips
  `input_layer="gray"`)
- `ruff check` clean. The remaining `mypy` errors are all in untouched files
  (`_checkpoint_manager.py`, `_cli.py`, `_grid_inference_mixin.py`,
  `image_metrics.py`) — pre-existing, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)