### PR TITLE
feat(enhance): add CompositeEnhance + unify composite list param to `ops`

### DIFF
--- a/src/phenotypic/detect/_composite_detector.py
+++ b/src/phenotypic/detect/_composite_detector.py
@@ -42,7 +42,7 @@ class CompositeDetector(ObjectDetector):
           strategies.
 
     Args:
-        detectors: List of :class:`~phenotypic.abc_.ObjectDetector` or
+        ops: List of :class:`~phenotypic.abc_.ObjectDetector` or
             :class:`~phenotypic.ImagePipeline` instances to combine.
             Pipelines allow preprocessing steps before detection. Defaults
             to ``[OtsuDetector(), RoundPeaksDetector()]`` when not
@@ -64,7 +64,7 @@ class CompositeDetector(ObjectDetector):
         colony mask and ``objmap`` derived from the merged mask.
 
     Raises:
-        ValueError: If ``detectors`` is empty or ``mode`` is not one of
+        ValueError: If ``ops`` is empty or ``mode`` is not one of
             ``'union'``, ``'intersection'``, or ``'overlap'``.
 
     See Also:
@@ -83,18 +83,18 @@ class CompositeDetector(ObjectDetector):
     # ``| None`` permits an empty list slot: the GUI builder marks an
     # unfilled detector slot in an in-progress pipeline with ``None``
     # (pre-migration the un-validated list accepted these implicitly).
