### PR TITLE
Clean up CLI output artifacts

### DIFF
--- a/src/phenotypic/_cli/_cli_interactive.py
+++ b/src/phenotypic/_cli/_cli_interactive.py
@@ -117,11 +117,12 @@ def _display_output_structure(config: ExecutionConfig, datasets: List[Dataset], 
     if len(datasets) > 2:
         click.echo("    ├── ... (more datasets)")
 
-    click.echo("    ├── logs/")
-    click.echo("    │   └── slurm/ (if using SLURM execution)")
-    click.echo("    ├── slurm_scripts/ (if using SLURM execution)")
-    click.echo("    ├── processing_state.json")
-    click.echo("    ├── processing_events.log")
+    click.echo("    ├── .phenotypic/")
+    click.echo("    │   ├── logs/")
+    click.echo("    │   │   └── slurm/ (if using SLURM execution)")
+    click.echo("    │   ├── slurm_scripts/ (if using SLURM execution)")
+    click.echo("    │   ├── processing_state.json")
+    click.echo("    │   └── processing_events.log")
     click.echo("    ├── processing_report.html")
     click.echo("    ├── master_measurements.csv")
     click.echo("    ├── measurements.csv  (editable copy for GUI; refreshed on every run)")

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -36,7 +36,6 @@ from phenotypic.util import split_measurements
 from phenotypic.sdk_ import (
     DIR_RESULTS,
     DIR_MEASUREMENTS,
-    DIR_LOGS,
     DIR_HDF,
     DIR_INSPECT,
     ANALYSIS_CSV,
@@ -51,6 +50,7 @@ from phenotypic.sdk_ import (
     measurements_csv_path,
     measurements_parquet_path,
     metadata_csv_deliverable_path,
+    logs_dir,
     pipeline_json_path,
     resolve_pipeline_config_path,
     resolve_processing_state_path,
@@ -1091,8 +1091,8 @@ class OutputManager:
         # Results directory for dataset outputs (images, measurements, overlays)
         self.results_dir = self.base_dir / DIR_RESULTS
 
-        # Logs directory (always at root level)
-        self.logs_dir = self.base_dir / DIR_LOGS
+        # Logs directory in the hidden machine-state cache.
+        self.logs_dir = logs_dir(self.base_dir)
 
     @classmethod
     def from_config(
@@ -1155,9 +1155,9 @@ class OutputManager:
         # Create results directory for dataset outputs
         self.results_dir.mkdir(exist_ok=True)
 
-        # Create logs directory at root level
-        self.logs_dir.mkdir(exist_ok=True)
-        (self.logs_dir / "slurm").mkdir(exist_ok=True)
+        # Create logs directory in the hidden machine-state cache.
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        (self.logs_dir / "slurm").mkdir(parents=True, exist_ok=True)
 
         # Create dataset folders with subdirectories under results/
         for dataset in datasets:

--- a/src/phenotypic/_cli/_cli_process_only.py
+++ b/src/phenotypic/_cli/_cli_process_only.py
@@ -23,15 +23,15 @@ def process_only_output_path(
 ) -> Path:
     """Mirror ``image_path`` (relative to ``input_root``) under ``output_dir``.
 
-    Names the file ``<stem>_<layer>.<ext>`` (``.png`` for objmap, else
-    ``.tiff``). Bounded by the 1-level dataset scanner (D12).
+    Names the file ``<stem>.<ext>`` (``.png`` for objmap, else ``.tiff``).
+    Bounded by the 1-level dataset scanner (D12).
     """
     ext = ".png" if layer == "objmap" else ".tiff"
     try:
         rel = image_path.relative_to(input_root)
     except ValueError:
         rel = Path(image_path.name)
-    return output_dir / rel.parent / f"{rel.stem}_{layer}{ext}"
+    return output_dir / rel.parent / f"{rel.stem}{ext}"
 
 
 def write_process_only_layer(

--- a/src/phenotypic/_cli/_cli_readme_generator.py
+++ b/src/phenotypic/_cli/_cli_readme_generator.py
@@ -109,9 +109,12 @@ output_folder/
 {dataset_list}
 |       +-- hdf/                      # Processed images as single .h5 per input (layers + metadata + grid state)
 |       +-- measurements/             # Per-image Parquet measurement files
-+-- processing_state.json             # Resume/state tracking
-+-- logs/                             # Execution logs
-|   +-- slurm/                        # SLURM job logs (if applicable)
++-- .phenotypic/                      # Hidden machine-state cache
+|   +-- processing_state.json         # Resume/state tracking
+|   +-- processing_events.log         # Append-only event log
+|   +-- logs/                         # Execution logs
+|   |   +-- slurm/                    # SLURM job logs (if applicable)
+|   +-- slurm_scripts/                # Generated SLURM scripts (if applicable)
 ```"""
 
     def _generate_layers_section(self) -> str:

--- a/src/phenotypic/_cli/_cli_recompile_slurm_scripts.py
+++ b/src/phenotypic/_cli/_cli_recompile_slurm_scripts.py
@@ -13,14 +13,14 @@ from ._cli_slurm_scripts import generate_slurm_directives
 from ._cli_utils import SLURM_THREAD_PIN_BASH, get_python_command
 from phenotypic.sdk_ import (
     DIR_HDF,
-    DIR_LOGS,
     DIR_RESULTS,
     dataset_overlays_dir,
-    DIR_SLURM_SCRIPTS,
     JobMetadataKey,
     RECOMPILE_TASK_MANIFEST_JSON,
+    logs_dir,
     progress_dir,
     recompile_dir,
+    slurm_scripts_dir,
 )
 
 TASK_MEASUREMENTS: Final[str] = "measurements"
@@ -127,9 +127,9 @@ def generate_recompile_slurm_scripts(
     if not tasks:
         return []
 
-    script_dir = output_dir / DIR_SLURM_SCRIPTS / "recompile"
+    script_dir = slurm_scripts_dir(output_dir) / "recompile"
     script_dir.mkdir(parents=True, exist_ok=True)
-    log_dir = output_dir / DIR_LOGS / "slurm" / "recompile"
+    log_dir = logs_dir(output_dir) / "slurm" / "recompile"
     log_dir.mkdir(parents=True, exist_ok=True)
 
     scripts: list[Path] = []

--- a/src/phenotypic/_cli/_cli_sentinel_scripts.py
+++ b/src/phenotypic/_cli/_cli_sentinel_scripts.py
@@ -21,6 +21,7 @@ from typing import Any, Dict
 
 from ._cli_slurm_scripts import generate_slurm_directives
 from ._cli_utils import get_python_command
+from phenotypic.sdk_ import logs_dir, slurm_scripts_dir
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ def generate_sentinel_script(
     Returns:
         Path to the generated sentinel script.
     """
-    script_dir = output_dir / "slurm_scripts"
+    script_dir = slurm_scripts_dir(output_dir)
     script_dir.mkdir(parents=True, exist_ok=True)
     script_path = script_dir / "sentinel.sh"
 
@@ -67,7 +68,7 @@ def generate_sentinel_script(
     if "slurm_partition" not in sentinel_slurm_args:
         sentinel_slurm_args["slurm_partition"] = "batch"
 
-    log_path = progress_dir / "sentinel_%j.log"
+    log_path = logs_dir(output_dir) / "slurm" / "sentinel_%j.log"
     directives = generate_slurm_directives(
         job_name="pht-sentinel",
         slurm_args=sentinel_slurm_args,

--- a/src/phenotypic/_cli/_cli_slurm_array_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_array_scripts.py
@@ -15,7 +15,7 @@ from typing import Dict, List, Optional, Tuple
 from ._cli_slurm_scripts import generate_slurm_directives
 from ._cli_types import Dataset, ExecutionConfig
 from ._cli_utils import SLURM_THREAD_PIN_BASH, get_python_command
-from phenotypic.sdk_ import DIR_LOGS, DIR_SLURM_SCRIPTS, event_log_path
+from phenotypic.sdk_ import event_log_path, logs_dir, slurm_scripts_dir
 
 # Sentinel value inserted into the image list to trigger checkpoint aggregation
 _CHECKPOINT_SENTINEL = "__PHENOTYPIC_CHECKPOINT__"
@@ -193,7 +193,7 @@ def generate_array_job_script(
         entries = _build_entry_list(chunk_images, checkpoint_interval, is_last_chunk)
 
     # Create script directory
-    script_dir = output_dir / DIR_SLURM_SCRIPTS / dataset.name
+    script_dir = slurm_scripts_dir(output_dir) / dataset.name
     script_dir.mkdir(parents=True, exist_ok=True)
 
     # Generate job name
@@ -207,7 +207,7 @@ def generate_array_job_script(
         script_name = f"array_job_chunk{chunk_id}.sh"
 
     # Generate log paths (using SLURM placeholders)
-    log_dir = output_dir / DIR_LOGS / "slurm" / dataset.name
+    log_dir = logs_dir(output_dir) / "slurm" / dataset.name
     log_dir.mkdir(parents=True, exist_ok=True)
     log_path = log_dir / f"{dataset.name}_%A_%a.log"
 

--- a/src/phenotypic/_cli/_cli_slurm_scripts.py
+++ b/src/phenotypic/_cli/_cli_slurm_scripts.py
@@ -12,7 +12,7 @@ import shlex
 
 from ._cli_types import Dataset, ExecutionConfig
 from ._cli_utils import SLURM_THREAD_PIN_BASH, get_python_command
-from phenotypic.sdk_ import DIR_LOGS, event_log_path
+from phenotypic.sdk_ import event_log_path, logs_dir, slurm_scripts_dir
 from phenotypic.sdk_.slurm._sbatch import (
     format_sbatch_directives as _format_sbatch_directives,
 )
@@ -74,7 +74,7 @@ def generate_image_processing_script(
     job_name = f"pht-{dataset.name}-{image_stem}"
 
     # Generate log paths
-    log_dir = output_dir / DIR_LOGS / "slurm" / dataset.name
+    log_dir = logs_dir(output_dir) / "slurm" / dataset.name
     log_dir.mkdir(parents=True, exist_ok=True)
     output_log = log_dir / f"{image_stem}_%j.out"
     error_log = log_dir / f"{image_stem}_%j.err"
@@ -183,7 +183,7 @@ def generate_all_image_scripts(
     Returns:
         Dictionary mapping dataset names to lists of script paths
     """
-    script_dir = output_dir / "slurm_scripts"
+    script_dir = slurm_scripts_dir(output_dir)
     event_log = event_log_path(output_dir)
 
     all_scripts = {}

--- a/src/phenotypic/_cli/_cli_slurm_submission.py
+++ b/src/phenotypic/_cli/_cli_slurm_submission.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
-from phenotypic.sdk_ import DIR_LOGS
+from phenotypic.sdk_ import logs_dir
 from phenotypic.sdk_.slurm import (
     generate_dispatcher_chain,
     submit_drip_feed_start,
@@ -59,7 +59,7 @@ def submit_slurm_script_chain(
             "Check that datasets contain images."
         )
 
-    log_dir = output_dir / DIR_LOGS / "slurm"
+    log_dir = logs_dir(output_dir) / "slurm"
     dispatcher_scripts = generate_dispatcher_chain(
         chunk_scripts=flat_scripts,
         output_dir=output_dir,

--- a/src/phenotypic/_cli/_cli_state_management.py
+++ b/src/phenotypic/_cli/_cli_state_management.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Optional, List
+from typing import Any, Optional, List
 from datetime import datetime
 
 from ._cli_types import ProcessingState, DatasetState, Dataset, ExecutionConfig
@@ -44,7 +44,8 @@ def save_processing_state(
     state_file.parent.mkdir(parents=True, exist_ok=True)
 
     # Convert state to dictionary
-    state_dict = {
+    dataset_entries: dict[str, dict[str, Any]] = {}
+    state_dict: dict[str, Any] = {
         ProcessingStateKey.VERSION: state.version,
         ProcessingStateKey.PIPELINE_PATH: str(state.pipeline_path),
         ProcessingStateKey.INPUT_PATH: str(state.input_path),
@@ -52,13 +53,13 @@ def save_processing_state(
         ProcessingStateKey.TIMESTAMP: state.timestamp.isoformat(),
         ProcessingStateKey.EXECUTION_MODE: state.execution_mode,
         ProcessingStateKey.LAST_UPDATED: state.last_updated.isoformat(),
-        ProcessingStateKey.DATASETS: {},
+        ProcessingStateKey.DATASETS: dataset_entries,
         ProcessingStateKey.CONFIG: state.config
     }
 
     # Add dataset states
     for dataset_name, ds_state in state.datasets.items():
-        state_dict[ProcessingStateKey.DATASETS][dataset_name] = {
+        dataset_entries[dataset_name] = {
             ProcessingStateKey.COMPLETED: list(ds_state.completed),
             ProcessingStateKey.FAILED: list(ds_state.failed),
             ProcessingStateKey.ERRORS: ds_state.errors,
@@ -178,6 +179,7 @@ def create_initial_state(
             "n_jobs": config.n_jobs,
             "slurm_args": config.slurm_args,
             "ext": config.ext,
+            "process_only_layer": config.process_only_layer,
         }
     )
     
@@ -244,6 +246,16 @@ def validate_resume_compatibility(
             return False, f"Grid rows mismatch: saved={state.config.get('nrows')}, current={config.nrows}"
         if state.config.get("ncols") != config.ncols:
             return False, f"Grid cols mismatch: saved={state.config.get('ncols')}, current={config.ncols}"
+
+    # Check process-only layer. Process mode writes one layer to the mirrored
+    # image path, so changing layers during resume would mix file semantics.
+    saved_process_only_layer = state.config.get("process_only_layer")
+    if saved_process_only_layer != config.process_only_layer:
+        return (
+            False,
+            "Process-only layer mismatch: "
+            f"saved={saved_process_only_layer}, current={config.process_only_layer}",
+        )
 
     return True, None
 

--- a/src/phenotypic/_execution/_slurm.py
+++ b/src/phenotypic/_execution/_slurm.py
@@ -24,7 +24,7 @@ import re
 from pathlib import Path
 from typing import Any, Callable, Optional, Sequence, TypeVar, cast
 
-from phenotypic.sdk_ import DIR_LOGS, DIR_SLURM_SCRIPTS
+from phenotypic.sdk_ import logs_dir, slurm_scripts_dir
 from phenotypic.sdk_.slurm import (
     format_sbatch_directives,
     generate_dispatcher_chain,
@@ -61,7 +61,7 @@ def _sanitize_job_name(study_name: str) -> str:
 #: worker — a fresh body with no image-chunk sentinels).
 _WORKER_MODULE = "phenotypic.tune._tune_cli._worker"
 
-#: The array worker script filename written under ``slurm_scripts/``.
+#: The array worker script filename written under ``.phenotypic/slurm_scripts/``.
 _WORKER_SCRIPT_NAME = "tune_workers.sh"
 
 
@@ -74,8 +74,9 @@ class SlurmExecutor:
     the shared study, so there is no per-item fan-out).
 
     Args:
-        output_dir: The run directory (scripts under ``slurm_scripts/``, logs
-            under ``logs/slurm/``).
+        output_dir: The run directory (scripts under
+            ``.phenotypic/slurm_scripts/``, logs under
+            ``.phenotypic/logs/slurm/``).
         spec_path: Path to the ``tuning_spec.json`` each worker loads.
         images_dir: The calibration image directory each worker scans.
         split_path: Path to the persisted held-out split each worker applies.
@@ -161,9 +162,9 @@ class SlurmExecutor:
         Returns:
             The path to the generated, executable script.
         """
-        script_dir = self.output_dir / DIR_SLURM_SCRIPTS
+        script_dir = slurm_scripts_dir(self.output_dir)
         script_dir.mkdir(parents=True, exist_ok=True)
-        log_dir = self.output_dir / DIR_LOGS / "slurm"
+        log_dir = logs_dir(self.output_dir) / "slurm"
         log_dir.mkdir(parents=True, exist_ok=True)
         log_path = log_dir / "tune_worker_%A_%a.log"
 
@@ -233,7 +234,7 @@ exit $EXIT_CODE
             The submitted SLURM job IDs (cast to the Protocol's ``list[R]``).
         """
         script = self.generate_worker_array_script()
-        log_dir = self.output_dir / DIR_LOGS / "slurm"
+        log_dir = logs_dir(self.output_dir) / "slurm"
         # A single array job → the chain is empty; submit_drip_feed_start still
         # submits the one array script (and no dispatcher).
         dispatchers = generate_dispatcher_chain(
@@ -274,7 +275,7 @@ exit $EXIT_CODE
         if worker_index in self._reenqueued:
             return None
         self._reenqueued.add(worker_index)
-        script_path = self.output_dir / DIR_SLURM_SCRIPTS / _WORKER_SCRIPT_NAME
+        script_path = slurm_scripts_dir(self.output_dir) / _WORKER_SCRIPT_NAME
         if not script_path.exists():
             script_path = self.generate_worker_array_script()
         return submit_script(script_path, array_index=worker_index)

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -1396,6 +1396,7 @@ def phenotypic_cli(
                     "slurm_args": config.slurm_args,
                     "ext": config.ext,
                     "save_overlays": config.save_overlays,
+                    "process_only_layer": config.process_only_layer,
                 }
             else:
                 state = create_initial_state(config, datasets, output_dir)
@@ -1829,9 +1830,9 @@ def _handle_recompile_slurm(
         click.echo("\nRecompile jobs submitted. Monitor progress with:")
         click.echo(f"  Open: {output_dir / 'dashboard.html'}")
         click.echo("  squeue -u $USER --array")
-        click.echo(
-            f"  tail -f {output_dir / 'logs' / 'slurm' / 'recompile'}/*.log"
-        )
+        from phenotypic.sdk_ import logs_dir
+
+        click.echo(f"  tail -f {logs_dir(output_dir) / 'slurm' / 'recompile'}/*.log")
 
 
 def _discover_recompile_dataset_names(

--- a/src/phenotypic/sdk_/_io_constants.py
+++ b/src/phenotypic/sdk_/_io_constants.py
@@ -389,7 +389,7 @@ DIR_MEASUREMENTS: Final[str] = "measurements"
 #: :func:`phenotypic._cli._cli_output_manager.split_master_by_feature`.
 DIR_MEASUREMENTS_BY_FEATURE: Final[str] = "measurements_by_feature"
 
-#: SLURM stdout/stderr / sbatch-script subdirectory.
+#: SLURM stdout/stderr subdirectory inside the hidden machine-state cache.
 DIR_LOGS: Final[str] = "logs"
 
 #: HDF5 image-state subdirectory: ``<output>/results/<ds>/hdf/``.
@@ -417,7 +417,7 @@ DIR_RECOMPILE_STATUS: Final[str] = "status"
 #: ``<progress>/recompile/measurement_shards/``.
 DIR_RECOMPILE_SHARDS: Final[str] = "measurement_shards"
 
-#: Generated SLURM script subdirectory: ``<output>/slurm_scripts/``.
+#: Generated SLURM script subdirectory inside the hidden machine-state cache.
 DIR_SLURM_SCRIPTS: Final[str] = "slurm_scripts"
 
 #: QC artifact subdirectory: ``<output>/deliverables/qc/``. Holds
@@ -779,9 +779,10 @@ def clear_machine_state(output_dir: Path) -> bool:
     """Remove **all** of a run's machine-state for a clean ``--restart``.
 
     Deletes the ``.phenotypic/`` cache (``progress/``, ``processing_state.json``,
-    ``processing_events.log``) and any pre-migration root-level machine-state,
-    while leaving user-facing output artifacts (``deliverables/``, ``results/``,
-    ``qc/``, ``logs/``, …) untouched. This is the difference between ``--restart``
+    ``processing_events.log``, logs, and generated SLURM scripts) and any
+    pre-migration root-level machine-state, while leaving user-facing output
+    artifacts (``deliverables/``, ``results/``, ``qc/``, …) untouched. This is
+    the difference between ``--restart``
     (re-run the orchestration against clean state, keep outputs) and
     ``--overwrite`` (delete the whole output dir). Clearing the event log here is
     what stops a restart from appending to — and rebuilding its manifest/failure
@@ -1135,7 +1136,7 @@ def pareto_importance_path(output_dir: Path, objective: str) -> Path:
 
 
 def phenotypic_cache_pipeline_json_path(output_dir: Path) -> Path:
-    """Return ``<output>/.phenotypic/pipeline.json`` — the process-only run's
+    """Return ``<output>/.phenotypic/pipeline.json.pht-pipe`` — the process-only run's
     reproducibility copy. Distinct from :func:`pipeline_json_path`, which roots
     under ``deliverables/`` (process-only writes no deliverables)."""
     return phenotypic_cache_dir(output_dir) / PIPELINE_JSON
@@ -1187,8 +1188,8 @@ def measurements_by_feature_dir(output_dir: Path) -> Path:
 
 
 def logs_dir(output_dir: Path) -> Path:
-    """Return ``<output>/logs/`` (SLURM stdout/stderr + sbatch scripts)."""
-    return output_dir / DIR_LOGS
+    """Return ``<output>/.phenotypic/logs/``."""
+    return phenotypic_cache_dir(output_dir) / DIR_LOGS
 
 
 def chunks_dir(progress_dir_: Path) -> Path:
@@ -1292,8 +1293,8 @@ def chunk_lock_path(progress_dir_: Path) -> Path:
 
 
 def slurm_scripts_dir(output_dir: Path) -> Path:
-    """Return ``<output>/slurm_scripts/``."""
-    return output_dir / DIR_SLURM_SCRIPTS
+    """Return ``<output>/.phenotypic/slurm_scripts/``."""
+    return phenotypic_cache_dir(output_dir) / DIR_SLURM_SCRIPTS
 
 
 def qc_dir(output_dir: Path) -> Path:

--- a/src/phenotypic/sdk_/slurm/_dispatcher.py
+++ b/src/phenotypic/sdk_/slurm/_dispatcher.py
@@ -13,6 +13,8 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from .._io_constants import slurm_scripts_dir
+
 logger = logging.getLogger(__name__)
 
 
@@ -125,7 +127,7 @@ def generate_dispatcher_chain(
         return []
 
     log_dir.mkdir(parents=True, exist_ok=True)
-    script_dir = output_dir / "slurm_scripts"
+    script_dir = slurm_scripts_dir(output_dir)
     script_dir.mkdir(parents=True, exist_ok=True)
 
     num_dispatchers = len(chunk_scripts) - 1

--- a/tests/integration/cli/test_phenotypic_cache_layout.py
+++ b/tests/integration/cli/test_phenotypic_cache_layout.py
@@ -13,6 +13,7 @@ Both pass ``--force-local`` so SLURM is never dispatched.
 """
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -73,6 +74,10 @@ def test_resume_of_legacy_layout_migrates_and_completes(
     events = cache / "processing_events.log"
     if events.exists():
         events.rename(out / "processing_events.log")
+    for generated_dir in ("logs", "slurm_scripts"):
+        leftover = cache / generated_dir
+        if leftover.exists():
+            shutil.rmtree(leftover)
     cache.rmdir()
     res = CliRunner().invoke(
         phenotypic_cli,

--- a/tests/integration/cli/test_process_only_e2e.py
+++ b/tests/integration/cli/test_process_only_e2e.py
@@ -1,5 +1,7 @@
 """End-to-end process-mode CLI run: mirrored layer files + manifest, no suite."""
 
+import json
+
 import numpy as np
 import tifffile
 from click.testing import CliRunner
@@ -9,6 +11,7 @@ from phenotypic.sdk_ import (
     deliverables_dir,
     manifest_json_path,
     phenotypic_cache_dir,
+    processing_state_path,
     rembi_manifest_path,
     results_dir,
 )
@@ -28,12 +31,21 @@ def test_process_only_end_to_end(tmp_path, synth_one_level_input, simple_pipelin
         ],
     )
     assert r.exit_code == 0, r.output
-    tiffs = list(out.rglob("*_detect_mat.tiff"))
+    tiffs = [
+        path
+        for path in out.rglob("*.tiff")
+        if not path.is_relative_to(phenotypic_cache_dir(out))
+    ]
     assert tiffs, "no mirrored tiffs"
+    assert not list(out.rglob("*_detect_mat.tiff"))
     # detect_mat float TIFF (imsave, full precision)
     assert np.issubdtype(tifffile.imread(tiffs[0]).dtype, np.floating)
     assert manifest_json_path(out).is_file()  # run-console visibility
     assert phenotypic_cache_dir(out).is_dir()
+    state = json.loads(processing_state_path(out).read_text(encoding="utf-8"))
+    assert state["config"]["process_only_layer"] == "detect_mat"
     assert not deliverables_dir(out).exists()  # no analysis suite
     assert not rembi_manifest_path(out).exists()  # no REMBI manifest in process mode
     assert not results_dir(out).exists()
+    assert not (out / "logs").exists()
+    assert not (out / "slurm_scripts").exists()

--- a/tests/unit/cli/test_cli_process_only.py
+++ b/tests/unit/cli/test_cli_process_only.py
@@ -14,11 +14,11 @@ def test_output_path_mirrors_one_level(tmp_path):
     img = root / "day1" / "plateA.tif"
     assert (
         process_only_output_path(out, img, root, "detect_mat")
-        == out / "day1" / "plateA_detect_mat.tiff"
+        == out / "day1" / "plateA.tiff"
     )
     assert (
         process_only_output_path(out, img, root, "objmap")
-        == out / "day1" / "plateA_objmap.png"
+        == out / "day1" / "plateA.png"
     )
 
 
@@ -27,13 +27,13 @@ def test_output_path_flat_and_single_file(tmp_path):
     root = tmp_path / "in"
     assert (
         process_only_output_path(out, root / "a.tif", root, "rgb")
-        == out / "a_rgb.tiff"
+        == out / "a.tiff"
     )
     # single-file input: input_root is the file's parent
     f = tmp_path / "solo.tif"
     assert (
         process_only_output_path(out, f, f.parent, "gray")
-        == tmp_path / "out" / "solo_gray.tiff"
+        == tmp_path / "out" / "solo.tiff"
     )
 
 

--- a/tests/unit/cli/test_cli_progress_dashboard.py
+++ b/tests/unit/cli/test_cli_progress_dashboard.py
@@ -44,7 +44,7 @@ from phenotypic._cli._dashboard._manifest_builder import (
 )
 from phenotypic._cli._dashboard import generate_dashboard
 from phenotypic._cli._cli_sentinel_scripts import generate_sentinel_script
-from phenotypic.sdk_ import analysis_html_path, dashboard_html_path
+from phenotypic.sdk_ import analysis_html_path, dashboard_html_path, logs_dir
 from phenotypic.sdk_ import progress_dir as _progress_dir
 
 
@@ -403,7 +403,6 @@ class TestManifestBuilder:
         assert manifest["datasets"]["plate2"]["total"] == 3
 
     def test_slurm_manifest_includes_slurm_info(self, tmp_dir):
-        event_log = tmp_dir / "processing_events.log"
         progress_dir = tmp_dir / "progress"
         progress_dir.mkdir()
 
@@ -644,6 +643,10 @@ class TestSentinelScript:
         assert "phenotypic._cli._cli_sentinel" in content
         # Uses the same Python path as array job scripts, not bare "python"
         assert "-m phenotypic._cli._cli_sentinel" in content
+        log_path = logs_dir(tmp_dir) / "slurm" / "sentinel_%j.log"
+        assert f"#SBATCH --output={log_path}" in content
+        assert f"#SBATCH --error={log_path}" in content
+        assert str(progress_dir / "sentinel_%j.log") not in content
 
     def test_time_derived_from_max_runtime(self, tmp_dir):
         script = generate_sentinel_script(

--- a/tests/unit/cli/test_cli_recompile_slurm.py
+++ b/tests/unit/cli/test_cli_recompile_slurm.py
@@ -18,6 +18,7 @@ from phenotypic.sdk_ import (
     measurements_csv_path,
     measurements_parquet_path,
     progress_dir,
+    slurm_scripts_dir,
 )
 from phenotypic.schema import METADATA
 
@@ -46,8 +47,8 @@ def test_recompile_slurm_dispatcher_submits_and_writes_metadata(
         [1],
     )
     scripts = [
-        output_dir / "slurm_scripts" / "recompile" / "chunk0.sh",
-        output_dir / "slurm_scripts" / "recompile" / "chunk1.sh",
+        slurm_scripts_dir(output_dir) / "recompile" / "chunk0.sh",
+        slurm_scripts_dir(output_dir) / "recompile" / "chunk1.sh",
     ]
     generated_tasks: list[dict[str, object]] = []
 
@@ -137,7 +138,7 @@ def test_recompile_slurm_dispatcher_waits_for_finalizer(
         output_dir / "results" / "plate_a" / "measurements" / "img1.parquet",
         [1],
     )
-    script = output_dir / "slurm_scripts" / "recompile" / "chunk0.sh"
+    script = slurm_scripts_dir(output_dir) / "recompile" / "chunk0.sh"
     finalizer_indices: list[int] = []
 
     def _fake_generate(

--- a/tests/unit/cli/test_cli_slurm_array.py
+++ b/tests/unit/cli/test_cli_slurm_array.py
@@ -487,14 +487,15 @@ class TestSLURMScriptChainSubmission:
     ):
         """Dispatcher generation and submission receive scripts in input order."""
         from phenotypic._cli._cli_slurm_submission import submit_slurm_script_chain
+        from phenotypic.sdk_ import logs_dir, slurm_scripts_dir
 
         output_dir = tmp_path / "output"
         slurm_args = {"slurm_partition": "short", "mem_gb": 16}
         chunk_scripts = [
-            output_dir / "slurm_scripts" / "dataset_a_chunk0.sh",
-            output_dir / "slurm_scripts" / "dataset_b_chunk0.sh",
+            slurm_scripts_dir(output_dir) / "dataset_a_chunk0.sh",
+            slurm_scripts_dir(output_dir) / "dataset_b_chunk0.sh",
         ]
-        dispatcher_scripts = [output_dir / "slurm_scripts" / "dispatch_1.sh"]
+        dispatcher_scripts = [slurm_scripts_dir(output_dir) / "dispatch_1.sh"]
         console = MagicMock()
 
         with patch(
@@ -515,7 +516,7 @@ class TestSLURMScriptChainSubmission:
             chunk_scripts=chunk_scripts,
             output_dir=output_dir,
             slurm_args=slurm_args,
-            log_dir=output_dir / "logs" / "slurm",
+            log_dir=logs_dir(output_dir) / "slurm",
         )
         mock_submit_drip_feed_start.assert_called_once_with(
             chunk_scripts=chunk_scripts,

--- a/tests/unit/cli/test_cli_state_management.py
+++ b/tests/unit/cli/test_cli_state_management.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
-from phenotypic._cli._cli_state_management import load_processing_state, save_processing_state
-from phenotypic._cli._cli_types import ProcessingState
+from phenotypic._cli._cli_state_management import (
+    load_processing_state,
+    save_processing_state,
+    validate_resume_compatibility,
+)
+from phenotypic._cli._cli_types import ExecutionConfig, ProcessingState
 from phenotypic.sdk_ import processing_state_path
 
 
@@ -43,3 +47,41 @@ def test_load_migrates_and_reads_legacy_run(tmp_path: Path) -> None:
     assert loaded is not None
     # migrate-on-load moved it into .phenotypic
     assert new.is_file()
+
+
+def test_resume_rejects_process_only_layer_change(tmp_path: Path) -> None:
+    state = _make_state(tmp_path)
+    state.config = {
+        "image_type": "GridImage",
+        "nrows": None,
+        "ncols": None,
+        "process_only_layer": "detect_mat",
+    }
+    config = ExecutionConfig(
+        pipeline_json=Path("p.json"),
+        input_path=Path("in"),
+        output_dir=tmp_path,
+        image_type="GridImage",
+        nrows=None,
+        ncols=None,
+        bit_depth=None,
+        n_jobs=1,
+        slurm_args={},
+        force_local=True,
+        wait=False,
+        ext=".tiff",
+        overlay_alpha=0.3,
+        include_dataset_column=True,
+        dry_run=False,
+        sample=None,
+        resume=True,
+        retry_failures=False,
+        skip_validation=True,
+        process_only_layer="rgb",
+    )
+
+    compatible, error = validate_resume_compatibility(state, config)
+
+    assert compatible is False
+    assert error is not None
+    assert "Process-only layer mismatch" in error

--- a/tests/unit/cli/test_cli_v2.py
+++ b/tests/unit/cli/test_cli_v2.py
@@ -388,8 +388,10 @@ class TestOutputManager:
 
         manager.create_structure(datasets)
 
-        # Check logs directory at root level
-        assert (temp_output_dir / "logs").exists()
+        from phenotypic.sdk_ import logs_dir
+
+        # Check logs directory in the hidden machine-state cache
+        assert logs_dir(temp_output_dir).exists()
 
         # Check results/ directory exists
         assert (temp_output_dir / "results").exists()

--- a/tests/unit/cli/test_local_strategy_process_only.py
+++ b/tests/unit/cli/test_local_strategy_process_only.py
@@ -31,8 +31,9 @@ def test_local_process_only_writes_layers_and_manifest_no_deliverables(
     strat.execute(datasets, out)
 
     # mirrored layer files exist
-    tiffs = list(out.rglob("*_detect_mat.tiff"))
+    tiffs = list(out.rglob("*.tiff"))
     assert tiffs, "no mirrored detect_mat tiffs written"
+    assert not list(out.rglob("*_detect_mat.tiff"))
     # progress manifest written (run console visibility), but no deliverables/dashboard
     assert manifest_json_path(out).is_file()
     assert not deliverables_dir(out).exists()

--- a/tests/unit/gui/shell/test_classifier_process_only.py
+++ b/tests/unit/gui/shell/test_classifier_process_only.py
@@ -24,7 +24,7 @@ def test_process_only_run_is_discoverable(tmp_path: Path) -> None:
     # Process-only run: mirrored layer + .phenotypic/progress/manifest.json,
     # no results/deliverables.
     (tmp_path / "day1").mkdir()
-    (tmp_path / "day1" / "plateA_detect_mat.tiff").write_bytes(b"II*\x00")
+    (tmp_path / "day1" / "plateA.tiff").write_bytes(b"II*\x00")
     mp = manifest_json_path(tmp_path)
     mp.parent.mkdir(parents=True, exist_ok=True)
     mp.write_text('{"is_complete": true}', encoding="utf-8")

--- a/tests/unit/sdk_/test_io_constants.py
+++ b/tests/unit/sdk_/test_io_constants.py
@@ -483,8 +483,8 @@ class TestPathHelpers:
         )
 
         prog = output / ".phenotypic" / "progress"
-        assert logs_dir(output) == output / "logs"
-        assert slurm_scripts_dir(output) == output / "slurm_scripts"
+        assert logs_dir(output) == output / ".phenotypic" / "logs"
+        assert slurm_scripts_dir(output) == output / ".phenotypic" / "slurm_scripts"
         assert analysis_html_path(output) == output / "deliverables" / "analysis.html"
         assert processing_report_html_path(output) == (
             output / "deliverables" / "processing_report.html"
@@ -910,8 +910,8 @@ class TestPhenotypicCacheLayout:
         assert deliverables_dir(out) == out / "deliverables"
         assert results_dir(out) == out / "results"
         assert qc_dir(out) == out / "deliverables" / "qc"
-        assert logs_dir(out) == out / "logs"
-        assert slurm_scripts_dir(out) == out / "slurm_scripts"
+        assert logs_dir(out) == out / ".phenotypic" / "logs"
+        assert slurm_scripts_dir(out) == out / ".phenotypic" / "slurm_scripts"
 
 
 class TestBackCompatResolvers:
@@ -1019,10 +1019,12 @@ class TestClearMachineState:
             clear_machine_state,
             deliverables_dir,
             event_log_path,
+            logs_dir,
             phenotypic_cache_dir,
             processing_state_path,
             progress_dir,
             results_dir,
+            slurm_scripts_dir,
         )
 
         out = tmp_path
@@ -1030,6 +1032,10 @@ class TestClearMachineState:
         (progress_dir(out) / "manifest.json").write_text("{}", encoding="utf-8")
         processing_state_path(out).write_text("{}", encoding="utf-8")
         event_log_path(out).write_text("x\n", encoding="utf-8")
+        logs_dir(out).mkdir(parents=True)
+        (logs_dir(out) / "run.log").write_text("log\n", encoding="utf-8")
+        slurm_scripts_dir(out).mkdir(parents=True)
+        (slurm_scripts_dir(out) / "array.sh").write_text("#!/bin/bash\n", encoding="utf-8")
         deliverables_dir(out).mkdir(parents=True)
         (deliverables_dir(out) / "master_measurements.parquet").write_bytes(b"x")
         results_dir(out).mkdir(parents=True)

--- a/tests/unit/sdk_/test_slurm_dispatcher.py
+++ b/tests/unit/sdk_/test_slurm_dispatcher.py
@@ -4,12 +4,13 @@ import sys
 
 import pytest
 
-pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="SLURM not available on Windows")
-
 from phenotypic.sdk_.slurm._dispatcher import (
     generate_dispatcher_chain,
     generate_dispatcher_script,
 )
+from phenotypic.sdk_ import slurm_scripts_dir
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="SLURM not available on Windows")
 
 
 @pytest.fixture
@@ -20,8 +21,8 @@ def slurm_args():
 @pytest.fixture
 def chunk_scripts(tmp_path):
     """Create dummy chunk script files."""
-    scripts_dir = tmp_path / "slurm_scripts"
-    scripts_dir.mkdir()
+    scripts_dir = slurm_scripts_dir(tmp_path)
+    scripts_dir.mkdir(parents=True)
     paths = []
     for i in range(4):
         p = scripts_dir / f"chunk{i}.sh"
@@ -182,7 +183,7 @@ class TestGenerateDispatcherChain:
 
     def test_single_chunk_no_dispatcher(self, tmp_path, slurm_args):
         """1 chunk should produce 0 dispatchers."""
-        chunk = tmp_path / "slurm_scripts" / "chunk0.sh"
+        chunk = slurm_scripts_dir(tmp_path) / "chunk0.sh"
         chunk.parent.mkdir(parents=True)
         chunk.write_text("#!/bin/bash\necho chunk")
 
@@ -196,8 +197,8 @@ class TestGenerateDispatcherChain:
 
     def test_two_chunks_one_dispatcher(self, tmp_path, slurm_args):
         """2 chunks should produce 1 dispatcher."""
-        scripts_dir = tmp_path / "slurm_scripts"
-        scripts_dir.mkdir()
+        scripts_dir = slurm_scripts_dir(tmp_path)
+        scripts_dir.mkdir(parents=True)
         chunks = []
         for i in range(2):
             p = scripts_dir / f"chunk{i}.sh"
@@ -226,6 +227,7 @@ class TestGenerateDispatcherChain:
         )
         for i, d in enumerate(dispatchers):
             assert d.name == f"dispatch_{i + 1}.sh"
+            assert d.parent == slurm_scripts_dir(tmp_path)
 
     def test_dispatcher_chain_wiring(self, chunk_scripts, tmp_path, slurm_args):
         """Each dispatcher should reference the correct next chunk and dispatcher."""

--- a/tests/unit/tune/test_slurm_executor.py
+++ b/tests/unit/tune/test_slurm_executor.py
@@ -21,6 +21,7 @@ pytestmark = [
 
 from phenotypic._execution import Executor  # noqa: E402
 from phenotypic._execution._slurm import SlurmExecutor  # noqa: E402
+from phenotypic.sdk_ import logs_dir, slurm_scripts_dir  # noqa: E402
 
 
 def _executor(tmp_path, *, n_workers=4, storage_url=None):
@@ -43,6 +44,7 @@ def test_worker_array_script_sizes_array_to_worker_count(tmp_path):
     ex = _executor(tmp_path, n_workers=5)
     script = ex.generate_worker_array_script()
     content = script.read_text()
+    assert script.parent == slurm_scripts_dir(tmp_path)
     # One array task = one worker; sized 0..n-1 (NOT image-chunk sized).
     assert "#SBATCH --array=0-4" in content
 
@@ -83,6 +85,7 @@ def test_worker_array_script_carries_sbatch_directives(tmp_path):
     assert content.startswith("#!/bin/bash")
     assert "--partition=short" in content
     assert "--mem=8G" in content
+    assert str(logs_dir(tmp_path) / "slurm" / "tune_worker_%A_%a.log") in content
 
 
 # --- Executor protocol --------------------------------------------------------

--- a/tests/unit/tune/test_storage_url_password.py
+++ b/tests/unit/tune/test_storage_url_password.py
@@ -125,3 +125,4 @@ def test_spec_password_url_fails_before_any_run_artifact_is_written(tmp_path):
     assert not io.tuning_spec_path(out).exists()
     assert not io.tune_cache_run_marker_path(out).exists()
     assert not (out / "slurm_scripts").exists()
+    assert not io.slurm_scripts_dir(out).exists()


### PR DESCRIPTION
## Summary
- write process-mode mirrored outputs without appending the layer name
- move CLI logs and generated SLURM scripts under the hidden .phenotypic cache
- persist and validate process_only_layer in processing state

## Verification
- uv run pytest tests/unit/sdk_/test_io_constants.py tests/unit/sdk_/test_slurm_dispatcher.py tests/unit/cli/test_cli_process_only.py tests/unit/cli/test_cli_state_management.py tests/unit/cli/test_cli_progress_dashboard.py::TestSentinelScript tests/unit/cli/test_local_strategy_process_only.py tests/unit/cli/test_slurm_process_only_scripts.py tests/unit/cli/test_cli_slurm_array.py::TestSLURMScriptChainSubmission tests/unit/cli/test_cli_recompile_slurm.py tests/unit/cli/test_staged_slurm_scripts.py tests/unit/tune/test_slurm_executor.py tests/unit/tune/test_slurm_passthrough.py tests/unit/tune/test_storage_url_password.py tests/unit/gui/shell/test_classifier_process_only.py tests/integration/cli/test_process_only_e2e.py tests/integration/cli/test_phenotypic_cache_layout.py -q
- uv run ruff check <touched files>

Note: full repository ruff/mypy still fail on existing baseline issues outside this change.