### PR TITLE
fix: don't force colour.plotting import on dunder introspection

### DIFF
--- a/src/phenotypic/_startup_perf.py
+++ b/src/phenotypic/_startup_perf.py
@@ -51,6 +51,14 @@ class _LazyColourPlotting(types.ModuleType):
     __phenotypic_lazy_stub__ = True
 
     def __getattr__(self, name: str):
+        # Introspection probes (e.g. inspect.getmodule asking for ``__file__``
+        # while formatting an unrelated traceback) must not force the heavy
+        # import — only genuine plotting attribute access should. Forwarding a
+        # dunder lookup would detonate the real ``colour.plotting`` import even
+        # in venvs where colour is broken, surfacing a confusing secondary
+        # error during traceback formatting.
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         # First real use: replace ourselves with the genuine submodule.
         sys.modules.pop("colour.plotting", None)
         real = importlib.import_module("colour.plotting")


### PR DESCRIPTION
## Problem

The lazy `colour.plotting` stub in `_startup_perf.py` skips colour-science's expensive eager `from colour import plotting` at startup, lazily forwarding to the real submodule only when something genuinely uses `colour.plotting`.

But its `__getattr__` forwarded **every** attribute lookup into the real import — including dunder probes like `__file__`. Introspection tooling reads `module.__file__` routinely; notably `inspect.getmodule`, which IPython's verbose traceback formatter calls while walking frames. That forced the heavy `colour.plotting` import at the worst possible moment: mid-traceback-formatting.

In a venv where `colour-science` is internally broken (e.g. `module 'colour.plotting.datasets' has no attribute 'CONSTANTS_ARROW_STYLE'`), this surfaced a confusing **secondary** `AttributeError` stacked on top of the user's actual (unrelated) error — making the real error nearly impossible to read.

## Fix

Guard dunder names in `__getattr__`: probes like `__file__` now raise a clean `AttributeError` (which `inspect.getmodule` handles gracefully) instead of detonating the import. Genuine plotting attribute access still lazily forwards to the real submodule, so the optimization is unchanged.

## Verification

```
$ uv run python -c "..."
is stub: True
OK: __file__ raises AttributeError, no heavy import triggered
colour.plotting still stub: True
```

The stub stays installed after an introspection probe; only real plotting access swaps in the genuine module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)