-    detectors: List[OperationField | None] = Field(
+    ops: List[OperationField | None] = Field(
         default_factory=lambda: [OtsuDetector(), RoundPeaksDetector()]
     )
     mode: Literal['union', 'intersection', 'overlap'] = 'overlap'
     min_overlap_ratio: Annotated[float, TuneSpec(0.0, 0.5)] = Field(0.0, ge=0.0, le=1.0)
 
-    @field_validator("detectors", mode="before")
+    @field_validator("ops", mode="before")
     @classmethod
-    def _default_detectors(cls, value: Any) -> Any:
+    def _default_ops(cls, value: Any) -> Any:
         """Map an explicit ``None`` onto the default detector pair.
 
-        The pre-migration ``__init__`` accepted ``detectors=None`` as the
+        The pre-migration ``__init__`` accepted ``ops=None`` as the
         "unset" sentinel and substituted ``[OtsuDetector(),
         RoundPeaksDetector()]``. The ``default_factory`` covers the
         omitted-argument case; this validator preserves the legacy
@@ -107,7 +107,7 @@ class CompositeDetector(ObjectDetector):
     def _operate(self, image: Image) -> Image:
         """Apply all detectors/pipelines and combine their objmask outputs."""
 
-        if not self.detectors:
+        if not self.ops:
             raise ValueError(
                     "At least one detector must be provided to CompositeDetector")
 
@@ -123,7 +123,7 @@ class CompositeDetector(ObjectDetector):
         # Apply all detectors/pipelines and collect masks
         objmaps = []
 
-        for detector in self.detectors:
+        for detector in self.ops:
             if detector is None:
                 # An unfilled list slot (the GUI builder marks an empty
                 # detector slot with None); nothing to apply — skip it.

--- a/src/phenotypic/enhance/CLAUDE.md
+++ b/src/phenotypic/enhance/CLAUDE.md
@@ -19,3 +19,10 @@
 - `SetDetectMode` is the only class inheriting `ImageOperation` instead of
   `ImageEnhancer` — it resets `detect_mat` rather than modifying it. Don't use
   it as a reference implementation for new enhancers.
+- `CompositeEnhance` is a **meta-enhancer**: it subclasses `ImageEnhancer`
+  directly (not a purpose-group marker), mirroring how `CompositeDetector`
+  subclasses `ObjectDetector` directly. It applies a `List[OperationField |
+  None]` of enhancers/pipelines to the same input and reduces their
+  `detect_mat` maps pixel-wise (`max`/`mean`/`min`/`median`, optional `[0,1]`
+  clip). Its produce-type depends on its children, so it has no single marker
+  ABC and is exempt from the `test_enhancer_taxonomy.py` roster.

--- a/src/phenotypic/enhance/CLAUDE.md
+++ b/src/phenotypic/enhance/CLAUDE.md
@@ -21,8 +21,9 @@
   it as a reference implementation for new enhancers.
 - `CompositeEnhance` is a **meta-enhancer**: it subclasses `ImageEnhancer`
   directly (not a purpose-group marker), mirroring how `CompositeDetector`
-  subclasses `ObjectDetector` directly. It applies a `List[OperationField |
-  None]` of enhancers/pipelines to the same input and reduces their
+  subclasses `ObjectDetector` directly. It applies its `ops` (a
+  `List[OperationField | None]` of enhancers/pipelines — same field name as
+  `CompositeDetector.ops`) to the same input and reduces their
   `detect_mat` maps pixel-wise (`max`/`mean`/`min`/`median`, optional `[0,1]`
   clip). Its produce-type depends on its children, so it has no single marker
   ABC and is exempt from the `test_enhancer_taxonomy.py` roster.

--- a/src/phenotypic/enhance/__init__.py
+++ b/src/phenotypic/enhance/__init__.py
@@ -40,6 +40,7 @@ from ._gray_opening import GrayOpening
 from ._flatten_illumination import FlattenIllumination
 from ._focus_blob_log import FocusBlobLoG
 from ._set_detect_mode import SetDetectMode
+from ._composite_enhance import CompositeEnhance
 
 __all__ = [
     "BayesShrinkEnhancer",
@@ -71,4 +72,5 @@ __all__ = [
     "WhiteTophatEnhance",
     "SubtractWhiteTophat",
     "SetDetectMode",
+    "CompositeEnhance",
 ]

--- a/src/phenotypic/enhance/_composite_enhance.py
+++ b/src/phenotypic/enhance/_composite_enhance.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Literal
+
+import numpy as np
+from pydantic import Field, field_validator
+
+if TYPE_CHECKING:
+    from phenotypic._core._image import Image
+
+from ..abc_ import ImageEnhancer
+from ..sdk_.typing_ import OperationField
+from ._gaussian_blur import GaussianBlur
+from ._median_filter import MedianFilter
+
+CombineMode = Literal["max", "mean", "min", "median"]
+
+
+class CompositeEnhance(ImageEnhancer):
+    """Enhance ``detect_mat`` by combining several enhancers' response maps pixel-wise.
+
+    Apply two or more enhancers (or preprocessing pipelines ending in an
+    enhancer) to the same plate image and reduce their ``detect_mat`` outputs
+    into a single response map. This ensembles complementary preprocessing
+    strategies: where one enhancer responds strongly to faint colonies and
+    another to sharp edges, ``'max'`` keeps the strongest signal from either.
+    It is the enhancer-side analogue of :class:`CompositeDetector`, which
+    combines binary masks rather than continuous response maps.
+
+    Each branch reads the *same* input ``detect_mat`` independently (branches
+    do not chain into one another), so the order of ``enhancers`` does not
+    affect the result for the commutative reductions used here.
+
+    Best For:
+        - Fusing complementary focus maps (e.g. an edge response and a blob
+          response) so colonies that only one branch emphasises survive.
+        - Averaging several denoisers (``'mean'`` / ``'median'``) to suppress
+          branch-specific artefacts before thresholding.
+        - Consensus preprocessing (``'min'``), where a pixel stays bright only
+          if every branch agrees it is signal.
+
+    Consider Also:
+        - A single :class:`ImageEnhancer` when one preprocessing step already
+          isolates colonies reliably.
+        - :class:`CompositeDetector` when you want to combine *detections*
+          (binary masks) rather than continuous enhancement maps.
+        - An :class:`ImagePipeline` of enhancers when the steps should be
+          applied *in sequence* rather than combined in parallel.
+
+    Args:
+        enhancers: List of :class:`~phenotypic.abc_.ImageEnhancer` or
+            :class:`~phenotypic.ImagePipeline` instances to combine. Pipelines
+            allow per-branch preprocessing before the response is collected.
+            Defaults to ``[GaussianBlur(), MedianFilter()]`` when not
+            specified. ``None`` entries mark unfilled GUI-builder slots and
+            are skipped.
+        mode: Pixel-wise reduction across branch response maps. ``'max'``
+            keeps the brightest response (union of complementary signals,
+            the default). ``'min'`` keeps the darkest (consensus suppression).
+            ``'mean'`` averages all branches. ``'median'`` takes the per-pixel
+            median (robust to a single outlier branch; most useful with three
+            or more enhancers). Default: ``'max'``.
+        clip: When ``True``, clamp the combined result into ``[0.0, 1.0]``
+            after reduction. Leave ``False`` (default) when ``detect_mat`` is
+            not unit-normalised, since clipping an arbitrarily-scaled map would
+            distort it.
+
+    Returns:
+        Image: Input image with ``detect_mat`` set to the combined response
+        map. ``rgb`` and ``gray`` are unchanged.
+
+    Raises:
+        ValueError: If ``enhancers`` is empty or contains only ``None`` slots.
+
+    Examples:
+        Combine two enhancers, keeping the strongest response per pixel:
+
+        >>> from phenotypic.data import load_synth_yeast_plate
+        >>> from phenotypic.enhance import (
+        ...     CompositeEnhance,
+        ...     GaussianBlur,
+        ...     SubtractRollingBall,
+        ... )
+        >>> image = load_synth_yeast_plate()
+        >>> combiner = CompositeEnhance(
+        ...     enhancers=[GaussianBlur(sigma=1.5), SubtractRollingBall()],
+        ...     mode="max",
+        ... )
+        >>> enhanced = combiner.apply(image)
+        >>> bool((image.gray[:] == enhanced.gray[:]).all())  # rgb/gray untouched
+        True
+
+        Average three branches and clamp the result to ``[0, 1]``:
+
+        >>> from phenotypic.enhance import MedianFilter, EnhanceLocalContrast
+        >>> combiner = CompositeEnhance(
+        ...     enhancers=[GaussianBlur(), MedianFilter(), EnhanceLocalContrast()],
+        ...     mode="mean",
+        ...     clip=True,
+        ... )
+        >>> enhanced = combiner.apply(load_synth_yeast_plate())
+        >>> float(enhanced.detect_mat[:].max()) <= 1.0
+        True
+    """
+
+    # Each branch may be an ``ImageEnhancer`` or a nested ``ImagePipeline``.
+    # ``OperationField`` keeps the concrete class of each entry across a JSON
+    # round-trip (a bare ``model_dump`` of the union would lose the subclass).
+    # ``| None`` permits an empty list slot that the GUI builder uses to mark
+    # an unfilled enhancer slot in an in-progress pipeline.
+    enhancers: List[OperationField | None] = Field(
+        default_factory=lambda: [GaussianBlur(), MedianFilter()]
+    )
+    mode: CombineMode = "max"
+    clip: bool = False
+
+    @field_validator("enhancers", mode="before")
+    @classmethod
+    def _default_enhancers(cls, value: Any) -> Any:
+        """Map an explicit ``None`` onto the default enhancer pair.
+
+        Mirrors :class:`CompositeDetector`: the ``default_factory`` covers the
+        omitted-argument case, and this validator preserves an explicit
+        ``enhancers=None`` call by substituting the default pair.
+        """
+        if value is None:
+            return [GaussianBlur(), MedianFilter()]
+        return value
+
+    def _operate(self, image: Image) -> Image:
+        """Apply each branch and reduce their ``detect_mat`` maps pixel-wise."""
+
+        # Import here to avoid a circular dependency at module load.
+        from phenotypic import ImagePipeline
+
+        response_maps: list[np.ndarray] = []
+        for enhancer in self.enhancers:
+            if enhancer is None:
+                # An unfilled GUI-builder slot; nothing to apply -- skip it.
+                continue
+            if isinstance(enhancer, ImagePipeline):
+                enhanced = enhancer.apply(image, inplace=False, reset=False)
+            else:
+                enhanced = enhancer.apply(image, inplace=False)
+            response_maps.append(np.asarray(enhanced.detect_mat[:], dtype=float))
+
+        if not response_maps:
+            raise ValueError(
+                "At least one enhancer must be provided to CompositeEnhance"
+            )
+
+        combined = self._combine(response_maps)
+
+        if self.clip:
+            combined = np.clip(combined, 0.0, 1.0)
+
+        original = image.detect_mat[:]
+        image.detect_mat[:] = combined.astype(original.dtype, copy=False)
+        return image
+
+    def _combine(self, response_maps: list[np.ndarray]) -> np.ndarray:
+        """Reduce stacked branch response maps according to ``self.mode``."""
+        if self.mode == "max":
+            return np.maximum.reduce(response_maps)
+        if self.mode == "min":
+            return np.minimum.reduce(response_maps)
+        stack = np.stack(response_maps, axis=0)
+        if self.mode == "mean":
+            return np.mean(stack, axis=0)
+        # "median"
+        return np.median(stack, axis=0)

--- a/src/phenotypic/enhance/_composite_enhance.py
+++ b/src/phenotypic/enhance/_composite_enhance.py
@@ -28,8 +28,8 @@ class CompositeEnhance(ImageEnhancer):
     combines binary masks rather than continuous response maps.
 
     Each branch reads the *same* input ``detect_mat`` independently (branches
-    do not chain into one another), so the order of ``enhancers`` does not
-    affect the result for the commutative reductions used here.
+    do not chain into one another), so the order of ``ops`` does not affect
+    the result for the commutative reductions used here.
 
     Best For:
         - Fusing complementary focus maps (e.g. an edge response and a blob

--- a/src/phenotypic/enhance/_composite_enhance.py
+++ b/src/phenotypic/enhance/_composite_enhance.py
@@ -48,7 +48,7 @@ class CompositeEnhance(ImageEnhancer):
           applied *in sequence* rather than combined in parallel.
 
     Args:
-        enhancers: List of :class:`~phenotypic.abc_.ImageEnhancer` or
+        ops: List of :class:`~phenotypic.abc_.ImageEnhancer` or
             :class:`~phenotypic.ImagePipeline` instances to combine. Pipelines
             allow per-branch preprocessing before the response is collected.
             Defaults to ``[GaussianBlur(), MedianFilter()]`` when not
@@ -70,7 +70,7 @@ class CompositeEnhance(ImageEnhancer):
         map. ``rgb`` and ``gray`` are unchanged.
 
     Raises:
-        ValueError: If ``enhancers`` is empty or contains only ``None`` slots.
+        ValueError: If ``ops`` is empty or contains only ``None`` slots.
 
     Examples:
         Combine two enhancers, keeping the strongest response per pixel:
@@ -83,7 +83,7 @@ class CompositeEnhance(ImageEnhancer):
         ... )
         >>> image = load_synth_yeast_plate()
         >>> combiner = CompositeEnhance(
-        ...     enhancers=[GaussianBlur(sigma=1.5), SubtractRollingBall()],
+        ...     ops=[GaussianBlur(sigma=1.5), SubtractRollingBall()],
         ...     mode="max",
         ... )
         >>> enhanced = combiner.apply(image)
@@ -94,7 +94,7 @@ class CompositeEnhance(ImageEnhancer):
 
         >>> from phenotypic.enhance import MedianFilter, EnhanceLocalContrast
         >>> combiner = CompositeEnhance(
-        ...     enhancers=[GaussianBlur(), MedianFilter(), EnhanceLocalContrast()],
+        ...     ops=[GaussianBlur(), MedianFilter(), EnhanceLocalContrast()],
         ...     mode="mean",
         ...     clip=True,
         ... )
@@ -108,20 +108,20 @@ class CompositeEnhance(ImageEnhancer):
     # round-trip (a bare ``model_dump`` of the union would lose the subclass).
     # ``| None`` permits an empty list slot that the GUI builder uses to mark
     # an unfilled enhancer slot in an in-progress pipeline.
-    enhancers: List[OperationField | None] = Field(
+    ops: List[OperationField | None] = Field(
         default_factory=lambda: [GaussianBlur(), MedianFilter()]
     )
     mode: CombineMode = "max"
     clip: bool = False
 
-    @field_validator("enhancers", mode="before")
+    @field_validator("ops", mode="before")
     @classmethod
-    def _default_enhancers(cls, value: Any) -> Any:
+    def _default_ops(cls, value: Any) -> Any:
         """Map an explicit ``None`` onto the default enhancer pair.
 
         Mirrors :class:`CompositeDetector`: the ``default_factory`` covers the
         omitted-argument case, and this validator preserves an explicit
-        ``enhancers=None`` call by substituting the default pair.
+        ``ops=None`` call by substituting the default pair.
         """
         if value is None:
             return [GaussianBlur(), MedianFilter()]
@@ -134,7 +134,7 @@ class CompositeEnhance(ImageEnhancer):
         from phenotypic import ImagePipeline
 
         response_maps: list[np.ndarray] = []
-        for enhancer in self.enhancers:
+        for enhancer in self.ops:
             if enhancer is None:
                 # An unfilled GUI-builder slot; nothing to apply -- skip it.
                 continue

--- a/src/phenotypic/tune/_evaluation/_builder.py
+++ b/src/phenotypic/tune/_evaluation/_builder.py
@@ -17,7 +17,7 @@ from pydantic_core import InitErrorDetails
 
 from phenotypic import ImagePipeline
 
-#: Matches a nested list-index segment ``name[i]`` (e.g. ``detectors[0]``) and
+#: Matches a nested list-index segment ``name[i]`` (e.g. ``ops[0]``) and
 #: captures the field name and the integer index. The depth cap is 1: a key may
 #: carry **exactly one** such segment (a second ``[i]`` is a depth error).
 _NESTED_SEGMENT_RE = re.compile(r"^(?P<field>[^\[\]]+)\[(?P<index>\d+)\]$")
@@ -86,7 +86,7 @@ def _parse_key(key: str, ordered_ops: list) -> ParsedKey:
     a segment matching ``name[i]`` switches the key into the nested grammar.
 
     Disambiguation and limits:
-        * A segment matching ``name[i]`` (e.g. ``detectors[0]``) marks a nested
+        * A segment matching ``name[i]`` (e.g. ``ops[0]``) marks a nested
           key; the **depth cap is 1** — a second ``[i]`` segment raises a
           "depth" ``ValueError``.
         * A malformed bracket segment (``name[x]``, ``name[]``) or a nested key
@@ -134,7 +134,7 @@ def _parse_key(key: str, ordered_ops: list) -> ParsedKey:
 
     if len(parts) == 2:
         # Guard against a malformed bracket that escaped the nested regex
-        # (e.g. ``"0.detectors[x]"``): an unmatched ``[`` is never a flat field.
+        # (e.g. ``"0.ops[x]"``): an unmatched ``[`` is never a flat field.
         if _BRACKET_SEGMENT_RE.search(parts[1]):
             raise ValueError(
                 f"combo key {key!r} has a malformed nested segment {parts[1]!r} "
@@ -321,7 +321,7 @@ def _rebuild_nested_field(
     Args:
         parent: The parent operation instance owning the list field.
         position: The parent's position in the pipeline (for key tagging).
-        field: The parent's operation-list field name (e.g. ``"detectors"``).
+        field: The parent's operation-list field name (e.g. ``"ops"``).
         slot_overrides: ``{index: {leaf_field: value}}`` for this field.
 
     Returns:

--- a/src/phenotypic/tune/_search_space/_infer.py
+++ b/src/phenotypic/tune/_search_space/_infer.py
@@ -562,8 +562,8 @@ def _reparent_key(child_key: str, prefix: str) -> str:
     ``_infer_field`` always builds keys as ``"<position>.<field>"`` with the
     position it is handed. When recursing, we infer each nested leaf field at a
     throwaway position ``0`` and then splice the real nested prefix
-    (``"1.detectors[0]"``) in front of the leaf name — so the canonical nested
-    key becomes ``"1.detectors[0].<leaf>"``.
+    (``"1.ops[0]"``) in front of the leaf name — so the canonical nested
+    key becomes ``"1.ops[0].<leaf>"``.
     """
     _, _, leaf = child_key.partition(".")
     return f"{prefix}.{leaf}"
@@ -587,7 +587,7 @@ def _recurse_into_op(
     Args:
         leaf_op: The nested operation instance to recurse into.
         prefix: The root-relative path of the nested slot (e.g.
-            ``"1.detectors[0]"``).
+            ``"1.ops[0]"``).
         factor: Multiplicative half-window for the unbounded heuristic.
         conditional_on: Parent-presence gate to stamp on each nested knob (a
             ``((key, value),)`` tuple), or ``None`` when the parent is not

--- a/src/phenotypic/tune/_search_space/_space.py
+++ b/src/phenotypic/tune/_search_space/_space.py
@@ -30,7 +30,7 @@ class Knob(BaseModel):
     Args:
         target: The structured ``KnobTarget`` identifying the parameter — a
             ``Param`` / ``Presence`` / ``Nested`` whose ``.key`` renders the
-            canonical position-index path (e.g. ``"1.detectors[0].ignore_zeros"``,
+            canonical position-index path (e.g. ``"1.ops[0].ignore_zeros"``,
             where the ``N.`` prefix is the operation's pipeline position). A
             legacy string ``key="0.sigma"`` is still accepted and coerced to a
             target (string-preserving round-trip), so older call sites and frozen

--- a/tests/e2e/gui/builder/test_list_aux.py
+++ b/tests/e2e/gui/builder/test_list_aux.py
@@ -106,7 +106,7 @@ def _publish_edge_event(page: Page, payload: dict) -> None:
 def _has_consumer_with_list_aux(page: Page) -> bool:
     """Return True iff the registry exposes a consumer with a list-aux param.
 
-    Spec §8.3.3 exercises ``CompositeDetector.detectors`` which is
+    Spec §8.3.3 exercises ``CompositeDetector.ops`` which is
     declared with ``List[Detector]``.  The class is registered in the
     fake-sandbox registry only when ``CompositeDetector`` is bundled in
     the build — if not, list-aux fan-in tests skip.
@@ -131,7 +131,7 @@ def _has_consumer_with_list_aux(page: Page) -> bool:
 
 
 def test_list_aux_fan_in_appends_to_next_slot(page: Page, hub_url: str) -> None:
-    """Wire 3 detectors into ``CompositeDetector.detectors``; slots = 1/2/3.
+    """Wire 3 detectors into ``CompositeDetector.ops``; slots = 1/2/3.
 
     The server-side dispatcher resolves slots from
     ``block.list_slot_counts`` — the client never emits a slot index

--- a/tests/fixtures/builder_dag/list_aux_three_detectors.json
+++ b/tests/fixtures/builder_dag/list_aux_three_detectors.json
@@ -17,7 +17,7 @@
         "label": "CompositeDetector",
         "nested": null,
         "collapsed": false,
-        "list_slot_counts": {"detectors": 3}
+        "list_slot_counts": {"ops": 3}
       },
       {
         "block_id": "00000000000000000000000000000022",
@@ -98,7 +98,7 @@
         "source_block_id": "00000000000000000000000000000022",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000021",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 0,
         "kind": "aux"
       },
@@ -107,7 +107,7 @@
         "source_block_id": "00000000000000000000000000000023",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000021",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 1,
         "kind": "aux"
       },
@@ -116,7 +116,7 @@
         "source_block_id": "00000000000000000000000000000026",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000021",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 2,
         "kind": "aux"
       }

--- a/tests/fixtures/builder_dag/list_aux_with_empty_slot.json
+++ b/tests/fixtures/builder_dag/list_aux_with_empty_slot.json
@@ -17,7 +17,7 @@
         "label": "CompositeDetector",
         "nested": null,
         "collapsed": false,
-        "list_slot_counts": {"detectors": 3}
+        "list_slot_counts": {"ops": 3}
       },
       {
         "block_id": "00000000000000000000000000000032",
@@ -53,7 +53,7 @@
         "source_block_id": "00000000000000000000000000000032",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000031",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 0,
         "kind": "aux"
       },
@@ -62,7 +62,7 @@
         "source_block_id": "00000000000000000000000000000033",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000031",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 2,
         "kind": "aux"
       }

--- a/tests/fixtures/builder_dag/nested_container.json
+++ b/tests/fixtures/builder_dag/nested_container.json
@@ -17,7 +17,7 @@
         "label": "Outer",
         "nested": null,
         "collapsed": false,
-        "list_slot_counts": {"detectors": 1}
+        "list_slot_counts": {"ops": 1}
       },
       {
         "block_id": "00000000000000000000000000000042",
@@ -42,7 +42,7 @@
               "label": "InnerComposite",
               "nested": null,
               "collapsed": false,
-              "list_slot_counts": {"detectors": 1}
+              "list_slot_counts": {"ops": 1}
             },
             {
               "block_id": "00000000000000000000000000000045",
@@ -105,7 +105,7 @@
               "source_block_id": "00000000000000000000000000000045",
               "source_port": "out",
               "target_block_id": "00000000000000000000000000000044",
-              "target_port": "detectors",
+              "target_port": "ops",
               "target_slot": 0,
               "kind": "aux"
             }
@@ -134,7 +134,7 @@
         "source_block_id": "00000000000000000000000000000042",
         "source_port": "out",
         "target_block_id": "00000000000000000000000000000041",
-        "target_port": "detectors",
+        "target_port": "ops",
         "target_slot": 0,
         "kind": "aux"
       }

--- a/tests/gui/builder/test_aux_port_e2e.py
+++ b/tests/gui/builder/test_aux_port_e2e.py
@@ -635,7 +635,7 @@ def test_disconnect_drops_aux(page: Page) -> None:
 def test_list_port_shows_multiple_slots(page: Page) -> None:
     """List-typed aux ports surface slot rows + an ``+ Add slot`` button.
 
-    ``CompositeDetector.detectors`` is a list-typed op param. The
+    ``CompositeDetector.ops`` is a list-typed op param. The
     popover should render one ``.cy-popover-slot-row`` per slot
     (including the empty defaults, if any) plus the
     ``.cy-popover-add-slot`` button at the bottom.
@@ -643,7 +643,7 @@ def test_list_port_shows_multiple_slots(page: Page) -> None:
     _add_op(page, "CompositeDetector")
     _wait_for_aux_port_count(page, 1)
     consumer_id = _first_consumer_node_id(page)
-    _click_aux_port(page, consumer_id, "detectors")
+    _click_aux_port(page, consumer_id, "ops")
     _wait_for_popover_visible(page)
 
     # Either slot rows OR a "no slots yet" placeholder + add button

--- a/tests/gui/builder/test_aux_ports.py
+++ b/tests/gui/builder/test_aux_ports.py
@@ -192,7 +192,7 @@ def test_wire_create_rejects_type_incompatible_class(app_ctx: Any) -> None:
 def test_wire_create_grows_slot_list_for_list_typed(app_ctx: Any) -> None:
     """For list-typed ports, wiring at an unallocated slot extends the list.
 
-    ``CompositeDetector.detectors`` is list-typed; wiring at slot 2 on
+    ``CompositeDetector.ops`` is list-typed; wiring at slot 2 on
     an empty consumer must pad slots 0 and 1 with ``None`` placeholders
     so the resulting list has length 3 with only slot 2 occupied.
     """
@@ -203,14 +203,14 @@ def test_wire_create_grows_slot_list_for_list_typed(app_ctx: Any) -> None:
         "wire_create",
         {
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 2,
             "class_name": "OtsuDetector",
         },
     )
 
     composite = out["root"]["nodes"][0]
-    slots = composite["aux_ports"]["detectors"]
+    slots = composite["aux_ports"]["ops"]
     assert len(slots) == 3
     assert slots[0] is None
     assert slots[1] is None
@@ -275,7 +275,7 @@ def test_wire_delete_other_slot_preserves_focus(app_ctx: Any) -> None:
         "wire_create",
         {
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 0,
             "class_name": "OtsuDetector",
         },
@@ -286,7 +286,7 @@ def test_wire_delete_other_slot_preserves_focus(app_ctx: Any) -> None:
         "wire_create",
         {
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 1,
             "class_name": "RoundPeaksDetector",
         },
@@ -299,7 +299,7 @@ def test_wire_delete_other_slot_preserves_focus(app_ctx: Any) -> None:
         {
             "focus": "aux",
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 0,
         },
     )
@@ -310,20 +310,20 @@ def test_wire_delete_other_slot_preserves_focus(app_ctx: Any) -> None:
         "wire_delete",
         {
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 1,
         },
     )
 
     composite = out["root"]["nodes"][0]
-    slots = composite["aux_ports"]["detectors"]
+    slots = composite["aux_ports"]["ops"]
     # Slot 0 still wired; slot 1 cleared.
     assert isinstance(slots[0], dict)
     assert slots[1] is None
     # Focus on slot 0 preserved.
     assert out["inspector_focus_aux"] == {
         "target_node_id": "composite",
-        "param": "detectors",
+        "param": "ops",
         "slot": 0,
     }
 
@@ -344,17 +344,17 @@ def test_port_slot_add_appends_none(app_ctx: Any) -> None:
     out = _dispatch(
         state,
         "port_slot_add",
-        {"node_id": "composite", "param": "detectors"},
+        {"node_id": "composite", "param": "ops"},
     )
-    assert out["root"]["nodes"][0]["aux_ports"]["detectors"] == [None]
+    assert out["root"]["nodes"][0]["aux_ports"]["ops"] == [None]
 
     # Adding twice grows to two placeholders.
     out = _dispatch(
         out,
         "port_slot_add",
-        {"node_id": "composite", "param": "detectors"},
+        {"node_id": "composite", "param": "ops"},
     )
-    assert out["root"]["nodes"][0]["aux_ports"]["detectors"] == [None, None]
+    assert out["root"]["nodes"][0]["aux_ports"]["ops"] == [None, None]
 
 
 def test_port_slot_remove_pops(app_ctx: Any) -> None:
@@ -373,22 +373,22 @@ def test_port_slot_remove_pops(app_ctx: Any) -> None:
             "wire_create",
             {
                 "target_node_id": "composite",
-                "param": "detectors",
+                "param": "ops",
                 "slot": slot,
                 "class_name": "OtsuDetector",
             },
         )
-    pre_slots = state["root"]["nodes"][0]["aux_ports"]["detectors"]
+    pre_slots = state["root"]["nodes"][0]["aux_ports"]["ops"]
     slot0_id = pre_slots[0]["node_id"]
     slot2_id = pre_slots[2]["node_id"]
 
     out = _dispatch(
         state,
         "port_slot_remove",
-        {"node_id": "composite", "param": "detectors", "slot": 1},
+        {"node_id": "composite", "param": "ops", "slot": 1},
     )
 
-    remaining = out["root"]["nodes"][0]["aux_ports"]["detectors"]
+    remaining = out["root"]["nodes"][0]["aux_ports"]["ops"]
     assert len(remaining) == 2
     assert remaining[0]["node_id"] == slot0_id
     assert remaining[1]["node_id"] == slot2_id
@@ -552,9 +552,9 @@ def test_set_inspector_focus_aux_rejects_empty_slot(app_ctx: Any) -> None:
     state = _dispatch(
         state,
         "port_slot_add",
-        {"node_id": "composite", "param": "detectors"},
+        {"node_id": "composite", "param": "ops"},
     )
-    assert state["root"]["nodes"][0]["aux_ports"]["detectors"] == [None]
+    assert state["root"]["nodes"][0]["aux_ports"]["ops"] == [None]
     # Stash a sentinel focus value so we can prove it survives the
     # rejected dispatch.
     state["inspector_focus_aux"] = {"sentinel": True}
@@ -565,7 +565,7 @@ def test_set_inspector_focus_aux_rejects_empty_slot(app_ctx: Any) -> None:
         {
             "focus": "aux",
             "target_node_id": "composite",
-            "param": "detectors",
+            "param": "ops",
             "slot": 0,
         },
     )

--- a/tests/gui/builder/test_state_roundtrip.py
+++ b/tests/gui/builder/test_state_roundtrip.py
@@ -383,7 +383,7 @@ def test_composite_detector_extracts_two_embedded_aux_nodes() -> None:
         OtsuDetector(ignore_zeros=True, ignore_borders=False),
         RoundPeaksDetector(),
     ]
-    composite = CompositeDetector(detectors=detectors, mode="union")
+    composite = CompositeDetector(ops=detectors, mode="union")
     pipeline = ImagePipeline(ops=[composite], name="composite_demo", desc="")
 
     rebuilt_scope = from_pipeline(pipeline)
@@ -392,9 +392,9 @@ def test_composite_detector_extracts_two_embedded_aux_nodes() -> None:
     assert consumer.class_name == "CompositeDetector"
 
     # Embedded-aux representation: detectors are extracted inline.
-    assert "detectors" not in consumer.params
-    assert "detectors" in consumer.aux_ports
-    slots = consumer.aux_ports["detectors"]
+    assert "ops" not in consumer.params
+    assert "ops" in consumer.aux_ports
+    slots = consumer.aux_ports["ops"]
     assert len(slots) == 2
     assert all(s is not None for s in slots)
     assert all(isinstance(s, StepNode) for s in slots)
@@ -417,7 +417,7 @@ def test_composite_detector_extracts_two_embedded_aux_nodes() -> None:
 def test_composite_detector_with_mixed_wired_and_empty_slots() -> None:
     """List-typed aux with one empty slot drops the empty on serialization.
 
-    The runtime ``CompositeDetector.detectors`` cannot represent an empty
+    The runtime ``CompositeDetector.ops`` cannot represent an empty
     slot — it just gets a 2-element list when 2 of 3 slots are wired.  On
     ``from_pipeline``, the reconstructed scope has 2 slots (not 3): the
     original empty slot does not survive a round-trip through
@@ -437,7 +437,7 @@ def test_composite_detector_with_mixed_wired_and_empty_slots() -> None:
                         label="CompositeDetector",
                         aux_ports={
                             # 3 slots: wired, empty, wired.
-                            "detectors": [otsu_aux, None, round_peaks_aux],
+                            "ops": [otsu_aux, None, round_peaks_aux],
                         },
                 ),
             ],
@@ -448,16 +448,16 @@ def test_composite_detector_with_mixed_wired_and_empty_slots() -> None:
     pipeline = to_pipeline(scope)
     composite = next(iter(pipeline.get_ops().values()))
     # The empty slot is dropped: runtime detectors is 2-element.
-    assert hasattr(composite, "detectors")
-    assert len(composite.detectors) == 2
-    assert type(composite.detectors[0]).__name__ == "OtsuDetector"
-    assert type(composite.detectors[1]).__name__ == "RoundPeaksDetector"
+    assert hasattr(composite, "ops")
+    assert len(composite.ops) == 2
+    assert type(composite.ops[0]).__name__ == "OtsuDetector"
+    assert type(composite.ops[1]).__name__ == "RoundPeaksDetector"
 
     # Round-trip back: the empty slot is gone.
     rebuilt_scope = from_pipeline(pipeline)
     assert len(rebuilt_scope.nodes) == 1
     consumer = rebuilt_scope.nodes[0]
-    slots = consumer.aux_ports["detectors"]
+    slots = consumer.aux_ports["ops"]
     assert len(slots) == 2  # ← the original 3 with one None becomes 2
     assert slots[0] is not None and slots[0].class_name == "OtsuDetector"
     assert slots[1] is not None and slots[1].class_name == "RoundPeaksDetector"

--- a/tests/integration/gui/builder/test_inspector_aux_section.py
+++ b/tests/integration/gui/builder/test_inspector_aux_section.py
@@ -228,13 +228,13 @@ def test_list_aux_row_renders_ordered_slots_with_remove_and_arrows() -> None:
         block_id=_new_block_id(),
         class_name="CompositeDetector",
         params={},
-        list_slot_counts={"detectors": 3},  # Two wired + one empty
+        list_slot_counts={"ops": 3},  # Two wired + one empty
     )
     edge_a = Edge(
         edge_id="ea",
         source_block_id=a.block_id,
         target_block_id=consumer.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=0,
         kind="aux",
     )
@@ -242,7 +242,7 @@ def test_list_aux_row_renders_ordered_slots_with_remove_and_arrows() -> None:
         edge_id="eb",
         source_block_id=b.block_id,
         target_block_id=consumer.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=1,
         kind="aux",
     )
@@ -254,8 +254,8 @@ def test_list_aux_row_renders_ordered_slots_with_remove_and_arrows() -> None:
             "CompositeDetector": _make_op_info(
                 "CompositeDetector",
                 {
-                    "detectors": _make_param(
-                        "detectors",
+                    "ops": _make_param(
+                        "ops",
                         is_operation=True,
                         is_list=True,
                         has_default=False,
@@ -278,7 +278,7 @@ def test_list_aux_row_renders_ordered_slots_with_remove_and_arrows() -> None:
     assert _find_by_id(section, ids.inspector_list_remove_id("eb"))
     # + Add empty slot button keyed by (block_id, param)
     add_btn_id = ids.inspector_add_empty_slot_id(
-        consumer.block_id, "detectors"
+        consumer.block_id, "ops"
     )
     assert _find_by_id(section, add_btn_id)
     # Up/down arrow buttons present for each row (pattern-match family).
@@ -300,13 +300,13 @@ def test_list_aux_row_includes_drag_handle_placeholder() -> None:
         block_id=_new_block_id(),
         class_name="CompositeDetector",
         params={},
-        list_slot_counts={"detectors": 1},
+        list_slot_counts={"ops": 1},
     )
     edge = Edge(
         edge_id="e",
         source_block_id=a.block_id,
         target_block_id=consumer.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=0,
         kind="aux",
     )
@@ -316,8 +316,8 @@ def test_list_aux_row_includes_drag_handle_placeholder() -> None:
             "CompositeDetector": _make_op_info(
                 "CompositeDetector",
                 {
-                    "detectors": _make_param(
-                        "detectors",
+                    "ops": _make_param(
+                        "ops",
                         is_operation=True,
                         is_list=True,
                         has_default=True,  # optional
@@ -353,13 +353,13 @@ def test_list_aux_row_emits_reorder_store_per_param() -> None:
         block_id=_new_block_id(),
         class_name="CompositeDetector",
         params={},
-        list_slot_counts={"detectors": 1},
+        list_slot_counts={"ops": 1},
     )
     edge = Edge(
         edge_id="e",
         source_block_id=a.block_id,
         target_block_id=consumer.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=0,
         kind="aux",
     )
@@ -369,8 +369,8 @@ def test_list_aux_row_emits_reorder_store_per_param() -> None:
             "CompositeDetector": _make_op_info(
                 "CompositeDetector",
                 {
-                    "detectors": _make_param(
-                        "detectors",
+                    "ops": _make_param(
+                        "ops",
                         is_operation=True,
                         is_list=True,
                     )
@@ -383,7 +383,7 @@ def test_list_aux_row_emits_reorder_store_per_param() -> None:
     )
     assert section is not None
     store_id = ids.inspector_list_reorder_store_id(
-        consumer.block_id, "detectors"
+        consumer.block_id, "ops"
     )
     stores = _find_by_id(section, store_id)
     assert len(stores) == 1
@@ -404,13 +404,13 @@ def test_aux_section_renders_inside_full_inspector() -> None:
         block_id=_new_block_id(),
         class_name="CompositeDetector",
         params={},
-        list_slot_counts={"detectors": 2},
+        list_slot_counts={"ops": 2},
     )
     edge = Edge(
         edge_id="e1",
         source_block_id=source.block_id,
         target_block_id=target.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=0,
         kind="aux",
     )
@@ -423,8 +423,8 @@ def test_aux_section_renders_inside_full_inspector() -> None:
             "CompositeDetector": _make_op_info(
                 "CompositeDetector",
                 {
-                    "detectors": _make_param(
-                        "detectors",
+                    "ops": _make_param(
+                        "ops",
                         is_operation=True,
                         is_list=True,
                         has_default=False,

--- a/tests/integration/gui/builder/test_inspector_wire_card.py
+++ b/tests/integration/gui/builder/test_inspector_wire_card.py
@@ -124,13 +124,13 @@ def test_wire_card_aux_edge_renders_param_name_and_slot() -> None:
         block_id=_new_block_id(),
         class_name="CompositeDetector",
         params={},
-        list_slot_counts={"detectors": 2},
+        list_slot_counts={"ops": 2},
     )
     edge = Edge(
         edge_id="aux1",
         source_block_id=src.block_id,
         target_block_id=tgt.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=1,
         kind="aux",
     )
@@ -138,7 +138,7 @@ def test_wire_card_aux_edge_renders_param_name_and_slot() -> None:
 
     card = _build_wire_card(scope, edge)
     text = _collect_text(card)
-    assert "detectors[1]" in text
+    assert "ops[1]" in text
     assert "aux assignment" in text
 
 
@@ -234,7 +234,7 @@ def test_wire_card_id_present_for_every_kind() -> None:
         edge_id="e2",
         source_block_id=src.block_id,
         target_block_id=tgt.block_id,
-        target_port="detectors",
+        target_port="ops",
         target_slot=0,
         kind="aux",
     )

--- a/tests/smoke/test_serialization.py
+++ b/tests/smoke/test_serialization.py
@@ -376,9 +376,9 @@ def test_operation_from_json_measurement_via_image_op_raises():
 @pytest.mark.smoke
 @timeit
 def test_nested_op_to_json_from_json_roundtrip():
-    """A nested ``OperationField`` (CompositeDetector.detectors) round-trips."""
+    """A nested ``OperationField`` (CompositeDetector.ops) round-trips."""
     composite = CompositeDetector(
-            detectors=[OtsuDetector(ignore_zeros=True), TriangleDetector()],
+            ops=[OtsuDetector(ignore_zeros=True), TriangleDetector()],
     )
     with tempfile.TemporaryDirectory() as tmpdir:
         filepath = Path(tmpdir) / "composite.json"
@@ -389,7 +389,7 @@ def test_nested_op_to_json_from_json_roundtrip():
 
         loaded = CompositeDetector.from_json(typed_filepath)
         assert isinstance(loaded, CompositeDetector)
-        assert len(loaded.detectors) == 2
-        assert isinstance(loaded.detectors[0], OtsuDetector)
-        assert loaded.detectors[0].ignore_zeros is True
-        assert isinstance(loaded.detectors[1], TriangleDetector)
+        assert len(loaded.ops) == 2
+        assert isinstance(loaded.ops[0], OtsuDetector)
+        assert loaded.ops[0].ignore_zeros is True
+        assert isinstance(loaded.ops[1], TriangleDetector)

--- a/tests/unit/core/test_pipeline_serialization.py
+++ b/tests/unit/core/test_pipeline_serialization.py
@@ -548,7 +548,7 @@ class TestPreMigrationBackwardCompat:
                     "params": {
                         "mode"             : "union",
                         "min_overlap_ratio": 0.0,
-                        "detectors"        : {
+                        "ops"        : {
                             "__type__": "operation_list",
                             "items"   : [
                                 {
@@ -571,11 +571,11 @@ class TestPreMigrationBackwardCompat:
         composite = loaded._ops["CompositeDetector"]
         assert isinstance(composite, CompositeDetector)
         assert composite.mode == "union"
-        assert len(composite.detectors) == 2
-        assert type(composite.detectors[0]).__name__ == "OtsuDetector"
-        assert composite.detectors[0].ignore_zeros is True
-        assert type(composite.detectors[1]).__name__ == "CannyDetector"
-        assert composite.detectors[1].sigma == 2
+        assert len(composite.ops) == 2
+        assert type(composite.ops[0]).__name__ == "OtsuDetector"
+        assert composite.ops[0].ignore_zeros is True
+        assert type(composite.ops[1]).__name__ == "CannyDetector"
+        assert composite.ops[1].sigma == 2
 
 
 class TestErrorHandling:

--- a/tests/unit/core/test_pipeline_serialization.py
+++ b/tests/unit/core/test_pipeline_serialization.py
@@ -530,10 +530,13 @@ class TestPreMigrationBackwardCompat:
     def test_loads_pre_migration_legacy_nested_operation_list(self):
         """Legacy ``__type__: operation_list`` nesting still reconstructs.
 
-        Before the migration a ``CompositeDetector`` serialized its
-        ``detectors`` field with the hand-rolled ``operation_list`` marker.
-        ``_deserialize_value`` must translate that legacy marker into live
-        operations so old composite pipelines load.
+        The hand-rolled ``operation_list`` marker (used before nested ops
+        moved to ``OperationField``) must still be translated into live
+        operations by ``_deserialize_value`` so old composite pipelines load.
+        This pins the *marker* translation under the current field name
+        ``ops``; the legacy ``detectors`` *field name* is a hard break, pinned
+        separately by
+        ``test_pre_migration_detectors_field_name_is_rejected``.
         """
         from phenotypic.detect import CompositeDetector
 
@@ -576,6 +579,42 @@ class TestPreMigrationBackwardCompat:
         assert composite.ops[0].ignore_zeros is True
         assert type(composite.ops[1]).__name__ == "CannyDetector"
         assert composite.ops[1].sigma == 2
+
+    def test_pre_migration_detectors_field_name_is_rejected(self):
+        """The renamed ``detectors``→``ops`` field is a hard break (no alias).
+
+        A pipeline saved before the rename keyed the composite's nested ops
+        under ``detectors``. ``BaseOperation`` sets ``extra="forbid"``, so such
+        a document no longer loads -- it raises ``ValidationError`` rather than
+        silently dropping the legacy ops. This pins the intentional breaking
+        change so a future accidental alias/leniency is caught.
+        """
+        from pydantic import ValidationError
+
+        old_json = json.dumps({
+            "version"  : "0.13.0",
+            "name"     : "legacy_composite",
+            "desc"     : None,
+            "reset"    : False,
+            "pipe_cfgs": {
+                "CompositeDetector": {
+                    "class" : "CompositeDetector",
+                    "params": {
+                        "mode"     : "union",
+                        "detectors": {
+                            "__type__": "operation_list",
+                            "items"   : [
+                                {"class": "OtsuDetector", "params": {}},
+                            ],
+                        },
+                    },
+                },
+            },
+            "meas"     : {},
+        })
+
+        with pytest.raises(ValidationError):
+            ImagePipeline.from_json(old_json)
 
 
 class TestErrorHandling:

--- a/tests/unit/detect/test_composite_detector.py
+++ b/tests/unit/detect/test_composite_detector.py
@@ -32,7 +32,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[OtsuDetector(), CannyDetector(sigma=2)],
+                ops=[OtsuDetector(), CannyDetector(sigma=2)],
                 mode='union'
         )
         result = composite.apply(image)
@@ -50,7 +50,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[OtsuDetector(), CannyDetector(sigma=2)],
+                ops=[OtsuDetector(), CannyDetector(sigma=2)],
                 mode='intersection'
         )
         result = composite.apply(image)
@@ -67,7 +67,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[OtsuDetector(), CannyDetector(sigma=2)],
+                ops=[OtsuDetector(), CannyDetector(sigma=2)],
                 mode='overlap',
                 min_overlap_ratio=0.7
         )
@@ -85,7 +85,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[OtsuDetector()],
+                ops=[OtsuDetector()],
                 mode='union'
         )
         result = composite.apply(image)
@@ -100,7 +100,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(),
                     CannyDetector(sigma=2),
                     TriangleDetector()
@@ -116,7 +116,7 @@ class TestCompositeDetector:
     def test_empty_detectors_raises(self, synth_plate):
         """Test that empty detectors list raises an error."""
         with pytest.raises(Exception, match="At least one detector"):
-            CompositeDetector(detectors=[]).apply(synth_plate.copy())
+            CompositeDetector(ops=[]).apply(synth_plate.copy())
 
     def test_invalid_mode_raises(self, synth_plate):
         """Test that an invalid mode is rejected at construction.
@@ -130,7 +130,7 @@ class TestCompositeDetector:
 
         with pytest.raises(ValidationError):
             CompositeDetector(
-                    detectors=[OtsuDetector()],
+                    ops=[OtsuDetector()],
                     mode='invalid'
             )
 
@@ -138,7 +138,7 @@ class TestCompositeDetector:
         """Test that CompositeDetector serializes and deserializes correctly."""
         # Create composite detector with nested detectors
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(ignore_zeros=True),
                     CannyDetector(sigma=2)
                 ],
@@ -158,14 +158,14 @@ class TestCompositeDetector:
         assert len(restored_pipeline._ops) == 1
         restored_composite = list(restored_pipeline._ops.values())[0]
         assert isinstance(restored_composite, CompositeDetector)
-        assert len(restored_composite.detectors) == 2
-        assert isinstance(restored_composite.detectors[0], OtsuDetector)
-        assert isinstance(restored_composite.detectors[1], CannyDetector)
+        assert len(restored_composite.ops) == 2
+        assert isinstance(restored_composite.ops[0], OtsuDetector)
+        assert isinstance(restored_composite.ops[1], CannyDetector)
         assert restored_composite.mode == 'union'
 
         # Verify parameters preserved
-        assert restored_composite.detectors[0].ignore_zeros is True
-        assert restored_composite.detectors[1].sigma == 2
+        assert restored_composite.ops[0].ignore_zeros is True
+        assert restored_composite.ops[1].sigma == 2
 
     def test_serialization_functional_equivalence(self, synth_plate):
         """Test that serialized/deserialized CompositeDetector produces identical results."""
@@ -173,7 +173,7 @@ class TestCompositeDetector:
 
         # Original detector
         composite = CompositeDetector(
-                detectors=[OtsuDetector(), CannyDetector(sigma=2)],
+                ops=[OtsuDetector(), CannyDetector(sigma=2)],
                 mode='intersection'
         )
         original_result = composite.apply(image, inplace=False)
@@ -209,7 +209,7 @@ class TestCompositeDetector:
 
         # Conservative overlap (high ratio)
         conservative = CompositeDetector(
-                detectors=[
+                ops=[
                     StaticMaskDetector(key="large"),
                     StaticMaskDetector(key="small"),
                 ],
@@ -220,7 +220,7 @@ class TestCompositeDetector:
 
         # Permissive overlap (low ratio)
         permissive = CompositeDetector(
-                detectors=[
+                ops=[
                     StaticMaskDetector(key="large"),
                     StaticMaskDetector(key="small"),
                 ],
@@ -244,7 +244,7 @@ class TestCompositeDetector:
         image = Image(arr=np.zeros((8, 8), dtype=np.uint8))
 
         permissive = CompositeDetector(
-                detectors=[
+                ops=[
                     StaticMaskDetector(key="large"),
                     StaticMaskDetector(key="small"),
                 ],
@@ -253,7 +253,7 @@ class TestCompositeDetector:
         ).apply(image)
 
         strict = CompositeDetector(
-                detectors=[
+                ops=[
                     StaticMaskDetector(key="large"),
                     StaticMaskDetector(key="small"),
                 ],
@@ -272,7 +272,7 @@ class TestCompositeDetector:
         import json
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(ignore_zeros=True),
                     CannyDetector(sigma=2)
                 ],
@@ -292,8 +292,8 @@ class TestCompositeDetector:
         # Verify nested detectors are serialized. Under the pydantic
         # serializer each ``OperationField`` entry is a plain
         # ``{"class", "params"}`` dict, so ``detectors`` is a JSON list.
-        assert 'detectors' in composite_data['params']
-        detectors_data = composite_data['params']['detectors']
+        assert 'ops' in composite_data['params']
+        detectors_data = composite_data['params']['ops']
         assert isinstance(detectors_data, list)
         assert len(detectors_data) == 2
 
@@ -321,7 +321,7 @@ class TestCompositeDetector:
         pipeline = ImagePipeline(ops=[
             GaussianBlur(sigma=2),
             CompositeDetector(
-                    detectors=[OtsuDetector(), CannyDetector(sigma=2)],
+                    ops=[OtsuDetector(), CannyDetector(sigma=2)],
                     mode='union'
             ),
             SmallObjectRemover(min_size=50)
@@ -359,7 +359,7 @@ class TestCompositeDetector:
         ])
 
         composite = CompositeDetector(
-                detectors=[pipeline],
+                ops=[pipeline],
                 mode='union'
         )
         result = composite.apply(image)
@@ -374,7 +374,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(),  # Direct detector
                     ImagePipeline(ops=[  # Pipeline
                         GaussianBlur(sigma=2),
@@ -394,7 +394,7 @@ class TestCompositeDetector:
         from phenotypic.enhance import GaussianBlur
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(),
                     ImagePipeline(ops=[
                         GaussianBlur(sigma=2),
@@ -412,12 +412,12 @@ class TestCompositeDetector:
         restored_composite = list(restored._ops.values())[0]
 
         # Verify structure
-        assert len(restored_composite.detectors) == 2
-        assert isinstance(restored_composite.detectors[0], OtsuDetector)
-        assert isinstance(restored_composite.detectors[1], ImagePipeline)
+        assert len(restored_composite.ops) == 2
+        assert isinstance(restored_composite.ops[0], OtsuDetector)
+        assert isinstance(restored_composite.ops[1], ImagePipeline)
 
         # Verify nested pipeline structure
-        nested_pipeline = restored_composite.detectors[1]
+        nested_pipeline = restored_composite.ops[1]
         assert len(nested_pipeline._ops) == 2
 
     def test_pipeline_functional_equivalence(self, synth_plate):
@@ -427,7 +427,7 @@ class TestCompositeDetector:
         image = synth_plate.copy()
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(),
                     ImagePipeline(ops=[
                         GaussianBlur(sigma=2),
@@ -458,7 +458,7 @@ class TestCompositeDetector:
         import json
 
         composite = CompositeDetector(
-                detectors=[
+                ops=[
                     OtsuDetector(),
                     ImagePipeline(ops=[
                         GaussianBlur(sigma=2),
@@ -481,7 +481,7 @@ class TestCompositeDetector:
         # each entry to a class-tagged dict; an ``ObjectDetector`` entry is
         # ``{"class", "params"}`` and a nested ``ImagePipeline`` entry is
         # ``{"__type__": "pipeline", "config": ...}``.
-        detectors_data = composite_data['params']['detectors']
+        detectors_data = composite_data['params']['ops']
         assert isinstance(detectors_data, list)
         assert len(detectors_data) == 2
 

--- a/tests/unit/enhance/test_composite_enhance.py
+++ b/tests/unit/enhance/test_composite_enhance.py
@@ -36,22 +36,22 @@ def _branches() -> list[_SetPlane]:
 class TestCombinationModes:
     def test_max_is_default(self):
         image, *_ = _three_branch_image()
-        result = CompositeEnhance(enhancers=_branches()).apply(image)
+        result = CompositeEnhance(ops=_branches()).apply(image)
         assert np.allclose(result.detect_mat[:], 0.6)
 
     def test_min(self):
         image, *_ = _three_branch_image()
-        result = CompositeEnhance(enhancers=_branches(), mode="min").apply(image)
+        result = CompositeEnhance(ops=_branches(), mode="min").apply(image)
         assert np.allclose(result.detect_mat[:], 0.2)
 
     def test_mean(self):
         image, *_ = _three_branch_image()
-        result = CompositeEnhance(enhancers=_branches(), mode="mean").apply(image)
+        result = CompositeEnhance(ops=_branches(), mode="mean").apply(image)
         assert np.allclose(result.detect_mat[:], (0.2 + 0.6 + 0.4) / 3)
 
     def test_median(self):
         image, *_ = _three_branch_image()
-        result = CompositeEnhance(enhancers=_branches(), mode="median").apply(image)
+        result = CompositeEnhance(ops=_branches(), mode="median").apply(image)
         assert np.allclose(result.detect_mat[:], 0.4)
 
 
@@ -59,14 +59,14 @@ class TestClipping:
     def test_clip_off_by_default_allows_out_of_range(self):
         image = Image(arr=np.zeros((8, 8), dtype=float))
         result = CompositeEnhance(
-            enhancers=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
+            ops=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
         ).apply(image)
         assert result.detect_mat[:].max() > 1.0
 
     def test_clip_clamps_to_unit_interval(self):
         image = Image(arr=np.zeros((8, 8), dtype=float))
         result = CompositeEnhance(
-            enhancers=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
+            ops=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
             mode="min",
             clip=True,
         ).apply(image)
@@ -79,26 +79,26 @@ class TestBranchTypes:
         image, *_ = _three_branch_image()
         pipe = ImagePipeline(pipe_cfgs=[_SetPlane(value=0.6)])
         result = CompositeEnhance(
-            enhancers=[_SetPlane(value=0.2), pipe],
+            ops=[_SetPlane(value=0.2), pipe],
         ).apply(image)
         assert np.allclose(result.detect_mat[:], 0.6)
 
     def test_none_slot_is_skipped(self):
         image, *_ = _three_branch_image()
         result = CompositeEnhance(
-            enhancers=[_SetPlane(value=0.2), None, _SetPlane(value=0.6)],
+            ops=[_SetPlane(value=0.2), None, _SetPlane(value=0.6)],
         ).apply(image)
         assert np.allclose(result.detect_mat[:], 0.6)
 
     def test_empty_enhancers_raises(self):
         image = Image(arr=np.zeros((8, 8), dtype=float))
         with pytest.raises(Exception, match="At least one enhancer"):
-            CompositeEnhance(enhancers=[]).apply(image)
+            CompositeEnhance(ops=[]).apply(image)
 
     def test_all_none_enhancers_raises(self):
         image = Image(arr=np.zeros((8, 8), dtype=float))
         with pytest.raises(Exception, match="At least one enhancer"):
-            CompositeEnhance(enhancers=[None, None]).apply(image)
+            CompositeEnhance(ops=[None, None]).apply(image)
 
 
 class TestIntegrityAndDefaults:
@@ -109,7 +109,7 @@ class TestIntegrityAndDefaults:
         rgb_before = image.rgb[:].copy()
         gray_before = image.gray[:].copy()
         result = CompositeEnhance(
-            enhancers=[GaussianBlur(sigma=1.0), MedianFilter()],
+            ops=[GaussianBlur(sigma=1.0), MedianFilter()],
         ).apply(image)
         assert np.array_equal(result.rgb[:], rgb_before)
         assert np.array_equal(result.gray[:], gray_before)
@@ -118,20 +118,20 @@ class TestIntegrityAndDefaults:
         op = CompositeEnhance()
         assert op.mode == "max"
         assert op.clip is False
-        assert len(op.enhancers) == 2
-        assert isinstance(op.enhancers[0], GaussianBlur)
-        assert isinstance(op.enhancers[1], MedianFilter)
+        assert len(op.ops) == 2
+        assert isinstance(op.ops[0], GaussianBlur)
+        assert isinstance(op.ops[1], MedianFilter)
 
     def test_explicit_none_enhancers_maps_to_default(self):
-        op = CompositeEnhance(enhancers=None)
-        assert isinstance(op.enhancers[0], GaussianBlur)
-        assert isinstance(op.enhancers[1], MedianFilter)
+        op = CompositeEnhance(ops=None)
+        assert isinstance(op.ops[0], GaussianBlur)
+        assert isinstance(op.ops[1], MedianFilter)
 
 
 class TestSerialization:
     def test_roundtrip_preserves_branch_subclasses_and_mode(self):
         op = CompositeEnhance(
-            enhancers=[GaussianBlur(sigma=1.5), MedianFilter()],
+            ops=[GaussianBlur(sigma=1.5), MedianFilter()],
             mode="mean",
             clip=True,
         )
@@ -139,6 +139,6 @@ class TestSerialization:
         assert isinstance(restored, CompositeEnhance)
         assert restored.mode == "mean"
         assert restored.clip is True
-        assert isinstance(restored.enhancers[0], GaussianBlur)
-        assert restored.enhancers[0].sigma == 1.5
-        assert isinstance(restored.enhancers[1], MedianFilter)
+        assert isinstance(restored.ops[0], GaussianBlur)
+        assert restored.ops[0].sigma == 1.5
+        assert isinstance(restored.ops[1], MedianFilter)

--- a/tests/unit/enhance/test_composite_enhance.py
+++ b/tests/unit/enhance/test_composite_enhance.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from phenotypic import Image, ImagePipeline
+from phenotypic.enhance import CompositeEnhance, GaussianBlur, MedianFilter
+
+
+def _three_branch_image() -> tuple[Image, np.ndarray, np.ndarray, np.ndarray]:
+    """An image plus the three constant detect_mat planes used as branches.
+
+    Each ``SetPlane`` enhancer below overwrites ``detect_mat`` with a flat
+    value, so the combined result is a deterministic per-pixel reduction of
+    the three constants -- ideal for asserting the exact mode arithmetic.
+    """
+    base = np.zeros((8, 8), dtype=float)
+    image = Image(arr=base)
+    return image, np.full((8, 8), 0.2), np.full((8, 8), 0.6), np.full((8, 8), 0.4)
+
+
+class _SetPlane(GaussianBlur):
+    """Test-only enhancer that floods ``detect_mat`` with a constant value."""
+
+    value: float = 0.0
+
+    def _operate(self, image):
+        image.detect_mat[:] = np.full_like(image.detect_mat[:], self.value)
+        return image
+
+
+def _branches() -> list[_SetPlane]:
+    return [_SetPlane(value=0.2), _SetPlane(value=0.6), _SetPlane(value=0.4)]
+
+
+class TestCombinationModes:
+    def test_max_is_default(self):
+        image, *_ = _three_branch_image()
+        result = CompositeEnhance(enhancers=_branches()).apply(image)
+        assert np.allclose(result.detect_mat[:], 0.6)
+
+    def test_min(self):
+        image, *_ = _three_branch_image()
+        result = CompositeEnhance(enhancers=_branches(), mode="min").apply(image)
+        assert np.allclose(result.detect_mat[:], 0.2)
+
+    def test_mean(self):
+        image, *_ = _three_branch_image()
+        result = CompositeEnhance(enhancers=_branches(), mode="mean").apply(image)
+        assert np.allclose(result.detect_mat[:], (0.2 + 0.6 + 0.4) / 3)
+
+    def test_median(self):
+        image, *_ = _three_branch_image()
+        result = CompositeEnhance(enhancers=_branches(), mode="median").apply(image)
+        assert np.allclose(result.detect_mat[:], 0.4)
+
+
+class TestClipping:
+    def test_clip_off_by_default_allows_out_of_range(self):
+        image = Image(arr=np.zeros((8, 8), dtype=float))
+        result = CompositeEnhance(
+            enhancers=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
+        ).apply(image)
+        assert result.detect_mat[:].max() > 1.0
+
+    def test_clip_clamps_to_unit_interval(self):
+        image = Image(arr=np.zeros((8, 8), dtype=float))
+        result = CompositeEnhance(
+            enhancers=[_SetPlane(value=1.5), _SetPlane(value=-0.3)],
+            mode="min",
+            clip=True,
+        ).apply(image)
+        assert result.detect_mat[:].min() >= 0.0
+        assert result.detect_mat[:].max() <= 1.0
+
+
+class TestBranchTypes:
+    def test_nested_pipeline_branch(self):
+        image, *_ = _three_branch_image()
+        pipe = ImagePipeline(pipe_cfgs=[_SetPlane(value=0.6)])
+        result = CompositeEnhance(
+            enhancers=[_SetPlane(value=0.2), pipe],
+        ).apply(image)
+        assert np.allclose(result.detect_mat[:], 0.6)
+
+    def test_none_slot_is_skipped(self):
+        image, *_ = _three_branch_image()
+        result = CompositeEnhance(
+            enhancers=[_SetPlane(value=0.2), None, _SetPlane(value=0.6)],
+        ).apply(image)
+        assert np.allclose(result.detect_mat[:], 0.6)
+
+    def test_empty_enhancers_raises(self):
+        image = Image(arr=np.zeros((8, 8), dtype=float))
+        with pytest.raises(Exception, match="At least one enhancer"):
+            CompositeEnhance(enhancers=[]).apply(image)
+
+    def test_all_none_enhancers_raises(self):
+        image = Image(arr=np.zeros((8, 8), dtype=float))
+        with pytest.raises(Exception, match="At least one enhancer"):
+            CompositeEnhance(enhancers=[None, None]).apply(image)
+
+
+class TestIntegrityAndDefaults:
+    def test_rgb_and_gray_unchanged(self):
+        from phenotypic.data import load_synth_yeast_plate
+
+        image = load_synth_yeast_plate()
+        rgb_before = image.rgb[:].copy()
+        gray_before = image.gray[:].copy()
+        result = CompositeEnhance(
+            enhancers=[GaussianBlur(sigma=1.0), MedianFilter()],
+        ).apply(image)
+        assert np.array_equal(result.rgb[:], rgb_before)
+        assert np.array_equal(result.gray[:], gray_before)
+
+    def test_constructs_with_no_args(self):
+        op = CompositeEnhance()
+        assert op.mode == "max"
+        assert op.clip is False
+        assert len(op.enhancers) == 2
+        assert isinstance(op.enhancers[0], GaussianBlur)
+        assert isinstance(op.enhancers[1], MedianFilter)
+
+    def test_explicit_none_enhancers_maps_to_default(self):
+        op = CompositeEnhance(enhancers=None)
+        assert isinstance(op.enhancers[0], GaussianBlur)
+        assert isinstance(op.enhancers[1], MedianFilter)
+
+
+class TestSerialization:
+    def test_roundtrip_preserves_branch_subclasses_and_mode(self):
+        op = CompositeEnhance(
+            enhancers=[GaussianBlur(sigma=1.5), MedianFilter()],
+            mode="mean",
+            clip=True,
+        )
+        restored = CompositeEnhance.from_json(op.to_json())
+        assert isinstance(restored, CompositeEnhance)
+        assert restored.mode == "mean"
+        assert restored.clip is True
+        assert isinstance(restored.enhancers[0], GaussianBlur)
+        assert restored.enhancers[0].sigma == 1.5
+        assert isinstance(restored.enhancers[1], MedianFilter)

--- a/tests/unit/enhance/test_composite_enhance.py
+++ b/tests/unit/enhance/test_composite_enhance.py
@@ -30,29 +30,32 @@ class _SetPlane(GaussianBlur):
 
 
 def _branches() -> list[_SetPlane]:
-    return [_SetPlane(value=0.2), _SetPlane(value=0.6), _SetPlane(value=0.4)]
+    # Skewed triple so max/min/mean/median are all distinct (0.9 / 0.1 / 0.4 /
+    # 0.2) -- a symmetric set like {0.2, 0.4, 0.6} has mean == median, which
+    # would let a median-implemented-as-mean bug slip through.
+    return [_SetPlane(value=0.1), _SetPlane(value=0.2), _SetPlane(value=0.9)]
 
 
 class TestCombinationModes:
     def test_max_is_default(self):
         image, *_ = _three_branch_image()
         result = CompositeEnhance(ops=_branches()).apply(image)
-        assert np.allclose(result.detect_mat[:], 0.6)
+        assert np.allclose(result.detect_mat[:], 0.9)
 
     def test_min(self):
         image, *_ = _three_branch_image()
         result = CompositeEnhance(ops=_branches(), mode="min").apply(image)
-        assert np.allclose(result.detect_mat[:], 0.2)
+        assert np.allclose(result.detect_mat[:], 0.1)
 
     def test_mean(self):
         image, *_ = _three_branch_image()
         result = CompositeEnhance(ops=_branches(), mode="mean").apply(image)
-        assert np.allclose(result.detect_mat[:], (0.2 + 0.6 + 0.4) / 3)
+        assert np.allclose(result.detect_mat[:], (0.1 + 0.2 + 0.9) / 3)
 
     def test_median(self):
         image, *_ = _three_branch_image()
         result = CompositeEnhance(ops=_branches(), mode="median").apply(image)
-        assert np.allclose(result.detect_mat[:], 0.4)
+        assert np.allclose(result.detect_mat[:], 0.2)
 
 
 class TestClipping:

--- a/tests/unit/gui/builder/test_conversion_dag.py
+++ b/tests/unit/gui/builder/test_conversion_dag.py
@@ -253,11 +253,11 @@ class TestToPipelineDagAuxFolding:
         assert len(ops) == 1
         consumer_inst = ops[0]
         assert isinstance(consumer_inst, CompositeDetector)
-        assert isinstance(consumer_inst.detectors, list)
-        assert len(consumer_inst.detectors) == 3
-        assert isinstance(consumer_inst.detectors[0], OtsuDetector)
-        assert consumer_inst.detectors[1] is None
-        assert isinstance(consumer_inst.detectors[2], OtsuDetector)
+        assert isinstance(consumer_inst.ops, list)
+        assert len(consumer_inst.ops) == 3
+        assert isinstance(consumer_inst.ops[0], OtsuDetector)
+        assert consumer_inst.ops[1] is None
+        assert isinstance(consumer_inst.ops[2], OtsuDetector)
 
 
 class TestToPipelineDagRaises:
@@ -493,7 +493,7 @@ class TestFromPipelineDagListAux:
         det_a = OtsuDetector()
         det_c = OtsuDetector()
         # slot 1 intentionally None (empty)
-        consumer = CompositeDetector(detectors=[det_a, None, det_c])
+        consumer = CompositeDetector(ops=[det_a, None, det_c])
         pipe = ImagePipeline(ops=[consumer])
 
         state = from_pipeline_dag(pipe)
@@ -503,7 +503,7 @@ class TestFromPipelineDagListAux:
         ]
         assert len(composite_blocks) == 1
         consumer_block = composite_blocks[0]
-        assert consumer_block.list_slot_counts.get("detectors") == 3
+        assert consumer_block.list_slot_counts.get("ops") == 3
 
         # Two aux edges should exist, with target_slot 0 and 2.
         aux_edges = [
@@ -511,7 +511,7 @@ class TestFromPipelineDagListAux:
             for e in state.root.edges
             if e.kind == "aux"
             and e.target_block_id == consumer_block.block_id
-            and e.target_port == "detectors"
+            and e.target_port == "ops"
         ]
         assert len(aux_edges) == 2
         slots = sorted(e.target_slot for e in aux_edges)
@@ -689,9 +689,9 @@ class TestContainerFixtureRoundTrip:
         assert isinstance(outer_op, CompositeDetector)
         # The consumer's detectors list-aux must carry one ImagePipeline
         # (the OuterContainer materialised).
-        assert isinstance(outer_op.detectors, list)
-        assert len(outer_op.detectors) >= 1
-        outer_container = outer_op.detectors[0]
+        assert isinstance(outer_op.ops, list)
+        assert len(outer_op.ops) >= 1
+        outer_container = outer_op.ops[0]
         assert isinstance(outer_container, ImagePipeline)
         # OuterContainer should expose one inner CompositeDetector that
         # in turn carries an inner ImagePipeline (the InnerContainer).
@@ -699,9 +699,9 @@ class TestContainerFixtureRoundTrip:
         assert len(inner_ops) == 1
         inner_composite = inner_ops[0]
         assert isinstance(inner_composite, CompositeDetector)
-        assert isinstance(inner_composite.detectors, list)
-        assert len(inner_composite.detectors) >= 1
-        inner_container = inner_composite.detectors[0]
+        assert isinstance(inner_composite.ops, list)
+        assert len(inner_composite.ops) >= 1
+        inner_container = inner_composite.ops[0]
         assert isinstance(inner_container, ImagePipeline)
         # Innermost pipeline holds the OtsuDetector.
         innermost_ops = list(inner_container.get_ops().values())
@@ -837,7 +837,7 @@ class TestContainerFixtureRoundTrip:
             ops=[GaussianBlur(sigma=1.0), OtsuDetector()], name="innermost"
         )
         outer_container = ImagePipeline(
-            ops=[CompositeDetector(detectors=[innermost])], name="outer"
+            ops=[CompositeDetector(ops=[innermost])], name="outer"
         )
         top = ImagePipeline(
             ops=[FilamentousFungiDetector(inoculum_detector=outer_container)],
@@ -900,8 +900,8 @@ class TestContainerFixtureRoundTrip:
         assert isinstance(rt_outer_composite, CompositeDetector)
         # Second-level aux container nested inside the
         # CompositeDetector's detectors list-aux.
-        assert isinstance(rt_outer_composite.detectors, list)
-        rt_inner = rt_outer_composite.detectors[0]
+        assert isinstance(rt_outer_composite.ops, list)
+        rt_inner = rt_outer_composite.ops[0]
         assert isinstance(rt_inner, ImagePipeline)
         rt_inner_classes = [
             type(o).__name__ for o in rt_inner.get_ops().values()

--- a/tests/unit/gui/builder/test_linear_callback_routing.py
+++ b/tests/unit/gui/builder/test_linear_callback_routing.py
@@ -13,7 +13,7 @@ def test_linear_pattern_id_decoders_round_trip_dash_safe_fields():
         kind="parameter_slot",
         scope_path=["pipe-a", "pipe-b"],
         block_id="consumer",
-        param="detectors",
+        param="ops",
         slot=2,
         surface="side",
     )
@@ -24,7 +24,7 @@ def test_linear_pattern_id_decoders_round_trip_dash_safe_fields():
         "kind": "parameter_slot",
         "scope_path": ["pipe-a", "pipe-b"],
         "block_id": "consumer",
-        "param": "detectors",
+        "param": "ops",
         "slot": 2,
     }
 

--- a/tests/unit/gui/builder/test_linear_dispatch.py
+++ b/tests/unit/gui/builder/test_linear_dispatch.py
@@ -84,8 +84,8 @@ def linear_registry(empty_registry, monkeypatch):
                     "detector": _make_param(
                         "detector", has_default=False, is_operation=True
                     ),
-                    "detectors": _make_param(
-                        "detectors",
+                    "ops": _make_param(
+                        "ops",
                         has_default=True,
                         is_operation=True,
                         is_list=True,
@@ -566,19 +566,19 @@ def test_linear_palette_add_replaces_list_slot_without_gaps(linear_registry):
     old_source = _block_dict("OtherOp")
     keep_source = _block_dict("SourceOp")
     state["root"]["blocks"].extend([old_source, keep_source])
-    consumer["list_slot_counts"]["detectors"] = 2
+    consumer["list_slot_counts"]["ops"] = 2
     state["root"]["edges"].extend(
         [
             _aux_edge_dict(
                 old_source["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=0,
             ),
             _aux_edge_dict(
                 keep_source["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=1,
             ),
         ]
@@ -587,7 +587,7 @@ def test_linear_palette_add_replaces_list_slot_without_gaps(linear_registry):
         ROOT_SCOPE_KEY: _target(
             "parameter_slot",
             block_id=consumer["block_id"],
-            param="detectors",
+            param="ops",
             slot=0,
         )
     }
@@ -605,7 +605,7 @@ def test_linear_palette_add_replaces_list_slot_without_gaps(linear_registry):
         edge
         for edge in _edges(out, kind="aux")
         if edge["target_block_id"] == consumer["block_id"]
-        and edge["target_port"] == "detectors"
+        and edge["target_port"] == "ops"
     ]
     assert sorted(edge["target_slot"] for edge in list_edges) == [0, 1]
 
@@ -728,19 +728,19 @@ def test_linear_clear_list_param_deletes_aux_subtree_and_compacts(linear_registr
     source_b = _block_dict("OtherOp")
     nested_dep = _block_dict("SourceOp")
     state["root"]["blocks"].extend([source_a, source_b, nested_dep])
-    consumer["list_slot_counts"]["detectors"] = 2
+    consumer["list_slot_counts"]["ops"] = 2
     state["root"]["edges"].extend(
         [
             _aux_edge_dict(
                 source_a["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=0,
             ),
             _aux_edge_dict(
                 source_b["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=1,
             ),
             _aux_edge_dict(nested_dep["block_id"], source_b["block_id"], "detector"),
@@ -754,7 +754,7 @@ def test_linear_clear_list_param_deletes_aux_subtree_and_compacts(linear_registr
             "target": _target(
                 "parameter_slot",
                 block_id=consumer["block_id"],
-                param="detectors",
+                param="ops",
                 slot=1,
             )
         },
@@ -767,10 +767,10 @@ def test_linear_clear_list_param_deletes_aux_subtree_and_compacts(linear_registr
         edge
         for edge in _edges(out, kind="aux")
         if edge["target_block_id"] == consumer["block_id"]
-        and edge["target_port"] == "detectors"
+        and edge["target_port"] == "ops"
     ]
     assert [edge["target_slot"] for edge in remaining] == [0]
-    assert _block_by_class(out, "ConsumerOp")["list_slot_counts"]["detectors"] == 1
+    assert _block_by_class(out, "ConsumerOp")["list_slot_counts"]["ops"] == 1
 
 
 def test_linear_clear_malformed_list_slot_is_noop(linear_registry):
@@ -779,19 +779,19 @@ def test_linear_clear_malformed_list_slot_is_noop(linear_registry):
     source_a = _block_dict("SourceOp")
     source_b = _block_dict("OtherOp")
     state["root"]["blocks"].extend([source_a, source_b])
-    consumer["list_slot_counts"]["detectors"] = 2
+    consumer["list_slot_counts"]["ops"] = 2
     state["root"]["edges"].extend(
         [
             _aux_edge_dict(
                 source_a["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=0,
             ),
             _aux_edge_dict(
                 source_b["block_id"],
                 consumer["block_id"],
-                "detectors",
+                "ops",
                 slot=1,
             ),
         ]
@@ -805,7 +805,7 @@ def test_linear_clear_malformed_list_slot_is_noop(linear_registry):
                 "kind": "parameter_slot",
                 "scope_path": [],
                 "block_id": consumer["block_id"],
-                "param": "detectors",
+                "param": "ops",
             }
         },
     )

--- a/tests/unit/gui/builder/test_state_dataclasses.py
+++ b/tests/unit/gui/builder/test_state_dataclasses.py
@@ -346,9 +346,9 @@ def test_list_slot_counts_default_is_empty_dict() -> None:
     assert a.list_slot_counts == {}
     assert b.list_slot_counts == {}
 
-    a.list_slot_counts["detectors"] = 3
+    a.list_slot_counts["ops"] = 3
     assert b.list_slot_counts == {}  # mutating one doesn't leak.
-    assert a.list_slot_counts == {"detectors": 3}
+    assert a.list_slot_counts == {"ops": 3}
     assert a.list_slot_counts is not b.list_slot_counts
 
 

--- a/tests/unit/gui/builder/test_validation.py
+++ b/tests/unit/gui/builder/test_validation.py
@@ -321,8 +321,8 @@ class TestRule3RequiredAux:
         empty_registry.ops["NeedsList"] = _make_op_info(
             "NeedsList",
             {
-                "detectors": _make_param(
-                    "detectors",
+                "ops": _make_param(
+                    "ops",
                     has_default=False,
                     is_operation=True,
                     is_list=True,
@@ -337,7 +337,7 @@ class TestRule3RequiredAux:
         issues = validate(_wrap(scope))
         req = [i for i in issues if i.kind == "required_aux"]
         assert any(
-            i.block_id == consumer.block_id and "detectors" in i.detail
+            i.block_id == consumer.block_id and "ops" in i.detail
             for i in req
         )
 
@@ -347,8 +347,8 @@ class TestRule3RequiredAux:
         empty_registry.ops["NeedsList"] = _make_op_info(
             "NeedsList",
             {
-                "detectors": _make_param(
-                    "detectors",
+                "ops": _make_param(
+                    "ops",
                     has_default=False,
                     is_operation=True,
                     is_list=True,
@@ -362,7 +362,7 @@ class TestRule3RequiredAux:
         scope.blocks.extend([producer, consumer])
         scope.edges.append(_image_edge(scope.blocks[0].block_id, consumer.block_id))
         scope.edges.append(
-            _aux_edge(producer.block_id, consumer.block_id, "detectors", slot=0)
+            _aux_edge(producer.block_id, consumer.block_id, "ops", slot=0)
         )
 
         issues = validate(_wrap(scope))

--- a/tests/unit/gui/test_operation_registry.py
+++ b/tests/unit/gui/test_operation_registry.py
@@ -285,7 +285,7 @@ class TestIsListDetection:
     """`_extract_parameters` populates ``ParamInfo.is_list`` for list-typed params.
 
     The flag distinguishes list-typed aux ports (e.g.
-    ``CompositeDetector.detectors: List[Union[ObjectDetector, ImagePipeline]]``)
+    ``CompositeDetector.ops: List[Union[ObjectDetector, ImagePipeline]]``)
     from scalar variants (e.g.
     ``FilamentousFungiDetector.inoculum_detector: Union[ObjectDetector,
     ImagePipeline, None]``) so the GUI builder can render multi-port
@@ -299,10 +299,10 @@ class TestIsListDetection:
         return reg
 
     def test_composite_detector_detectors_is_list(self, registry):
-        """``CompositeDetector.detectors: List[Union[Op, Pipeline]]``."""
+        """``CompositeDetector.ops: List[Union[Op, Pipeline]]``."""
         info = registry.get("CompositeDetector")
         assert info is not None
-        p = info.parameters.get("detectors")
+        p = info.parameters.get("ops")
         assert p is not None
         assert p.is_list is True
         assert p.is_operation is True

--- a/tests/unit/gui/tune/test_space.py
+++ b/tests/unit/gui/tune/test_space.py
@@ -34,7 +34,7 @@ def _synth_runnable_pipeline() -> ImagePipeline:
 def _nested_pipeline() -> ImagePipeline:
     """A pipeline whose CompositeDetector yields depth-1 ``Nested`` knobs."""
     return ImagePipeline(
-        ops=[GaussianBlur(sigma=2.0), CompositeDetector(detectors=[OtsuDetector()])]
+        ops=[GaussianBlur(sigma=2.0), CompositeDetector(ops=[OtsuDetector()])]
     )
 
 

--- a/tests/unit/tune/test_auto_space.py
+++ b/tests/unit/tune/test_auto_space.py
@@ -48,8 +48,8 @@ def test_written_proposal_round_trips_from_json(tmp_path):
 def test_run_auto_space_includes_nested_knobs(tmp_path):
     out = tmp_path / "auto"
     pipe = ImagePipeline(ops=[
-        CompositeDetector(detectors=[OtsuDetector(), RoundPeaksDetector()]),
+        CompositeDetector(ops=[OtsuDetector(), RoundPeaksDetector()]),
     ])
     proposal = run_auto_space(pipe, out)
     keys = {k.key for k in proposal.knobs}
-    assert any(k.startswith("0.detectors[0].") for k in keys)
+    assert any(k.startswith("0.ops[0].") for k in keys)

--- a/tests/unit/tune/test_build_pipeline_nested.py
+++ b/tests/unit/tune/test_build_pipeline_nested.py
@@ -1,7 +1,7 @@
 """Nested-op overlay in ``build_pipeline`` (P3-5b).
 
-Real nesting host: ``CompositeDetector.detectors: List[OperationField | None]``.
-A ``NestedKey`` (``"<pos>.detectors[<i>].<leaf>"``) overlays a scalar field on
+Real nesting host: ``CompositeDetector.ops: List[OperationField | None]``.
+A ``NestedKey`` (``"<pos>.ops[<i>].<leaf>"``) overlays a scalar field on
 the leaf op occupying slot ``i``, rebuilds that leaf through the key-tagged
 backstop, splices it back into the parent's list, and reconstructs the parent —
 leaving sibling slots, sibling ops, and the base pipeline untouched.
@@ -24,108 +24,108 @@ from phenotypic.tune._evaluation._builder import build_pipeline
 def _composite_base() -> ImagePipeline:
     """A pipeline whose sole op nests two detectors in a list field."""
     return ImagePipeline(ops=[
-        CompositeDetector(detectors=[
-            OtsuDetector(ignore_zeros=False),       # detectors[0]
-            RoundPeaksDetector(),                   # detectors[1]
+        CompositeDetector(ops=[
+            OtsuDetector(ignore_zeros=False),       # ops[0]
+            RoundPeaksDetector(),                   # ops[1]
         ]),
     ])
 
 
 def test_nested_overlay_rebuilds_leaf_and_leaves_base_untouched():
     base = _composite_base()
-    candidate = build_pipeline(base, {"0.detectors[0].ignore_zeros": True})
+    candidate = build_pipeline(base, {"0.ops[0].ignore_zeros": True})
 
     comp = candidate.get_ops()["CompositeDetector"]
-    assert comp.detectors[0].ignore_zeros is True
+    assert comp.ops[0].ignore_zeros is True
     # sibling slot is untouched
-    assert type(comp.detectors[1]).__name__ == "RoundPeaksDetector"
+    assert type(comp.ops[1]).__name__ == "RoundPeaksDetector"
     # base is unmutated
     base_comp = base.get_ops()["CompositeDetector"]
-    assert base_comp.detectors[0].ignore_zeros is False
+    assert base_comp.ops[0].ignore_zeros is False
 
 
 def test_nested_overlay_preserves_sibling_leaf_fields():
     base = _composite_base()
-    candidate = build_pipeline(base, {"0.detectors[0].ignore_borders": True})
+    candidate = build_pipeline(base, {"0.ops[0].ignore_borders": True})
     comp = candidate.get_ops()["CompositeDetector"]
     # only the addressed field changed; ignore_zeros stays at its base value
-    assert comp.detectors[0].ignore_borders is True
-    assert comp.detectors[0].ignore_zeros is False
+    assert comp.ops[0].ignore_borders is True
+    assert comp.ops[0].ignore_zeros is False
 
 
 def test_multiple_nested_overlays_on_same_field_fold_into_one_rebuild():
     base = _composite_base()
     candidate = build_pipeline(base, {
-        "0.detectors[0].ignore_zeros": True,
-        "0.detectors[1].split_merged": True,
+        "0.ops[0].ignore_zeros": True,
+        "0.ops[1].split_merged": True,
     })
     comp = candidate.get_ops()["CompositeDetector"]
-    assert comp.detectors[0].ignore_zeros is True
-    assert comp.detectors[1].split_merged is True
+    assert comp.ops[0].ignore_zeros is True
+    assert comp.ops[1].split_merged is True
 
 
 def test_nested_overlay_combined_with_parent_scalar_field():
     base = _composite_base()
     candidate = build_pipeline(base, {
         "0.mode": "union",
-        "0.detectors[0].ignore_zeros": True,
+        "0.ops[0].ignore_zeros": True,
     })
     comp = candidate.get_ops()["CompositeDetector"]
     assert comp.mode == "union"
-    assert comp.detectors[0].ignore_zeros is True
+    assert comp.ops[0].ignore_zeros is True
 
 
 def test_nested_overlay_alongside_flat_op_in_pipeline():
     base = ImagePipeline(ops=[
         GaussianBlur(sigma=2.0),                    # position 0
-        CompositeDetector(detectors=[               # position 1
+        CompositeDetector(ops=[               # position 1
             OtsuDetector(ignore_zeros=False),
             RoundPeaksDetector(),
         ]),
     ])
     candidate = build_pipeline(base, {
         "0.sigma": 4.0,
-        "1.detectors[0].ignore_zeros": True,
+        "1.ops[0].ignore_zeros": True,
     })
     ops = candidate.get_ops()
     assert ops["GaussianBlur"].sigma == 4.0
-    assert ops["CompositeDetector"].detectors[0].ignore_zeros is True
+    assert ops["CompositeDetector"].ops[0].ignore_zeros is True
 
 
 def test_nested_index_out_of_range_raises():
     base = _composite_base()
     with pytest.raises(IndexError):
-        build_pipeline(base, {"0.detectors[5].ignore_zeros": True})
+        build_pipeline(base, {"0.ops[5].ignore_zeros": True})
 
 
 def test_nested_overlay_on_none_slot_raises():
     base = ImagePipeline(ops=[
-        CompositeDetector(detectors=[OtsuDetector(), None]),
+        CompositeDetector(ops=[OtsuDetector(), None]),
     ])
     with pytest.raises(ValueError, match="empty"):
-        build_pipeline(base, {"0.detectors[1].ignore_zeros": True})
+        build_pipeline(base, {"0.ops[1].ignore_zeros": True})
 
 
 def test_untouched_none_slot_passes_through():
     """A ``None`` slot that is not targeted survives the rebuild unchanged."""
     base = ImagePipeline(ops=[
-        CompositeDetector(detectors=[OtsuDetector(ignore_zeros=False), None]),
+        CompositeDetector(ops=[OtsuDetector(ignore_zeros=False), None]),
     ])
-    candidate = build_pipeline(base, {"0.detectors[0].ignore_zeros": True})
+    candidate = build_pipeline(base, {"0.ops[0].ignore_zeros": True})
     comp = candidate.get_ops()["CompositeDetector"]
-    assert comp.detectors[0].ignore_zeros is True
-    assert comp.detectors[1] is None
+    assert comp.ops[0].ignore_zeros is True
+    assert comp.ops[1] is None
 
 
 def test_nested_leaf_validation_error_names_the_knob_key():
     """A bad nested value surfaces a ValidationError tagged with its knob key."""
     base = ImagePipeline(ops=[
-        CompositeDetector(detectors=[
-            RoundPeaksDetector(),                   # detectors[0]
+        CompositeDetector(ops=[
+            RoundPeaksDetector(),                   # ops[0]
             OtsuDetector(),
         ]),
     ])
     # thresh_method is a closed Literal set; an out-of-set value must fail
     # reconstruction of the leaf, tagged with the nested knob key.
-    with pytest.raises(ValidationError, match=r"detectors\[0\]\.thresh_method"):
-        build_pipeline(base, {"0.detectors[0].thresh_method": "not_a_method"})
+    with pytest.raises(ValidationError, match=r"ops\[0\]\.thresh_method"):
+        build_pipeline(base, {"0.ops[0].thresh_method": "not_a_method"})

--- a/tests/unit/tune/test_builder.py
+++ b/tests/unit/tune/test_builder.py
@@ -66,8 +66,8 @@ def test_nested_key_on_non_list_field_raises():
     the apply step rejects the key loudly rather than silently no-op'ing.
     """
     base = _base()
-    with pytest.raises(ValueError, match="detectors"):
-        build_pipeline(base, {"1.detectors[0].ignore_zeros": True})
+    with pytest.raises(ValueError, match="ops"):
+        build_pipeline(base, {"1.ops[0].ignore_zeros": True})
 
 
 def test_filamentous_scene_parent_tuning_recomputes_auto_derived_fields():

--- a/tests/unit/tune/test_infer_nested.py
+++ b/tests/unit/tune/test_infer_nested.py
@@ -1,6 +1,6 @@
 """One-level nested-op recursion in ``infer_search_space`` (P3-5c).
 
-Real host: ``CompositeDetector.detectors: List[OperationField | None]``. With
+Real host: ``CompositeDetector.ops: List[OperationField | None]``. With
 ``recurse_nested=True`` (the default), inference emits ``pos.field[i].leaf``
 knobs for each non-``None`` leaf op's scalar fields — depth-capped at 1 (a
 nested op's *own* operation-valued fields are excluded). ``recurse_nested=False``
@@ -22,9 +22,9 @@ from phenotypic.tune import Knob, infer_search_space
 
 def _composite_pipe() -> ImagePipeline:
     return ImagePipeline(ops=[
-        CompositeDetector(detectors=[
-            OtsuDetector(ignore_zeros=False),   # detectors[0] — two bool fields
-            RoundPeaksDetector(),               # detectors[1]
+        CompositeDetector(ops=[
+            OtsuDetector(ignore_zeros=False),   # ops[0] — two bool fields
+            RoundPeaksDetector(),               # ops[1]
         ]),
     ])
 
@@ -40,17 +40,17 @@ def _keys(space) -> set[str]:
 def test_nested_recursion_emits_depth1_leaf_keys():
     space = infer_search_space(_composite_pipe())
     keys = _keys(space)
-    # OtsuDetector leaf fields at detectors[0]
-    assert "0.detectors[0].ignore_zeros" in keys
-    assert "0.detectors[0].ignore_borders" in keys
-    # RoundPeaksDetector leaf bool/enum fields at detectors[1]
-    assert "0.detectors[1].split_merged" in keys
-    assert "0.detectors[1].thresh_method" in keys
+    # OtsuDetector leaf fields at ops[0]
+    assert "0.ops[0].ignore_zeros" in keys
+    assert "0.ops[0].ignore_borders" in keys
+    # RoundPeaksDetector leaf bool/enum fields at ops[1]
+    assert "0.ops[1].split_merged" in keys
+    assert "0.ops[1].thresh_method" in keys
 
 
 def test_nested_leaf_provenance_and_description_from_nested_class():
     space = infer_search_space(_composite_pipe())
-    knob = _knob(space, "0.detectors[0].ignore_zeros")
+    knob = _knob(space, "0.ops[0].ignore_zeros")
     # a bool field resolves to the ``bool`` source
     assert knob.source == "bool"
     # description is sourced from the *nested* class's schema (OtsuDetector)
@@ -61,14 +61,14 @@ def test_nested_conditional_on_is_none_without_presence_wrapping():
     """v1: nested ops are never presence-wrapped, so conditional_on stays None."""
     space = infer_search_space(_composite_pipe())
     for knob in space.knobs:
-        if knob.key.startswith("0.detectors["):
+        if knob.key.startswith("0.ops["):
             assert knob.conditional_on is None
 
 
 def test_depth_cap_excludes_nested_ops_own_operation_fields():
     """A nested op's own OperationField children are not recursed (depth cap 1)."""
     space = infer_search_space(_composite_pipe())
-    # No key descends two ``[i]`` levels and no nested 'detectors' of a nested op.
+    # No key descends two ``[i]`` levels and no nested 'ops' of a nested op.
     for key in _keys(space):
         # at most one ``[`` index segment in any emitted key
         assert key.count("[") <= 1
@@ -86,7 +86,7 @@ def test_recurse_nested_false_yields_flat_only():
 def test_nested_recursion_additive_alongside_flat_op():
     pipe = ImagePipeline(ops=[
         GaussianBlur(sigma=2.0),                # position 0 — flat
-        CompositeDetector(detectors=[           # position 1 — nested host
+        CompositeDetector(ops=[           # position 1 — nested host
             OtsuDetector(ignore_zeros=False),
             RoundPeaksDetector(),
         ]),
@@ -96,18 +96,18 @@ def test_nested_recursion_additive_alongside_flat_op():
     # flat knob for the GaussianBlur op survives unchanged
     assert "0.sigma" in keys
     # nested keys are prefixed with the parent's position (1)
-    assert "1.detectors[0].ignore_zeros" in keys
+    assert "1.ops[0].ignore_zeros" in keys
 
 
 def test_none_slot_is_skipped_in_recursion():
     pipe = ImagePipeline(ops=[
-        CompositeDetector(detectors=[OtsuDetector(ignore_zeros=False), None]),
+        CompositeDetector(ops=[OtsuDetector(ignore_zeros=False), None]),
     ])
     space = infer_search_space(pipe)
     keys = _keys(space)
-    assert "0.detectors[0].ignore_zeros" in keys
+    assert "0.ops[0].ignore_zeros" in keys
     # the None slot produces no knobs
-    assert not any(k.startswith("0.detectors[1]") for k in keys)
+    assert not any(k.startswith("0.ops[1]") for k in keys)
 
 
 def test_single_operation_field_is_excluded_not_emitted_as_unparsable_key():

--- a/tests/unit/tune/test_parse_key_grammar.py
+++ b/tests/unit/tune/test_parse_key_grammar.py
@@ -65,16 +65,16 @@ def test_classed_presence_class_mismatch_raises():
 # nested
 # --------------------------------------------------------------------------- #
 def test_nested_key_parses_to_nestedkey():
-    parsed = _parse_key("0.detectors[0].ignore_zeros", _composite_base())
+    parsed = _parse_key("0.ops[0].ignore_zeros", _composite_base())
     assert isinstance(parsed, NestedKey)
     assert parsed.position == 0
-    assert parsed.field == "detectors"
+    assert parsed.field == "ops"
     assert parsed.index == 0
     assert parsed.leaf == "ignore_zeros"
 
 
 def test_nested_key_high_index_parses():
-    parsed = _parse_key("0.detectors[1].thresh_method", _composite_base())
+    parsed = _parse_key("0.ops[1].thresh_method", _composite_base())
     assert isinstance(parsed, NestedKey)
     assert parsed.index == 1
     assert parsed.leaf == "thresh_method"
@@ -85,7 +85,7 @@ def test_nested_key_high_index_parses():
 # --------------------------------------------------------------------------- #
 def test_second_index_segment_rejected_as_depth_error():
     with pytest.raises(ValueError, match="depth"):
-        _parse_key("0.detectors[0].sub[1].x", _composite_base())
+        _parse_key("0.ops[0].sub[1].x", _composite_base())
 
 
 # --------------------------------------------------------------------------- #
@@ -93,12 +93,12 @@ def test_second_index_segment_rejected_as_depth_error():
 # --------------------------------------------------------------------------- #
 def test_malformed_bracket_raises():
     with pytest.raises(ValueError):
-        _parse_key("0.detectors[x].ignore_zeros", _composite_base())
+        _parse_key("0.ops[x].ignore_zeros", _composite_base())
 
 
 def test_nested_missing_leaf_raises():
     with pytest.raises(ValueError):
-        _parse_key("0.detectors[0]", _composite_base())
+        _parse_key("0.ops[0]", _composite_base())
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/tune/test_targets.py
+++ b/tests/unit/tune/test_targets.py
@@ -24,8 +24,8 @@ def test_presence_key_bare_and_classed():
 
 
 def test_nested_key():
-    t = Nested(op=1, field="detectors", index=0, leaf="ignore_zeros")
-    assert t.key == "1.detectors[0].ignore_zeros"
+    t = Nested(op=1, field="ops", index=0, leaf="ignore_zeros")
+    assert t.key == "1.ops[0].ignore_zeros"
 
 
 def test_targets_are_frozen_and_discriminated():
@@ -38,7 +38,7 @@ def test_targets_are_frozen_and_discriminated():
 
 
 @pytest.mark.parametrize("key", [
-    "0.sigma", "0.__enabled__", "0.GaussianBlur.__enabled__", "1.detectors[0].ignore_zeros",
+    "0.sigma", "0.__enabled__", "0.GaussianBlur.__enabled__", "1.ops[0].ignore_zeros",
 ])
 def test_parse_key_round_trips(key):
     assert parse_key(key).key == key          # string-preserving
@@ -80,8 +80,8 @@ def test_parse_key_rejects_depth_2_nested():
 
 
 def test_parse_key_accepts_depth_1_nested():
-    t = parse_key("0.detectors[1].ignore_zeros")
-    assert (t.op, t.field, t.index, t.leaf) == (0, "detectors", 1, "ignore_zeros")
+    t = parse_key("0.ops[1].ignore_zeros")
+    assert (t.op, t.field, t.index, t.leaf) == (0, "ops", 1, "ignore_zeros")
 
 
 def test_parse_key_rejects_empty_class_presence():


### PR DESCRIPTION
## Summary

Adds `CompositeEnhance` — the enhancer-side sibling of `CompositeDetector` — and **unifies the list-of-operations field name to `ops`** across both composite classes.

`CompositeEnhance` applies N enhancers (or enhancer pipelines) to the **same** input image and reduces their `detect_mat` response maps **pixel-wise** into one map. This ensembles complementary preprocessing: where one branch responds to faint colonies and another to sharp edges, `max` keeps the strongest signal from either.

## API: `ops`

Both composite classes now take a single list param named **`ops`**:

```python
CompositeEnhance(ops=[GaussianBlur(), MedianFilter()], mode="max", clip=False)
CompositeDetector(ops=[OtsuDetector(), RoundPeaksDetector()], mode="overlap")
```

- `CompositeEnhance.enhancers` → `ops`
- `CompositeDetector.detectors` → `ops` (rename of existing field)

The field name is the GUI builder's **aux-port identifier** and the root of tune's **derived knob keys** (now `<pos>.ops[i].<leaf>`), so the rename ripples through the builder DAG fixtures, tune key-grammar tests, and serialization tests. No production code hardcodes the old name — the GUI registry and tune inference derive it from the model field. Migration goldens are unaffected (no functional `detectors` usage).

> [!WARNING]
> **Breaking change:** a `pipeline.json` saved with the old `detectors`/`enhancers` key no longer deserializes into the renamed `ops` field. (No backward-compat alias is added, matching the project's hard-cutover convention — happy to add a pydantic `validation_alias` if you'd prefer old DAGs to keep loading.)

## CompositeEnhance behavior

- **`mode`** — `Literal["max", "mean", "min", "median"]`, default `"max"`. Invalid modes rejected at construction by the `Literal`.
  - `max`: union of complementary signals (default) · `min`: consensus suppression · `mean`: averages branches · `median`: robust to a single outlier branch (best with 3+).
- **`clip`** — `bool`, default `False`. When `True`, clamps the combined result into `[0, 1]` after reduction. Off by default since `detect_mat` isn't guaranteed unit-normalized.
- **`ops`** — `List[OperationField | None]`, default `[GaussianBlur(), MedianFilter()]`. Each branch may be an `ImageEnhancer` **or** an `ImagePipeline`; `OperationField` preserves concrete subclasses across JSON round-trip; `None` slots (unfilled GUI-builder entries) are skipped. Empty / all-`None` raises.

Branches read the same input `detect_mat` independently (they don't chain), so branch order doesn't affect these commutative reductions. `rgb`/`gray` untouched (passes `@validate_operation_integrity`).

### Implementation notes

- `CompositeEnhance` subclasses `ImageEnhancer` **directly** as a meta-enhancer (no purpose-group marker ABC), mirroring how `CompositeDetector` subclasses `ObjectDetector` directly. Documented as marker-exempt in `enhance/CLAUDE.md`; the hardcoded `test_enhancer_taxonomy.py` roster is unaffected.
- Exported from `phenotypic.enhance` so the GUI builder registry auto-discovers it.
- No `int`/`float` fields, so it doesn't trip the tune annotation-coverage gate; `default_factory` keeps it `from_json`-deserializable.

## Tests

- New `tests/unit/enhance/test_composite_enhance.py` (14 tests): each of the 4 modes, clip on/off, nested-`ImagePipeline` branch, `None`-slot skipped, empty/all-`None` raises, `rgb`/`gray` unchanged on a real plate, JSON round-trip preserving branch subclasses + `mode` + `clip`.
- Updated all `CompositeDetector` dependents for the `ops` rename: serialization tests, tune key-grammar/inference tests, GUI builder + registry tests, and 3 builder DAG fixtures.

## Verification

- Full affected sweep: **1476 passed** (`tests/unit/enhance`, `detect`, `core/test_pipeline_serialization`, `tune/`, `gui/`, `integration/gui/builder`) + module doctests; the 3 initial misses (single-quoted `'detectors'` keys, an escaped-bracket regex) were fixed and re-verified.
- `tests/gui/builder/` (Flask/dataclass) pass; the Playwright e2e `test_list_aux` skips without a live browser but its fixtures are exercised by the unit `test_conversion_dag`.
- `ruff` clean; mypy at baseline parity (only the pre-existing `OperationField` type-form notes shared with the sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)