### PR TITLE
fix(nn): GPU detector resolution & tiling — tile_px was inert, six defects fixed

### DIFF
--- a/docs/source/how_to/pages/gpu_detection_setup.md
+++ b/docs/source/how_to/pages/gpu_detection_setup.md
@@ -3,6 +3,22 @@
 Set up and use deep-learning-based colony detectors (SAM2, micro-sam, SAM3,
 DinoSam2) with GPU acceleration.
 
+```{warning}
+**Behaviour change (this release).** The DINO-backed detectors
+(`FssDinoDetector`, `Insid3Detector`) previously fed every tile to the ViT
+backbone at a fixed 224x224 regardless of `tile_px` -- the checkpoint's
+*classification* preset, not the tile you asked for. They now feed the
+backbone the tile at its native geometry, so native pixels per patch equal the
+backbone's `patch_size` (14 for DINOv2, 16 for DINOv3) instead of collapsing to
+whatever 224 implied. Pipelines deserialized from JSON keep their pinned
+`tile_px` (`to_json()` writes every field), but **will produce different,
+higher-resolution masks** and cost substantially more GPU time -- re-serialize
+to adopt the new `tile_px` defaults described below. Separately,
+`Sam2Detector.crop_n_layers` moves from `0` to `1` (~5.2x cost) for
+**newly-constructed** detectors only; existing serialized pipelines are
+unaffected.
+```
+
 ## Installation
 
 The GPU detectors have different packaging constraints:
@@ -109,6 +125,18 @@ print(result.num_objects)
 - **`model_size`** (default `"tiny"`): `"tiny"` is fastest and sufficient
   for most colony plates. Use `"large"` for maximum mask quality on
   publication figures.
+- **`crop_n_layers`** (default 1): Number of additional crop-pyramid layers.
+  SAM2's encoder resizes the whole image to a fixed 1024x1024 square, so small
+  colonies on a multi-megapixel plate can be lost to downsampling; each added
+  layer re-tiles the image into nearer-native-resolution crops and merges them
+  by NMS that prefers masks from smaller crops. `0` keeps a single full-image
+  pass; the default `1` costs 5 encoder passes instead of 1 (~5.2x wall-clock)
+  but recovered far more ground-truth colonies in measurement (see the
+  behaviour-change notice above).
+- **`box_nms_thresh`** (default 0.7): Box-IoU cutoff for non-maximum
+  suppression between the dense point grid's redundant proposals *within* one
+  crop -- distinct from `crop_nms_thresh`, which deduplicates the same colony
+  seen in two different overlapping crops.
 
 ## Using MicroSamDetector
 
@@ -163,11 +191,18 @@ SAM3 weights are **gated** (SAM License). Accept the gate and authenticate
 once (see {ref}`Deep Learning Detectors`)
 before the first `apply()`.
 
-**Dense plates.** SAM3 caps at 200 instances per forward and runs at 1008 px
-internally, so `Sam3Detector` tiles large plates into fixed `tile_px` crops
-with `tile_overlap`, infers each tile, offsets the masks back to full
-coordinates, and merges cross-tile duplicates by IoU-NMS — all automatically.
-Images that fit one tile run un-tiled.
+**Dense plates.** SAM3 caps at 200 instances per forward. `facebook/sam3` is a
+gated repository whose processor config we cannot read (requests return 403),
+so the claim that it runs at 1008 px internally is carried as an
+**assumption**, not a verified fact. `Sam3Detector` tiles large plates into
+fixed `tile_px` crops with `tile_overlap`, infers each tile, and merges the
+per-tile instances by **centroid-in-core assignment**
+(`~phenotypic.detect.nn._tiling.assign_by_centroid_core`): each instance is
+kept by the one tile whose core -- the Voronoi cell of the tile centres --
+contains its centroid, so a colony straddling a seam is claimed by exactly one
+tile and the fragment a neighbouring tile saw is never kept as its own
+colony. There is no IoU-NMS deduplication step here; duplicates cannot occur
+by construction. Images that fit one tile run un-tiled.
 
 Key parameters:
 
@@ -175,7 +210,14 @@ Key parameters:
 - `score_thresh` / `mask_threshold` — instance-confidence and mask-probability
   cutoffs.
 - `min_mask_region_area` — drop masks smaller than this (default 100).
-- `tile_px` / `tile_overlap` — dense-plate tiling controls (defaults 1008 / 0.15).
+- `tile_px` / `tile_overlap` — dense-plate tiling controls (default 1008 / 0.15,
+  the 1008 figure being the unverified assumption noted above). `tile_px` is a
+  compute/context knob, not a fidelity knob: attention cost is quadratic in
+  tokens per tile, while the total tokens across the plate are roughly fixed,
+  so a larger `tile_px` costs more without segmenting any more finely.
+- `tile_merge_iou` — **deprecated and ignored.** The cross-tile merge is
+  centroid-in-core (above), which needs no IoU threshold. The field is
+  retained only so pipelines serialized before this change still deserialize.
 
 ## Using DinoSam2Detector
 
@@ -208,6 +250,17 @@ Key parameters:
 - `sam2_model_size` — SAM2 variant for the proposal generator.
 - `similarity_thresh` — minimum cosine-to-prototype score to keep a proposal.
 - `merge_iou_thresh` — IoU above which two survivors are merged.
+- `tile_px` / `tile_overlap` — geometry of the tiles the DINO backbone scores
+  proposals against (defaults 518 / 0.15). Each SAM2 proposal is pooled from
+  the tile whose core contains its centroid. Scoring against one whole-plate
+  feature grid instead would leave every colony smaller than a single patch, so
+  each proposal's pooled feature would collapse to the same zero vector and the
+  re-ranking would do no work.
+- `crop_n_layers` / `crop_nms_thresh` / `crop_overlap_ratio` /
+  `crop_n_points_downscale_factor` — SAM2 crop-pyramid controls for the
+  *proposal* half, forwarded to the same mask generator `Sam2Detector` uses and
+  documented under {ref}`Using Sam2Detector`. `crop_n_layers` defaults to `1`
+  here too.
 
 ## Semantic few-shot detectors (`Insid3Detector`, `FssDinoDetector`)
 
@@ -232,6 +285,27 @@ cosine-matches every query patch — but first removes DINOv3's **positional bia
 (estimated by SVD and projected out, INSID3's defining step) so patches match on
 appearance, not position. It is DINOv3-native (gated, `dino_version=3` default);
 a `dino_version=2` opt-in runs gate-free (the debias is then a near-no-op).
+
+Because `dino_version=3` is the default and DINOv3 weights are gated, the
+constructor now emits a `UserWarning` at construction time (rather than
+deferring the failure to first `apply()`) pointing at the Hugging Face access
+request and `PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3`. Contrast
+`FssDinoDetector` below, which defaults to the ungated DINOv2 backbone and so
+needs no access request. (Both detectors additionally warn at model-load time
+if `tile_px` is not a multiple of the loaded backbone's `patch_size` — which
+happens when you flip `dino_version` and leave `tile_px` at the other
+backbone's default.)
+
+```{warning}
+`Insid3Detector` is **weak at its default `similarity_thresh=0.5`**. On the
+bundled synthetic plate it recovers only 8 of 96 colonies, and its own
+functional test lowers the floor to `similarity_thresh=0.0` to obtain a
+non-empty mask at all. This is a threshold-calibration problem that predates
+the resolution work described in the behaviour-change notice above, and it is
+independent of `tile_px`: the detection *rate* is the same on a small plate and
+on a plate twelve times its area. Tune `similarity_thresh` down for your own
+plates before trusting its output.
+```
 
 ```python
 from phenotypic.detect.nn import Insid3Detector
@@ -258,7 +332,16 @@ Key parameters:
 - `similarity_thresh` — cosine cutoff binarising the match map.
 - `svd_components` — INSID3's positional-debias strength (leading SVD directions
   removed; default 4 ≈ DINOv3's register-token count; `0` disables the debias).
-- `tile_px` / `tile_overlap` — large-plate tiling (defaults 1024 / 0.15).
+- `tile_px` / `tile_overlap` — large-plate tiling (defaults 512 / 0.15). `512 =
+  16 * 32` is an exact multiple of DINOv3's patch size (16). Under the native
+  processor geometry, native pixels per patch equal the backbone's
+  `patch_size` regardless of `tile_px`, so this is a compute/context choice,
+  not a fidelity one: 512 and 1024 both resolve to 16.0 native px/patch, but
+  1024 costs 2.6x more (attention is quadratic in tokens per tile, while the
+  total tokens across the plate are roughly fixed). Raising it buys no extra
+  detail. Note `config.image_size` reports 224 for DINOv3 — that is a
+  classification preset, not a native-resolution signal, and is not used to
+  pick this default.
 
 ### `FssDinoDetector` — few-shot (DINOv2 default, ungated)
 
@@ -296,7 +379,13 @@ Key parameters:
 - `dino_version` / `dino_size` — backbone (2 = DINOv2 default/ungated, 3 = DINOv3
   gated opt-in).
 - `similarity_thresh` — foreground-score floor on top of the fg-vs-bg argmax.
-- `tile_px` / `tile_overlap` — large-plate tiling (defaults 512 / 0.15).
+- `tile_px` / `tile_overlap` — large-plate tiling (defaults 518 / 0.15). `518 =
+  14 * 37` is an exact multiple of DINOv2's patch size (14). Native pixels per
+  patch equal the backbone's `patch_size` regardless of `tile_px`, so 518 and
+  1022 both resolve to 14.0 native px/patch — 1022 just costs 3.3x more
+  (attention is quadratic in tokens per tile, while total tokens across the
+  plate are roughly fixed). Smaller is cheaper at equal fidelity; raising it
+  buys no extra detail.
 
 ## Pipeline Integration
 

--- a/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
+++ b/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
@@ -1431,12 +1431,17 @@ On `Sam2Detector`:
 
 ```python
     box_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
-    # 1 crop layer = 5 encoder passes (1 full image + 2**(1+1)**2 = 4 crops).
-    # Engages SAM2's edge rejection, crop overlap, full-image fallback, and
-    # resolution-preferring NMS. ~3.91 -> ~1.9 native px per encoder px on a
-    # 4000x3000 plate, at ~5x the inference cost.
+    # 1 crop layer = 5 encoder passes: the always-present full-image pass plus
+    # (2 ** 1) ** 2 = 4 crops. Engages SAM2's edge rejection, crop overlap,
+    # full-image fallback, and resolution-preferring NMS. ~3.91 -> ~1.9 native
+    # px per encoder px on a 4000x3000 plate, at ~5x the inference cost.
     crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 1
 ```
+
+**Index carefully.** `**` is right-associative, so `2**(1+1)**2` is `2**((1+1)**2)`
+== 16, not 4. And the loop variable `i_layer` is **0-based**, so `crop_n_layers=1`
+runs `i_layer=0` → `(2**(0+1))**2 == 4` crops. Write the docstring in terms of a
+1-based layer number `n` to avoid the ambiguity entirely.
 
 and forward `box_nms_thresh=self.box_nms_thresh` in `_ensure_model_loaded`.
 
@@ -1449,12 +1454,13 @@ Fix the three docstring defects. Replace the `crop_n_layers` paragraph
             resizes the whole image to a fixed **1024x1024 square** -- a
             non-aspect-preserving squash, so a 4:3 plate enters the model as
             ellipses -- and small colonies on a multi-megapixel plate can be
-            lost to downsampling.  ``0`` keeps a single full-image pass; each
-            added layer ``i`` re-tiles the *entire* image into
-            ``(2 ** (i + 1)) ** 2`` overlapping crops (4 at layer 1, 16 at
-            layer 2), each encoded nearer native resolution, and merges them by
-            NMS that prefers masks from smaller crops.  The full-image pass is
-            always included.  Default 1 (5 encoder passes).
+            lost to downsampling.  ``0`` keeps a single full-image pass; the
+            ``n``-th added layer (``n`` = 1, 2, ...) re-tiles the *entire*
+            image into ``(2 ** n) ** 2`` overlapping crops -- 4 at layer 1,
+            16 at layer 2 -- each encoded nearer native resolution, and merges
+            them by NMS that prefers masks from smaller crops.  The full-image
+            pass is always included, so ``crop_n_layers=1`` costs 5 encoder
+            passes and ``2`` costs 21.  Default 1.
 ```
 
 Add to the `Sam2Detector` docstring's parameter list:

--- a/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
+++ b/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
@@ -1655,8 +1655,10 @@ def evaluate(detector, label: str, *, legacy: bool = False) -> float:
     truth = truth_om > 0
     ctx = legacy_processor_policy() if legacy else contextlib.nullcontext()
     with ctx:
-        detector.apply(image)
-    pred = np.asarray(image.objmask[:])
+        # apply() defaults to inplace=False and returns a COPY. Reading objmask
+        # back off `image` yields 0 objects for every arm.
+        result = detector.apply(image)
+    pred = np.asarray(result.objmask[:])
     iou = mask_iou(pred, truth)
     print(
         f"{label:<40} IoU {iou:.4f}  "

--- a/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
+++ b/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
@@ -48,6 +48,55 @@
 
 ---
 
+## Execution: cluster DAG
+
+Derived from each task's `Files`/`Interfaces` blocks. **Shared-file edges** are what
+constrain parallelism:
+
+- `_dino_support.py` — T1, T2, **T7**
+- `_sam3_detector.py` — **T5**, T6
+
+```
+T1 → T2 → {T3, T4, T7}
+T5 → {T6, T7}
+T8  (independent)
+{T3, T4, T8} → T10 → T9
+```
+
+| # | Tasks | Shape | Files | Model / effort | Depends |
+|---|---|---|---|---|---|
+| **C1** | T1, T2 | Keystone | `_dino_support.py` | Opus, high | — |
+| **C2** | T3, T4 | Leaf-pair | `_fssdino`, `_insid3` | Sonnet, medium | C1 |
+| **C3** | T5 | Keystone | `_tiling.py`, `_sam3` (deletes) | Opus, high | — |
+| **C4** | T6 | **Seam** | `_sam3_detector.py` | Opus, high | C3 |
+| **C5** | T7 | Keystone | `_dino_support`, `_dinosam2` | Opus, high | C1, C3 |
+| **C6** | T8 | Leaf | `_sam2_detector.py` | Sonnet, medium | — |
+| **C7** | T9 | Sweep | docs, tune gate | Sonnet, medium | all code |
+| **C8** | T10 | Gate | `scripts/`, spec | Opus, high | C2, C6 |
+
+**C1 = T1+T2** because T2's `upsample_grid_to_image` is meaningless without T1's
+`covered_hw`; same file, same intent, one reviewable diff.
+
+**C4 is isolated despite being one task** — risk ≠ size. It is the only place the
+objmap coordinate contract flips (full-image-offset → tile-local). A coordinate error
+here is silent and yields plausible-looking objmaps.
+
+**C8 precedes C7** — if the accuracy gate says 1:1 loses, C8 reverts the *defaults*,
+and C7's docs describe those defaults.
+
+**Waves.** Zero-file-overlap sets: wave 1 `{C1, C3, C6}`, wave 2 `{C2, C4, C5}`.
+Agents in a wave run concurrently but **must not run git commands** — the plan's
+per-task commits would contend on one git index. The orchestrator commits each
+cluster after its gate. This supersedes the per-task "Commit" steps below: they
+describe *what* to commit, not who runs it.
+
+**Gates.** Light gate after each cluster (read diff, run that cluster's tests). Deep
+gate after wave 2 over the combined `{C2, C4, C5}` diff with a frontier code-review
+agent. Simplify pass at the end, then `uv run pytest tests/unit/detect/nn`.
+Never review with a model weaker than the implementer.
+
+---
+
 ## Task 1: Native processor kwargs + patch geometry
 
 **Files:**
@@ -1511,18 +1560,68 @@ Tasks 3, 4, and 8 lands regardless; only the defaults are gated.
 
 - [ ] **Step 1: Write the gate script**
 
-```python
-"""Measure objmask IoU against synth_plate's 96 ground-truth colonies.
+Two traps this script has to avoid, both discovered while drafting it:
 
-Run before/after the resolution fixes to decide whether the new tile_px and
-crop_n_layers defaults ship. Spec: docs/superpowers/specs/2026-07-08-gpu-detect-fixes/
+1. **After the fix, `tile_px` no longer controls resolution** — that is the finding.
+   Comparing `tile_px=512` vs `518` on the fixed code measures nothing; both give
+   14.0 px/patch. The real before/after is the **processor policy**: the 224
+   classification preset versus native geometry. The baseline is produced by
+   monkeypatching `NATIVE_PROCESSOR_KWARGS` to `{}`.
+2. **`synth_plate` is 600×800, smaller than SAM2's 1024 encoder**, so SAM2 *upsamples*
+   it and the crop pyramid has no downsampling to recover — `crop_n_layers` would
+   measure as noise. The gate builds a larger plate by replicating `synth_plate` 3×4
+   into 1800×3200 with 1152 relabelled ground-truth colonies. Colony sizes are
+   unchanged (32–44 px); only the plate exceeds the encoder, which is the regime the
+   fixes target (1.76× × 3.13× native px per encoder px).
+
+```python
+"""Measure objmask IoU against a synthetic plate with known ground truth.
+
+Decides whether the costly defaults ship: the DINO 1:1 processor policy
+(FssDino, Insid3) and Sam2's crop_n_layers. The code changes land regardless;
+only the defaults are gated.
+
+Spec: docs/superpowers/specs/2026-07-08-gpu-detect-fixes/
+
+Insid3 needs the gated DINOv3 weights:
+    PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3 uv run python scripts/accuracy_gate_gpu_detectors.py
 """
 
 from __future__ import annotations
 
+import contextlib
+
 import numpy as np
 
+from phenotypic import Image
 from phenotypic.data import load_synth_yeast_plate
+
+
+def tiled_plate(rows: int = 3, cols: int = 4) -> tuple[Image, np.ndarray]:
+    """Replicate synth_plate into a plate larger than SAM2's 1024 encoder.
+
+    Colony diameters stay 32-44 px; only the plate grows, so the detectors face
+    real downsampling instead of upsampling. Labels are offset per block so the
+    ground truth stays instance-correct.
+
+    Returns:
+        ``(Image, truth_objmap)`` — the image carries only RGB.
+    """
+    src = load_synth_yeast_plate()
+    rgb = np.asarray(src.rgb[:])
+    om = np.asarray(src.objmap[:])
+    h, w = om.shape
+    n = int(om.max())
+
+    big_om = np.zeros((h * rows, w * cols), dtype=np.uint16)
+    k = 0
+    for r in range(rows):
+        for c in range(cols):
+            blk = om.astype(np.uint16).copy()
+            blk[blk > 0] += k
+            big_om[r * h:(r + 1) * h, c * w:(c + 1) * w] = blk
+            k += n
+    return Image(np.tile(rgb, (rows, cols, 1))), big_om
 
 
 def mask_iou(pred: np.ndarray, truth: np.ndarray) -> float:
@@ -1532,28 +1631,63 @@ def mask_iou(pred: np.ndarray, truth: np.ndarray) -> float:
     return float((pred & truth).sum() / union) if union else 0.0
 
 
-def evaluate(detector, label: str) -> None:
-    image = load_synth_yeast_plate()
-    truth = np.asarray(image.objmap[:]) > 0
-    n_truth = int(image.num_objects)
+@contextlib.contextmanager
+def legacy_processor_policy():
+    """Restore the pre-fix 224 classification preset for the baseline run."""
+    import phenotypic.detect.nn._dino_support as ds
 
-    detector.apply(image)
+    saved = dict(ds.NATIVE_PROCESSOR_KWARGS)
+    ds.NATIVE_PROCESSOR_KWARGS.clear()
+    try:
+        yield
+    finally:
+        ds.NATIVE_PROCESSOR_KWARGS.update(saved)
+
+
+def evaluate(detector, label: str, *, legacy: bool = False) -> float:
+    image, truth_om = tiled_plate()
+    truth = truth_om > 0
+    ctx = legacy_processor_policy() if legacy else contextlib.nullcontext()
+    with ctx:
+        detector.apply(image)
     pred = np.asarray(image.objmask[:])
+    iou = mask_iou(pred, truth)
     print(
-        f"{label:<34} IoU {mask_iou(pred, truth):.4f}  "
-        f"objects {image.num_objects:>4} / {n_truth}"
+        f"{label:<40} IoU {iou:.4f}  "
+        f"objects {image.num_objects:>5} / {int(truth_om.max())}"
     )
+    return iou
 
 
 if __name__ == "__main__":
-    from phenotypic.detect.nn import FssDinoDetector, Insid3Detector
+    from phenotypic.detect.nn import FssDinoDetector, Insid3Detector, Sam2Detector
 
-    # Baseline reproduces the pre-fix geometry by forcing the old tile_px.
-    evaluate(FssDinoDetector(dino_version=2, dino_size="small", tile_px=512,
-                             device="cpu"), "FssDino  tile_px=512 (old default)")
-    evaluate(FssDinoDetector(dino_version=2, dino_size="small", tile_px=518,
-                             device="cpu"), "FssDino  tile_px=518 (new default)")
+    print("plate: 1800x3200, 1152 ground-truth colonies\n")
+
+    evaluate(FssDinoDetector(dino_version=2, dino_size="small", device="auto"),
+             "FssDino  224 preset (pre-fix)", legacy=True)
+    evaluate(FssDinoDetector(dino_version=2, dino_size="small", device="auto"),
+             "FssDino  1:1 native (post-fix)")
+
+    evaluate(Insid3Detector(dino_size="small", device="auto"),
+             "Insid3   224 preset (pre-fix)", legacy=True)
+    evaluate(Insid3Detector(dino_size="small", device="auto"),
+             "Insid3   1:1 native (post-fix)")
+
+    # Sam2's crop_n_layers is the one costly default with no measurement behind
+    # it — it ships on the strength of SAM2's four documented defenses (edge
+    # rejection, crop overlap, full-image fallback, resolution-preferring NMS),
+    # not on evidence. SAM2 is ungated and installed, so measure it.
+    evaluate(Sam2Detector(model_size="tiny", crop_n_layers=0, device="auto"),
+             "Sam2     crop_n_layers=0 (old default)")
+    evaluate(Sam2Detector(model_size="tiny", crop_n_layers=1, device="auto"),
+             "Sam2     crop_n_layers=1 (new default)")
 ```
+
+This exercises the tiling path too: `_plan_tiles((1800, 3200), 518, 0.15)` returns
+many tiles, so a merge regression would show up as a depressed IoU or a wrong object
+count. It does **not** substitute for Task 5's unit regressions on the fragment bug —
+IoU is insensitive to a colony being split into two labels.
 
 - [ ] **Step 2: Run the gate**
 

--- a/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
+++ b/docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md
@@ -1,0 +1,1619 @@
+# GPU Detector Resolution & Tiling Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the DINO-backed GPU detectors from silently downsampling every tile to 224×224, and replace SAM3's fragment-producing tile merge with a centroid-in-core assignment that cannot duplicate or delete colonies.
+
+**Architecture:** Two shared modules absorb the policy so detectors get thinner, not fatter. `_dino_support.py` becomes the single resize policy (`NATIVE_PROCESSOR_KWARGS` + a grid↔image geometry pair that always uses the *covered* extent `hp*patch × wp*patch`). `_tiling.py` becomes the single tiling policy (owns the instance merge, which currently lives in `_sam3_detector.py`). Detectors then only choose `tile_px` and call into these.
+
+**Tech Stack:** Python 3.12, pydantic v2 operations, `transformers` (DINOv2/DINOv3), `sam2`, numpy, scikit-image, pytest. Runner is `uv`.
+
+## Global Constraints
+
+- **`uv` is the sole runner.** Never bare `python`/`pip`. Test env: `uv sync --group dev --extra foundation`.
+- **Operations are pydantic v2 models.** Keyword-only construction, class-level annotated fields, no `__init__`. Normalize in a `field_validator`.
+- **Every new numeric field needs `Annotated[T, TuneSpec(lo, hi)]` or `TuneSpec(tunable=False)`**, or the coverage gate against `tests/fixtures/tune/annotation_allowlist.json` fails.
+- **Resolution invariant:** under 1:1, native px per patch `== patch_size`, independent of `tile_px`. `tile_px` is a compute/context knob only, and **smaller is cheaper at equal fidelity**.
+- **DINOv2 is patch 14 / 0 registers; DINOv3 is patch 16 / 4 registers.** Never hardcode 14 or 16 — read `model.config.patch_size`.
+- **`config.image_size` is not a native-resolution signal** (DINOv2 → 518, DINOv3 → 224). Do not use it to pick defaults.
+- **Semantic tiling (`stitch_semantic_tiles`) is already correct.** Do not apply instance-merge or edge logic to it.
+- Google-style docstrings; doctests must run against `load_synth_yeast_plate()` (600×800, 96 ground-truth colonies).
+- Commit after every task.
+
+---
+
+## File Structure
+
+**Modified:**
+- `src/phenotypic/detect/nn/_dino_support.py` — resize policy + grid geometry. Gains `NATIVE_PROCESSOR_KWARGS`, `patch_grid_hw`, `covered_hw`, `upsample_grid_to_image`, `pool_prototype_tiled`. Existing `resize_mask_to_grid`, `align_mask_to_grid`, `cosine_match_to_mask`, `pool_prototype` gain a `patch` parameter.
+- `src/phenotypic/detect/nn/_tiling.py` — tiling policy. Gains `_iou`, `_merge_tiles_iou_nms` (moved in), `tile_overlap_px`, `owning_tile_index`, `assign_by_centroid_core`.
+- `src/phenotypic/detect/nn/_sam3_detector.py` — merge moves out; switches to centroid-in-core.
+- `src/phenotypic/detect/nn/_fssdino_detector.py` — `tile_px` default, `_segment_crop` upsample.
+- `src/phenotypic/detect/nn/_insid3_detector.py` — `tile_px` default, patch threading.
+- `src/phenotypic/detect/nn/_dinosam2_detector.py` — tiled DINO, `crop_*` pass-through.
+- `src/phenotypic/detect/nn/_sam2_detector.py` — `crop_n_layers` default, `box_nms_thresh`, docstring corrections.
+- `docs/source/how_to/pages/gpu_detection_setup.md` — lines 167, 178, 261, 299.
+
+**Test files:**
+- `tests/unit/detect/nn/test_dino_support.py`
+- `tests/unit/detect/nn/test_tiling.py`
+- `tests/unit/detect/nn/test_sam3_detector.py`
+- `tests/unit/detect/nn/test_fssdino_detector.py`
+- `tests/unit/detect/nn/test_insid3_detector.py`
+- `tests/unit/detect/nn/test_dinosam2_detector.py`
+- `tests/unit/detect/nn/test_sam2_detector.py`
+
+**Created:**
+- `scripts/accuracy_gate_gpu_detectors.py` — measures IoU against `synth_plate` ground truth.
+
+---
+
+## Task 1: Native processor kwargs + patch geometry
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_dino_support.py:154-280`
+- Test: `tests/unit/detect/nn/test_dino_support.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `NATIVE_PROCESSOR_KWARGS: dict[str, bool]`
+  - `patch_grid_hw(pixel_hw: Tuple[int, int], patch: int) -> Tuple[int, int]`
+  - `covered_hw(grid_hw: Tuple[int, int], patch: int) -> Tuple[int, int]`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/unit/detect/nn/test_dino_support.py`:
+
+```python
+class TestPatchGeometry:
+    def test_patch_grid_hw_floors(self):
+        from phenotypic.detect.nn._dino_support import patch_grid_hw
+
+        assert patch_grid_hw((518, 518), 14) == (37, 37)
+        assert patch_grid_hw((512, 512), 14) == (36, 36)
+        assert patch_grid_hw((512, 512), 16) == (32, 32)
+        assert patch_grid_hw((600, 800), 14) == (42, 57)
+
+    def test_covered_hw_is_grid_times_patch(self):
+        from phenotypic.detect.nn._dino_support import covered_hw
+
+        assert covered_hw((37, 37), 14) == (518, 518)
+        assert covered_hw((42, 57), 14) == (588, 798)
+
+    def test_native_kwargs_disable_resize_and_crop(self):
+        from phenotypic.detect.nn._dino_support import NATIVE_PROCESSOR_KWARGS
+
+        assert NATIVE_PROCESSOR_KWARGS == {
+            "do_resize": False,
+            "do_center_crop": False,
+        }
+
+
+class TestProcessorPolicy:
+    def test_extract_patch_features_requests_native_geometry(self):
+        """The three extract_* fns must never let the checkpoint's
+        classification preset (224 center-crop) decide the input size."""
+        import numpy as np
+        import torch
+
+        from phenotypic.detect.nn._dino_support import extract_patch_features
+
+        seen = {}
+
+        class FakeInputs(dict):
+            def to(self, _device):
+                return self
+
+        class FakeProcessor:
+            def __call__(self, images, return_tensors=None, **kwargs):
+                seen.update(kwargs)
+                h, w = images.shape[:2]
+                return FakeInputs({"pixel_values": torch.zeros((1, 3, h, w))})
+
+        class FakeConfig:
+            patch_size = 14
+            num_register_tokens = 0
+
+        class FakeModel:
+            config = FakeConfig()
+
+            def __call__(self, pixel_values=None, **_):
+                hp, wp = 518 // 14, 518 // 14
+                tokens = torch.zeros((1, 1 + hp * wp, 8))
+
+                class Out:
+                    last_hidden_state = tokens
+
+                return Out()
+
+        rgb = np.zeros((518, 518, 3), dtype=np.uint8)
+        dense = extract_patch_features(
+            FakeModel(), FakeProcessor(), rgb, device="cpu"
+        )
+        assert seen == {"do_resize": False, "do_center_crop": False}
+        assert dense.shape == (37, 37, 8)
+```
+
+`FakeInputs` subclasses `dict` because `extract_patch_features` calls `.to(device)`
+on the processor's return value.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dino_support.py::TestPatchGeometry -v`
+Expected: FAIL with `ImportError: cannot import name 'patch_grid_hw'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `_dino_support.py`, after the `_DINOV3_SIZE_TO_REPO` block (line ~40):
+
+```python
+#: Processor kwargs that pin the model input to the tile's native geometry.
+#: Without these, ``AutoImageProcessor`` applies the checkpoint's *classification*
+#: preset — DINOv2 resizes shortest-edge to 256 then center-crops to 224; DINOv3
+#: resizes squarely to 224 — so every tile reaches the ViT at 224x224 regardless
+#: of ``tile_px``. Under these kwargs the patch grid is ``(h // patch, w // patch)``
+#: and native px per patch is exactly ``patch_size``.
+NATIVE_PROCESSOR_KWARGS: dict[str, bool] = {
+    "do_resize": False,
+    "do_center_crop": False,
+}
+
+
+def patch_grid_hw(pixel_hw: Tuple[int, int], patch: int) -> Tuple[int, int]:
+    """Return the ``(Hp, Wp)`` patch grid a ViT produces for ``pixel_hw``.
+
+    Patch embedding is a stride-``patch`` convolution, so it floors: a
+    non-multiple input silently drops up to ``patch - 1`` pixels off the bottom
+    and right. Use :func:`covered_hw` for the extent the grid actually spans.
+
+    Args:
+        pixel_hw: ``(H, W)`` of the tensor handed to the model.
+        patch: ``model.config.patch_size`` (14 for DINOv2, 16 for DINOv3).
+
+    Returns:
+        ``(Hp, Wp)`` patch-grid shape.
+    """
+    return (int(pixel_hw[0]) // int(patch), int(pixel_hw[1]) // int(patch))
+
+
+def covered_hw(grid_hw: Tuple[int, int], patch: int) -> Tuple[int, int]:
+    """Return the pixel extent a ``grid_hw`` patch grid actually covers.
+
+    ``(hp * patch, wp * patch)`` — never the original ``(H, W)``. Mapping a grid
+    onto ``(H, W)`` instead introduces a scale error of up to
+    ``(patch - 1) / H`` (2.0% vertically for a 600-px tile at patch 14).
+
+    Args:
+        grid_hw: ``(Hp, Wp)`` patch grid.
+        patch: ``model.config.patch_size``.
+
+    Returns:
+        ``(Hp * patch, Wp * patch)``.
+    """
+    return (int(grid_hw[0]) * int(patch), int(grid_hw[1]) * int(patch))
+```
+
+Then in **all three** extract functions, replace the processor call at lines 175, 216, 263:
+
+```python
+    inputs = processor(
+        images=rgb_uint8, return_tensors="pt", **NATIVE_PROCESSOR_KWARGS
+    ).to(device)
+```
+
+And in `extract_patch_features`, replace the inline grid computation (line ~183):
+
+```python
+    patch = int(getattr(model.config, "patch_size", 16))
+    grid_hw = patch_grid_hw((in_h, in_w), patch)
+```
+
+Apply the same substitution in `extract_reference_features` and
+`extract_hidden_layer_features`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dino_support.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Verify against the real backbones**
+
+Run:
+
+```bash
+uv run python -c "
+import numpy as np
+from transformers import AutoImageProcessor, AutoModel
+from phenotypic.detect.nn._dino_support import NATIVE_PROCESSOR_KWARGS, patch_grid_hw
+for rid, tile in [('facebook/dinov2-base', 518), ('facebook/dinov3-vitb16-pretrain-lvd1689m', 512)]:
+    p = AutoImageProcessor.from_pretrained(rid); m = AutoModel.from_pretrained(rid)
+    px = p(images=np.zeros((tile,tile,3),dtype=np.uint8), return_tensors='pt', **NATIVE_PROCESSOR_KWARGS)['pixel_values']
+    hw = tuple(px.shape[-2:]); patch = m.config.patch_size
+    print(rid.split('/')[-1], hw, patch_grid_hw(hw, patch), f'{tile/patch_grid_hw(hw,patch)[0]:.1f} px/patch')
+"
+```
+
+Expected:
+```
+dinov2-base (518, 518) (37, 37) 14.0 px/patch
+dinov3-vitb16-pretrain-lvd1689m (512, 512) (32, 32) 16.0 px/patch
+```
+
+If DINOv3 is not downloaded, this step needs `PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3` and an approved HF gate. Skip the DINOv3 half and note it, rather than guessing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_dino_support.py tests/unit/detect/nn/test_dino_support.py
+git commit -m "fix(nn): feed DINO tiles at native geometry, not the 224 classification preset"
+```
+
+---
+
+## Task 2: Covered-extent grid↔image mapping
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_dino_support.py:282-360` (`resize_mask_to_grid`, `align_mask_to_grid`), `:428-464` (`cosine_match_to_mask`), `:361-398` (`pool_prototype`)
+- Test: `tests/unit/detect/nn/test_dino_support.py`
+
+**Interfaces:**
+- Consumes: `patch_grid_hw`, `covered_hw` (Task 1).
+- Produces:
+  - `upsample_grid_to_image(grid, image_hw: Tuple[int, int], patch: int, *, order: int = 0) -> np.ndarray`
+  - `resize_mask_to_grid(mask, grid_hw, patch: int | None = None) -> np.ndarray`
+  - `align_mask_to_grid(mask, proc_hw, grid_hw, patch: int | None = None) -> np.ndarray`
+  - `cosine_match_to_mask(features, prototype, thresh, out_shape, patch: int | None = None) -> np.ndarray`
+  - `pool_prototype(features, mask, proc_hw=None, patch: int | None = None) -> np.ndarray`
+
+`patch` is keyword-with-default `None` on the four existing functions so present callers and tests keep working; `None` reproduces today's whole-extent behaviour. Every in-repo caller passes it.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestCoveredExtentMapping:
+    def test_upsample_grid_preserves_centroid(self):
+        """A disc centred in the grid must stay centred after upsampling.
+
+        Mapping a (42, 57) grid onto a 600x800 tile instead of its covered
+        588x798 extent displaces objects by ~2% vertically.
+        """
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import upsample_grid_to_image
+
+        grid = np.zeros((42, 57), dtype=bool)
+        grid[20:23, 27:30] = True  # centred block
+        gy, gx = np.nonzero(grid)
+        grid_cy = (gy.mean() + 0.5) / 42
+        grid_cx = (gx.mean() + 0.5) / 57
+
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        assert full.shape == (600, 800)
+        fy, fx = np.nonzero(full)
+        assert abs(fy.mean() / 600 - grid_cy) < 0.01
+        assert abs(fx.mean() / 800 - grid_cx) < 0.01
+
+    def test_upsample_pads_the_truncated_remainder(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import upsample_grid_to_image
+
+        grid = np.ones((42, 57), dtype=bool)
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        assert full.shape == (600, 800)
+        assert full.all()  # edge-padded, no False stripe at 588..600
+
+    def test_resize_mask_to_grid_crops_to_covered_extent(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import resize_mask_to_grid
+
+        mask = np.zeros((600, 800), dtype=bool)
+        mask[588:600, :] = True  # lives ONLY in the truncated remainder
+        small = resize_mask_to_grid(mask, (42, 57), patch=14)
+        assert not small.any()  # the ViT never saw those rows
+
+    def test_round_trip_grid_image_grid_is_identity(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import (
+            resize_mask_to_grid,
+            upsample_grid_to_image,
+        )
+
+        rng = np.random.default_rng(0)
+        grid = rng.random((42, 57)) > 0.5
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        back = resize_mask_to_grid(full, (42, 57), patch=14)
+        assert (back == grid).all()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dino_support.py::TestCoveredExtentMapping -v`
+Expected: FAIL with `ImportError: cannot import name 'upsample_grid_to_image'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add after `covered_hw`:
+
+```python
+def upsample_grid_to_image(
+    grid: "np.ndarray",
+    image_hw: Tuple[int, int],
+    patch: int,
+    *,
+    order: int = 0,
+) -> "np.ndarray":
+    """Upsample a patch grid to full resolution through its covered extent.
+
+    The grid spans ``covered_hw(grid.shape, patch)``, **not** ``image_hw``: a
+    stride-``patch`` conv floors, so up to ``patch - 1`` rows/columns at the
+    bottom/right were never seen by the model. Resizing straight to ``image_hw``
+    stretches the grid over pixels it does not describe (a 2.0% vertical scale
+    error for a 600-px tile at patch 14). Resize to the covered extent, then
+    edge-pad the remainder.
+
+    Args:
+        grid: ``(Hp, Wp)`` patch-grid array (boolean mask or float score map).
+        image_hw: ``(H, W)`` of the tile the grid came from.
+        patch: ``model.config.patch_size``.
+        order: Interpolation order — ``0`` (nearest) for masks, ``1`` for
+            score maps.
+
+    Returns:
+        ``(H, W)`` array with ``grid``'s dtype semantics preserved.
+    """
+    import numpy as np
+    from skimage.transform import resize
+
+    h, w = int(image_hw[0]), int(image_hw[1])
+    ch, cw = covered_hw(grid.shape, patch)
+    arr = np.asarray(grid)
+    is_bool = arr.dtype == bool
+
+    covered = resize(
+        arr.astype(np.float32),
+        (ch, cw),
+        order=order,
+        preserve_range=True,
+        anti_aliasing=False,
+    )
+    if (ch, cw) != (h, w):
+        covered = np.pad(
+            covered, ((0, max(0, h - ch)), (0, max(0, w - cw))), mode="edge"
+        )[:h, :w]
+    return (covered > 0.5) if is_bool else covered
+```
+
+Amend `resize_mask_to_grid` to accept `patch` and crop first:
+
+```python
+def resize_mask_to_grid(
+    mask: "np.ndarray", grid_hw: Tuple[int, int], patch: int | None = None
+) -> "np.ndarray":
+    """Downsample a full-resolution boolean mask onto the patch grid.
+
+    Nearest-neighbour (``order=0``) so labels are not interpolated. When
+    ``patch`` is given the mask is first cropped to
+    ``covered_hw(grid_hw, patch)`` — the extent the grid actually describes —
+    so the truncated bottom/right remainder cannot leak into a patch.
+
+    Args:
+        mask: ``(H, W)`` boolean (or 0/1) mask.
+        grid_hw: ``(Hp, Wp)`` target patch grid.
+        patch: ``model.config.patch_size``. When *None*, the whole mask is
+            resized (legacy behaviour; introduces a sub-patch scale error).
+
+    Returns:
+        ``(Hp, Wp)`` boolean mask.
+    """
+    import numpy as np
+    from skimage.transform import resize
+
+    hp, wp = int(grid_hw[0]), int(grid_hw[1])
+    arr = np.asarray(mask)
+    if patch is not None:
+        ch, cw = covered_hw((hp, wp), patch)
+        arr = arr[:ch, :cw]
+    small = (
+        resize(
+            arr.astype(np.float32),
+            (hp, wp),
+            order=0,
+            preserve_range=True,
+            anti_aliasing=False,
+        )
+        > 0.5
+    )
+    return small.astype(bool)
+```
+
+Thread `patch` through `align_mask_to_grid` (final line becomes
+`return resize_mask_to_grid(processed, grid_hw, patch)`), through `pool_prototype`
+(both branches forward `patch`), and rewrite `cosine_match_to_mask`'s upsample:
+
+```python
+    sim = cosine_similarity_map(features, proto)
+    if patch is None:
+        sim_full = resize(
+            sim.astype(np.float32), out_shape, order=1,
+            preserve_range=True, anti_aliasing=False,
+        )
+    else:
+        sim_full = upsample_grid_to_image(
+            sim.astype(np.float32), out_shape, patch, order=1
+        )
+    return (sim_full > thresh).astype(bool)
+```
+
+adding `patch: int | None = None` to its signature and documenting it.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dino_support.py -v`
+Expected: PASS (all classes, including Task 1's)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_dino_support.py tests/unit/detect/nn/test_dino_support.py
+git commit -m "fix(nn): map patch grids through their covered extent, not the full tile"
+```
+
+---
+
+## Task 3: FssDinoDetector — 1:1 tiles
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_fssdino_detector.py:386` (`tile_px`), `:545-572` (`_segment_crop`)
+- Test: `tests/unit/detect/nn/test_fssdino_detector.py`
+
+**Interfaces:**
+- Consumes: `upsample_grid_to_image` (Task 2).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestFssDinoResolution:
+    def test_tile_px_default_is_a_dinov2_patch_multiple(self):
+        from phenotypic.detect.nn import FssDinoDetector
+
+        det = FssDinoDetector()
+        assert det.dino_version == 2
+        assert det.tile_px == 518
+        assert det.tile_px % 14 == 0   # 14 * 37
+
+    def test_segment_crop_upsamples_through_covered_extent(self, monkeypatch):
+        """A 600x800 crop at patch 14 has a (42, 57) grid covering 588x798.
+        The returned mask must be 600x800 with no scale error."""
+        import numpy as np
+
+        from phenotypic.detect.nn import FssDinoDetector
+
+        det = FssDinoDetector(dino_version=2)
+        det._device = "cpu"
+        det._model = type("M", (), {"config": type("C", (), {"patch_size": 14})()})()
+        det._processor = object()
+        det._fg_prototypes = np.ones((1, 4), dtype=np.float64)
+        det._bg_prototypes = np.zeros((1, 4), dtype=np.float64)
+        det._fg_gram = np.eye(4)
+        det._bg_gram = np.eye(4)
+
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.extract_hidden_layer_features",
+            lambda *a, **k: np.ones((42, 57, 4), dtype=np.float32),
+        )
+        out = det._segment_crop(np.zeros((600, 800, 3), dtype=np.uint8))
+        assert out.shape == (600, 800)
+        assert out.dtype == bool
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_fssdino_detector.py::TestFssDinoResolution -v`
+Expected: FAIL — `assert 512 == 518`
+
+- [ ] **Step 3: Write minimal implementation**
+
+At `_fssdino_detector.py:386`:
+
+```python
+    # 518 = 14 * 37 — an exact DINOv2 patch multiple. Under the native
+    # processor kwargs the resolution is pinned at patch_size (14.0 native
+    # px/patch) regardless of tile_px, so this is a COMPUTE choice, not a
+    # fidelity one: 518 and 1022 both give 14.0 px/patch, but 1022 costs 3.3x
+    # more (attention is quadratic in tokens per tile). Smaller wins.
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 518
+```
+
+Rewrite `_segment_crop`'s tail (replacing the `resize(...)` at line 565):
+
+```python
+        grid_mask = assign_foreground(fg_score, bg_score, self.similarity_thresh)
+        patch = int(getattr(self._model.config, "patch_size", 14))
+        return upsample_grid_to_image(
+            grid_mask.astype(bool), (rgb.shape[0], rgb.shape[1]), patch
+        )
+```
+
+and import `upsample_grid_to_image` alongside `extract_hidden_layer_features`.
+
+Add a load-time guard at the end of `_ensure_model_loaded`:
+
+```python
+        patch = int(getattr(self._model.config, "patch_size", 14))
+        if self.tile_px % patch:
+            warnings.warn(
+                f"tile_px={self.tile_px} is not a multiple of the backbone's "
+                f"patch_size={patch}; the ViT will silently drop "
+                f"{self.tile_px % patch} px off each tile's bottom and right. "
+                f"Use {(self.tile_px // patch) * patch}.",
+                UserWarning,
+                stacklevel=2,
+            )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_fssdino_detector.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the functional regression (needs DINOv2, ungated)**
+
+Add to the existing `TestFssDinoFunctionalDinoV2` class (`test_fssdino_detector.py:201`):
+
+```python
+    def test_dense_grid_is_native_not_224(self, synth_plate):
+        """Direct F1 regression: synth_plate is 600x800, so at patch 14 the
+        grid must be (42, 57). Before the fix every tile was squashed to
+        224x224 -> a (16, 16) grid."""
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import extract_patch_features
+        from transformers import AutoImageProcessor, AutoModel
+
+        m = AutoModel.from_pretrained("facebook/dinov2-small").eval()
+        p = AutoImageProcessor.from_pretrained("facebook/dinov2-small")
+        rgb = np.asarray(synth_plate.rgb[:], dtype=np.uint8)
+        dense = extract_patch_features(m, p, rgb, device="cpu")
+        assert dense.shape[:2] == (600 // 14, 800 // 14) == (42, 57)
+```
+
+Run: `uv run pytest tests/unit/detect/nn/test_fssdino_detector.py -v -k Functional`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_fssdino_detector.py tests/unit/detect/nn/test_fssdino_detector.py
+git commit -m "fix(fssdino): 1:1 native tiles (32.0 -> 14.0 native px/patch)"
+```
+
+---
+
+## Task 4: Insid3Detector — 1:1 tiles + gate error
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_insid3_detector.py:266` (`tile_px`), `:409-425` (`_match_crop`)
+- Test: `tests/unit/detect/nn/test_insid3_detector.py`
+
+**Interfaces:**
+- Consumes: `cosine_match_to_mask(..., patch=...)` (Task 2).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestInsid3Resolution:
+    def test_tile_px_default_is_a_dinov3_patch_multiple(self):
+        from phenotypic.detect.nn import Insid3Detector
+
+        det = Insid3Detector()
+        assert det.dino_version == 3
+        assert det.tile_px == 512
+        assert det.tile_px % 16 == 0   # 16 * 32
+
+    def test_match_crop_threads_patch_into_cosine_match(self, monkeypatch):
+        import numpy as np
+
+        from phenotypic.detect.nn import Insid3Detector
+
+        det = Insid3Detector()
+        det._device = "cpu"
+        det._model = type("M", (), {"config": type("C", (), {"patch_size": 16})()})()
+        det._processor = object()
+        det._basis = np.zeros((4, 0))
+        det._prototype = np.ones(4)
+
+        seen = {}
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.extract_patch_features",
+            lambda *a, **k: np.ones((32, 32, 4), dtype=np.float32),
+        )
+
+        def fake_match(features, prototype, thresh, out_shape, patch=None):
+            seen["patch"] = patch
+            return np.zeros(out_shape, dtype=bool)
+
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.cosine_match_to_mask", fake_match
+        )
+        det._match_crop(np.zeros((512, 512, 3), dtype=np.uint8))
+        assert seen["patch"] == 16
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_insid3_detector.py::TestInsid3Resolution -v`
+Expected: FAIL — `assert 1024 == 512`
+
+- [ ] **Step 3: Write minimal implementation**
+
+At `_insid3_detector.py:266`:
+
+```python
+    # 512 = 16 * 32 — an exact DINOv3 patch multiple. Resolution is pinned at
+    # patch_size (16.0 native px/patch) regardless of tile_px, so this is a
+    # COMPUTE choice: 512 and 1024 both give 16.0 px/patch, but 1024 costs
+    # 2.6x more. NOTE: DINOv3's config.image_size reports 224 (a classification
+    # preset) and must NOT be used to pick this default.
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 512
+```
+
+In `_match_crop`, thread the patch size:
+
+```python
+        patch = int(getattr(self._model.config, "patch_size", 16))
+        return cosine_match_to_mask(
+            feats_deb,
+            self._prototype,
+            thresh=self.similarity_thresh,
+            out_shape=(rgb.shape[0], rgb.shape[1]),
+            patch=patch,
+        )
+```
+
+Add the same non-multiple `warnings.warn` guard as Task 3 to `_ensure_model_loaded`
+(default `patch` fallback `16`).
+
+Raise the DINOv3 gate error at construction rather than first `apply()` — add to
+`Insid3Detector`:
+
+```python
+    @field_validator("dino_version")
+    @classmethod
+    def _warn_gated_default(cls, v: int) -> int:
+        """DINOv3 is gated; surface that at construction, not at first apply()."""
+        if v == 3:
+            warnings.warn(
+                "Insid3Detector defaults to dino_version=3 (DINOv3), whose "
+                "weights are gated: request access at "
+                "https://huggingface.co/facebook/dinov3-vitb16-pretrain-lvd1689m, "
+                "run `uv run hf auth login`, and set "
+                "PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3. "
+                "Pass dino_version=2 for the ungated DINOv2 backbone.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return v
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_insid3_detector.py -v`
+Expected: PASS. Existing construction tests may now emit the gate warning — if any
+assert on `pytest.warns(None)` or run under `-W error`, wrap those constructions in
+`pytest.warns(UserWarning)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_insid3_detector.py tests/unit/detect/nn/test_insid3_detector.py
+git commit -m "fix(insid3): 1:1 native tiles (73.1 -> 16.0 native px/patch); surface the DINOv3 gate at construction"
+```
+
+---
+
+## Task 5: `_tiling.py` — centroid-in-core instance merge
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_tiling.py`
+- Modify: `src/phenotypic/detect/nn/_sam3_detector.py:27-93` (remove `_iou`, `_merge_tiles_iou_nms`)
+- Test: `tests/unit/detect/nn/test_tiling.py`
+
+**Interfaces:**
+- Consumes: `_Tile`, `_plan_tiles` (existing).
+- Produces:
+  - `_iou(mask_a, mask_b) -> float` (moved verbatim)
+  - `_merge_tiles_iou_nms(objmaps: List[np.ndarray], iou_thresh: float) -> np.ndarray` (moved verbatim; retained for the single-tile relabel path)
+  - `tile_overlap_px(tiles: List[_Tile]) -> int`
+  - `owning_tile_index(tiles: List[_Tile], centroid_yx: Tuple[float, float]) -> int`
+  - `assign_by_centroid_core(tiles: List[_Tile], tile_objmaps: List[np.ndarray], out_shape: Tuple[int, int]) -> np.ndarray`
+
+`tile_objmaps[i]` is **tile-local**, shape `(tiles[i].h, tiles[i].w)`. This differs
+from `_merge_tiles_iou_nms`, which takes full-image-offset objmaps.
+
+**Why not port SAM2's `is_box_near_crop_edge`:** edge rejection requires
+`overlap_px >= d + 2*atol` or the colony is rejected from *every* tile and vanishes.
+SAM2 survives this only because its pyramid always runs a full-image layer 0 and its
+`1/box_area` NMS outvotes that coarse copy. Uniform tiles have neither. At
+`tile_px=512, overlap=0.15, atol=20` the safe diameter is 37 px while `synth_plate`'s
+median colony is 39 px.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestAssignByCentroidCore:
+    def _two_tiles(self):
+        from phenotypic.detect.nn._tiling import _Tile
+        # 100x180 image, two 100x100 tiles overlapping by 20 px.
+        return [_Tile(0, 0, 100, 100), _Tile(0, 80, 100, 180)]
+
+    def test_fragment_regression_one_colony_stays_one(self):
+        """A colony fully inside tile A also appears as a fragment in tile B.
+        Under _merge_tiles_iou_nms(iou_thresh=0.5) the fragment survives
+        (IoU == area fraction) and paints OVER the colony. Centroid-in-core
+        must yield exactly one instance with its area intact."""
+        import numpy as np
+
+        from phenotypic.detect.nn._tiling import assign_by_centroid_core
+
+        tiles = self._two_tiles()
+        # Colony spans image cols 70..90 -> inside A (0..100); B (80..180)
+        # sees only cols 80..90 as a fragment.
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[40:60, 70:90] = 1                      # whole, tile-local
+        b = np.zeros((100, 100), dtype=np.uint16)
+        b[40:60, 0:10] = 1                       # fragment, tile-local
+
+        merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        labels = [l for l in np.unique(merged) if l]
+        assert len(labels) == 1
+        assert int((merged == labels[0]).sum()) == 20 * 20
+
+    def test_instance_claimed_by_exactly_one_tile(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._tiling import assign_by_centroid_core
+
+        tiles = self._two_tiles()
+        # Colony wholly inside the overlap band, cols 82..88: both tiles see it whole.
+        a = np.zeros((100, 100), dtype=np.uint16); a[10:20, 82:88] = 1
+        b = np.zeros((100, 100), dtype=np.uint16); b[10:20, 2:8] = 1
+        merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        assert len([l for l in np.unique(merged) if l]) == 1
+
+    def test_single_tile_relabels_contiguously(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._tiling import _Tile, assign_by_centroid_core
+
+        t = [_Tile(0, 0, 50, 50)]
+        om = np.zeros((50, 50), dtype=np.uint16)
+        om[5:10, 5:10] = 7
+        om[20:25, 20:25] = 9
+        merged = assign_by_centroid_core(t, [om], (50, 50))
+        assert sorted(int(l) for l in np.unique(merged) if l) == [1, 2]
+
+    def test_overlap_guard_warns_when_colony_exceeds_overlap(self):
+        import numpy as np
+        import pytest
+
+        from phenotypic.detect.nn._tiling import assign_by_centroid_core
+
+        tiles = self._two_tiles()          # overlap_px == 20
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[10:70, 30:90] = 1                # d == 60 > 20
+        b = np.zeros((100, 100), dtype=np.uint16)
+        with pytest.warns(UserWarning, match="overlap"):
+            merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        assert len([l for l in np.unique(merged) if l]) == 1   # not deleted
+
+
+class TestTileOverlapPx:
+    def test_overlap_of_two_tiles(self):
+        from phenotypic.detect.nn._tiling import _Tile, tile_overlap_px
+
+        assert tile_overlap_px([_Tile(0, 0, 100, 100), _Tile(0, 80, 100, 180)]) == 20
+
+    def test_single_tile_has_no_overlap(self):
+        from phenotypic.detect.nn._tiling import _Tile, tile_overlap_px
+
+        assert tile_overlap_px([_Tile(0, 0, 10, 10)]) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_tiling.py -v`
+Expected: FAIL with `ImportError: cannot import name 'assign_by_centroid_core'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Move `_iou` and `_merge_tiles_iou_nms` verbatim from `_sam3_detector.py:27-93` into
+`_tiling.py` (change the warning text `"SAM3 merged"` → `"Tiled merge kept"`), and
+add:
+
+```python
+def tile_overlap_px(tiles: List[_Tile]) -> int:
+    """Smallest overlap in pixels between any two overlapping tiles.
+
+    Zero when a single tile covers the image. This is the bound that decides
+    whether a colony can be lost: an instance wider than the overlap is cleaved
+    in every tile that contains it.
+
+    Args:
+        tiles: Crop rectangles from :func:`_plan_tiles`.
+
+    Returns:
+        Minimum positive pairwise overlap along either axis, or ``0``.
+    """
+    if len(tiles) < 2:
+        return 0
+    best: int | None = None
+    for i, a in enumerate(tiles):
+        for b in tiles[i + 1:]:
+            oy = min(a.y1, b.y1) - max(a.y0, b.y0)
+            ox = min(a.x1, b.x1) - max(a.x0, b.x0)
+            if oy > 0 and ox > 0:  # genuinely overlapping, not merely abutting
+                cand = min(oy, ox)
+                best = cand if best is None else min(best, cand)
+    return int(best) if best is not None else 0
+
+
+def owning_tile_index(
+    tiles: List[_Tile], centroid_yx: tuple[float, float]
+) -> int:
+    """Index of the tile whose *core* contains ``centroid_yx``.
+
+    A tile's core is the region closer to its centre than to any other tile's
+    centre — a Voronoi partition of the tile centres, intersected with the tile.
+    Since :func:`_plan_tiles` guarantees the tiles cover the image, every point
+    lies in at least one tile, and the nearest-centre rule picks exactly one.
+    Border tiles' cores therefore reach the image edge with no gap.
+
+    This is what makes cross-tile duplicates impossible: a colony fully inside
+    one tile is claimed by whichever core holds its true centroid; the same
+    colony's *fragment* in a neighbouring tile has a centroid pushed within
+    ``d/2`` of that tile's edge, while the core begins ``overlap_px / 2`` inside
+    it — so when ``overlap_px >= d`` the fragment is never claimed.
+
+    Args:
+        tiles: Crop rectangles from :func:`_plan_tiles`.
+        centroid_yx: ``(y, x)`` in full-image coordinates.
+
+    Returns:
+        Index into *tiles*.
+    """
+    cy, cx = float(centroid_yx[0]), float(centroid_yx[1])
+    best_i, best_d = 0, None
+    for i, t in enumerate(tiles):
+        if not (t.y0 <= cy < t.y1 and t.x0 <= cx < t.x1):
+            continue
+        ty = (t.y0 + t.y1) / 2.0
+        tx = (t.x0 + t.x1) / 2.0
+        d = (cy - ty) ** 2 + (cx - tx) ** 2
+        if best_d is None or d < best_d:
+            best_i, best_d = i, d
+    return best_i
+
+
+def assign_by_centroid_core(
+    tiles: List[_Tile],
+    tile_objmaps: List["np.ndarray"],
+    out_shape: tuple[int, int],
+) -> "np.ndarray":
+    """Merge tile-local instance maps by centroid-in-core assignment.
+
+    Each instance is kept by exactly the one tile whose core contains its
+    centroid (:func:`owning_tile_index`); every other copy is discarded. No NMS,
+    no edge tolerance, no duplicates by construction. Fragments are dropped
+    because nobody claims them.
+
+    Contrast :func:`_merge_tiles_iou_nms`, whose IoU between a whole colony and
+    its cross-tile fragment equals the fragment's area fraction ``f`` — so every
+    fragment with ``f <= iou_thresh`` survives and, being painted later in the
+    largest-first order, overwrites the colony it came from.
+
+    Survivors are relabelled ``1..N`` largest-first, matching
+    :func:`_merge_tiles_iou_nms`.
+
+    Args:
+        tiles: Crop rectangles in full-image coordinates.
+        tile_objmaps: Per-tile uint16 objmaps, each ``(tile.h, tile.w)``,
+            **tile-local** (not offset).
+        out_shape: ``(H, W)`` of the full image.
+
+    Returns:
+        A full-image uint16 objmap with contiguous labels ``1..N``.
+
+    Raises:
+        ValueError: If *tiles* and *tile_objmaps* differ in length.
+
+    Warns:
+        UserWarning: When the largest retained instance is wider than
+            :func:`tile_overlap_px` — the condition under which a colony can be
+            cleaved in every tile and lost.
+    """
+    import warnings
+
+    import numpy as np
+
+    if len(tiles) != len(tile_objmaps):
+        raise ValueError(
+            f"assign_by_centroid_core: {len(tiles)} tiles vs "
+            f"{len(tile_objmaps)} objmaps"
+        )
+
+    kept: list["np.ndarray"] = []
+    for i, (tile, om) in enumerate(zip(tiles, tile_objmaps)):
+        om = np.asarray(om)
+        for label in np.unique(om):
+            if label == 0:
+                continue
+            local = om == label
+            ys, xs = np.nonzero(local)
+            cy = ys.mean() + tile.y0
+            cx = xs.mean() + tile.x0
+            if owning_tile_index(tiles, (cy, cx)) != i:
+                continue
+            full = np.zeros(out_shape, dtype=bool)
+            full[tile.y0:tile.y1, tile.x0:tile.x1] = local
+            kept.append(full)
+
+    if not kept:
+        return np.zeros(out_shape, dtype=np.uint16)
+
+    kept.sort(key=lambda m: int(m.sum()), reverse=True)
+
+    overlap = tile_overlap_px(tiles)
+    if overlap:
+        ys, xs = np.nonzero(kept[0])
+        d = max(ys.max() - ys.min() + 1, xs.max() - xs.min() + 1)
+        if d > overlap:
+            warnings.warn(
+                f"Largest instance is {d} px across but tiles overlap by only "
+                f"{overlap} px; an instance wider than the overlap can be "
+                f"cleaved in every tile and lost. Raise tile_overlap.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    max_labels = int(np.iinfo(np.uint16).max)
+    if len(kept) > max_labels:
+        warnings.warn(
+            f"Tiled merge kept {len(kept)} instances, exceeding uint16 range. "
+            f"Only the first {max_labels} (largest) will be labeled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        kept = kept[:max_labels]
+
+    objmap = np.zeros(out_shape, dtype=np.uint16)
+    for idx, mask in enumerate(kept, start=1):
+        objmap[mask] = idx
+    return objmap
+```
+
+Update `_tiling.py`'s module docstring: the instance merge now lives here, not in
+`_sam3_detector.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_tiling.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_tiling.py src/phenotypic/detect/nn/_sam3_detector.py tests/unit/detect/nn/test_tiling.py
+git commit -m "feat(tiling): centroid-in-core instance merge; move IoU-NMS out of _sam3_detector"
+```
+
+---
+
+## Task 6: Sam3Detector — adopt the new merge
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_sam3_detector.py:337-396` (`_infer_batch`), imports at `:14-24`
+- Test: `tests/unit/detect/nn/test_sam3_detector.py:117-137` (existing merge tests import from `_sam3_detector`)
+
+**Interfaces:**
+- Consumes: `assign_by_centroid_core`, `_merge_tiles_iou_nms`, `_plan_tiles`, `_Tile` (Task 5).
+- Produces: nothing downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestSam3UsesCentroidCore:
+    def test_infer_batch_merges_by_centroid_core(self, monkeypatch):
+        """A colony straddling a tile seam must yield one instance, not a
+        colony plus its fragment."""
+        import numpy as np
+
+        from phenotypic.detect.nn import Sam3Detector
+
+        det = Sam3Detector(tile_px=100, tile_overlap=0.2)
+        det._model = object()
+        det._processor = object()
+        monkeypatch.setattr(det, "_ensure_model_loaded", lambda: None)
+
+        # _plan_tiles((100, 180), 100, 0.2) -> [(0,0,100,100), (0,80,100,180)].
+        # Tile 0 sees the whole colony at global cols 70..90; tile 1 sees only
+        # its fragment at global cols 80..90.
+        def fake_forward(crops):
+            out = []
+            for i, c in enumerate(crops):
+                om = np.zeros(c.shape[:2], dtype=np.uint16)
+                if i == 0:
+                    om[40:60, 70:90] = 1     # whole colony, tile-local
+                else:
+                    om[40:60, 0:10] = 1      # fragment, tile-local
+                out.append(om)
+            return out
+
+        monkeypatch.setattr(det, "_forward_tiles", fake_forward)
+        sample = np.zeros((100, 180, 3), dtype=np.uint8)
+        (result,) = det._infer_batch([sample])
+        assert result.shape == (100, 180)
+        labels = [l for l in np.unique(result) if l]
+        assert len(labels) == 1                          # not colony + fragment
+        assert int((result == labels[0]).sum()) == 20 * 20   # area uncorrupted
+```
+
+Also retarget the two existing merge tests (`test_sam3_detector.py:117`, `:129`)
+to import from the new home:
+
+```python
+        from phenotypic.detect.nn._tiling import _merge_tiles_iou_nms
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_sam3_detector.py -v`
+Expected: FAIL — `ImportError: cannot import name '_merge_tiles_iou_nms' from '_sam3_detector'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace `_sam3_detector.py`'s import block:
+
+```python
+from phenotypic.detect.nn._tiling import (
+    _merge_tiles_iou_nms,
+    _plan_tiles,
+    _Tile,
+    _tile_starts,
+    assign_by_centroid_core,
+)
+
+_ = (_Tile, _tile_starts, _merge_tiles_iou_nms)
+```
+
+Rewrite the tail of `_infer_batch` so tile objmaps stay **tile-local** (delete the
+`full = np.zeros(full_shape); full[...] = crop_obj` offsetting loop):
+
+```python
+        # Group tile-local objmaps by sample (no offsetting — the merge does it).
+        per_sample_local: list[list[np.ndarray]] = [[] for _ in batch]
+        cursor = 0
+        for s_idx in range(len(batch)):
+            for _t in plans[s_idx]:
+                per_sample_local[s_idx].append(crop_objmaps[cursor])
+                cursor += 1
+
+        results: list[np.ndarray] = []
+        for s_idx in range(len(batch)):
+            tile_objmaps = per_sample_local[s_idx]
+            if not tile_objmaps:
+                results.append(np.zeros(full_shapes[s_idx], dtype=np.uint16))
+            else:
+                results.append(
+                    assign_by_centroid_core(
+                        plans[s_idx], tile_objmaps, full_shapes[s_idx]
+                    )
+                )
+        return results
+```
+
+`tile_merge_iou` is now unused by this path. Keep the field (removing it would break
+`from_json` on existing payloads) and mark it deprecated in its docstring:
+
+```python
+    # Deprecated: the tiled instance merge is centroid-in-core
+    # (_tiling.assign_by_centroid_core), which needs no IoU threshold. Retained
+    # so existing serialized pipelines keep deserializing.
+    tile_merge_iou: Annotated[float, TuneSpec(0.0, 1.0)] = 0.5
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_sam3_detector.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_sam3_detector.py tests/unit/detect/nn/test_sam3_detector.py
+git commit -m "fix(sam3): merge tiles by centroid-in-core; a seam-straddling colony is no longer split"
+```
+
+---
+
+## Task 7: DinoSam2Detector — tiled DINO + crop pass-through
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_dinosam2_detector.py:250-266` (fields), `:304-318` (`_ensure_model_loaded`), `:328-362` (`_infer_one`)
+- Modify: `src/phenotypic/detect/nn/_dino_support.py` (add `pool_prototype_tiled`)
+- Test: `tests/unit/detect/nn/test_dinosam2_detector.py`
+
+**Interfaces:**
+- Consumes: `extract_patch_features`, `pool_prototype` (Tasks 1–2); `_plan_tiles`, `owning_tile_index` (Task 5).
+- Produces: `pool_prototype_tiled(dense_by_tile: List[np.ndarray], tiles: List[_Tile], mask: np.ndarray, patch: int) -> np.ndarray`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestDinoSam2Tiling:
+    def test_has_tiling_fields(self):
+        from phenotypic.detect.nn import DinoSam2Detector
+
+        det = DinoSam2Detector()
+        assert det.tile_px == 518
+        assert det.tile_overlap == 0.15
+        assert det.crop_n_layers == 1
+
+    def test_pool_prototype_tiled_is_nonzero_for_a_small_colony(self):
+        """F3 regression: on a full plate a 30px colony is 0.16 patches wide,
+        so pool_prototype rounds it to empty and returns a zero vector."""
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import pool_prototype_tiled
+        from phenotypic.detect.nn._tiling import _Tile
+
+        tiles = [_Tile(0, 0, 518, 518)]
+        dense = [np.ones((37, 37, 8), dtype=np.float32)]
+        mask = np.zeros((518, 518), dtype=bool)
+        mask[250:280, 250:280] = True          # 30 px colony
+
+        proto = pool_prototype_tiled(dense, tiles, mask, 14)
+        assert proto.shape == (8,)
+        assert np.any(proto)                   # NOT the zero vector
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dinosam2_detector.py::TestDinoSam2Tiling -v`
+Expected: FAIL — `assert 0 == 518` (no `tile_px` field)
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `_dino_support.py`:
+
+```python
+def pool_prototype_tiled(
+    dense_by_tile: List["np.ndarray"],
+    tiles: List["_Tile"],
+    mask: "np.ndarray",
+    patch: int,
+) -> "np.ndarray":
+    """Pool a full-image mask's prototype from per-tile dense features.
+
+    The mask is assigned to the tile whose core contains its centroid
+    (:func:`~phenotypic.detect.nn._tiling.owning_tile_index`), cropped to that
+    tile, and pooled against that tile's feature grid. Pooling against a
+    full-plate grid instead makes every colony sub-patch — a 30 px colony on a
+    3000x4000 plate spans 0.16 patches — so the mask rounds to empty and
+    :func:`pool_prototype` returns its zero-vector fail-safe for every proposal.
+
+    Args:
+        dense_by_tile: One ``(Hp, Wp, D)`` feature grid per tile.
+        tiles: Crop rectangles, aligned with *dense_by_tile*.
+        mask: ``(H, W)`` boolean mask in full-image coordinates.
+        patch: ``model.config.patch_size``.
+
+    Returns:
+        ``(D,)`` mean-pooled prototype.
+    """
+    import numpy as np
+
+    from phenotypic.detect.nn._tiling import owning_tile_index
+
+    ys, xs = np.nonzero(mask)
+    if ys.size == 0:
+        return np.zeros(dense_by_tile[0].shape[-1], dtype=np.float32)
+    i = owning_tile_index(tiles, (ys.mean(), xs.mean()))
+    t = tiles[i]
+    local = mask[t.y0:t.y1, t.x0:t.x1]
+    return pool_prototype(dense_by_tile[i], local, patch=patch)
+```
+
+Add fields to `DinoSam2Detector` (mirroring `Sam2Detector`):
+
+```python
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 518
+    tile_overlap: Annotated[float, TuneSpec(0.0, 0.4)] = 0.15
+    crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 1
+    crop_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
+    crop_overlap_ratio: Annotated[float, TuneSpec(0.0, 0.5)] = 512 / 1500
+    crop_n_points_downscale_factor: Annotated[int, TuneSpec(1, 2)] = 1
+```
+
+Pass them through at `_dinosam2_detector.py:311`:
+
+```python
+        self._generator = build_sam2_generator(
+            self.sam2_model_size,
+            device=self._device,
+            min_mask_region_area=self.min_proposal_area,
+            crop_n_layers=self.crop_n_layers,
+            crop_nms_thresh=self.crop_nms_thresh,
+            crop_overlap_ratio=self.crop_overlap_ratio,
+            crop_n_points_downscale_factor=self.crop_n_points_downscale_factor,
+        )
+```
+
+Replace the feature extraction in `_infer_one`:
+
+```python
+        from phenotypic.detect.nn._dino_support import (
+            extract_patch_features,
+            pool_prototype_tiled,
+        )
+        from phenotypic.detect.nn._tiling import _plan_tiles
+
+        patch = int(getattr(self._dino_model.config, "patch_size", 14))
+        tiles = _plan_tiles(rgb.shape[:2], self.tile_px, self.tile_overlap)
+        dense_by_tile = [
+            extract_patch_features(
+                self._dino_model,
+                self._dino_processor,
+                rgb[t.y0:t.y1, t.x0:t.x1],
+                device=self._device,
+            )
+            for t in tiles
+        ]
+        features = np.stack(
+            [
+                pool_prototype_tiled(dense_by_tile, tiles, p, patch).astype(np.float64)
+                for p in proposals
+            ]
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_dinosam2_detector.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the functional F3 regression (DINOv2, ungated)**
+
+Add to the DINOv2-guarded functional class:
+
+```python
+    def test_prototypes_are_not_all_zero(self, synth_plate):
+        """Direct F3 regression: before the fix every proposal pooled an empty
+        mask and got the zero vector, so all scores were identical."""
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import (
+            extract_patch_features,
+            pool_prototype_tiled,
+        )
+        from phenotypic.detect.nn._tiling import _plan_tiles
+        from transformers import AutoImageProcessor, AutoModel
+
+        m = AutoModel.from_pretrained("facebook/dinov2-small").eval()
+        p = AutoImageProcessor.from_pretrained("facebook/dinov2-small")
+        rgb = np.asarray(synth_plate.rgb[:], dtype=np.uint8)
+        om = np.asarray(synth_plate.objmap[:])
+
+        tiles = _plan_tiles(rgb.shape[:2], 518, 0.15)
+        dense = [
+            extract_patch_features(m, p, rgb[t.y0:t.y1, t.x0:t.x1], device="cpu")
+            for t in tiles
+        ]
+        protos = [
+            pool_prototype_tiled(dense, tiles, om == lab, 14)
+            for lab in np.unique(om)[1:6]
+        ]
+        assert all(np.any(pr) for pr in protos)
+        assert len({tuple(np.round(pr, 4)) for pr in protos}) > 1
+```
+
+Run: `uv run pytest tests/unit/detect/nn/test_dinosam2_detector.py -v -k Functional`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_dinosam2_detector.py src/phenotypic/detect/nn/_dino_support.py tests/unit/detect/nn/test_dinosam2_detector.py
+git commit -m "fix(dinosam2): tile DINO features; stop pooling every colony into a zero vector"
+```
+
+---
+
+## Task 8: Sam2Detector — engage the crop pyramid
+
+**Files:**
+- Modify: `src/phenotypic/detect/nn/_sam2_detector.py:18-32` (`build_sam2_generator` signature), `:108-280` (docstring + fields), `:284-309` (`_ensure_model_loaded`)
+- Test: `tests/unit/detect/nn/test_sam2_detector.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `build_sam2_generator(..., box_nms_thresh: float = 0.7)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestSam2CropPyramid:
+    def test_crop_pyramid_is_engaged_by_default(self):
+        from phenotypic.detect.nn import Sam2Detector
+
+        det = Sam2Detector()
+        assert det.crop_n_layers == 1
+        assert det.box_nms_thresh == 0.7
+
+    def test_build_sam2_generator_accepts_box_nms_thresh(self):
+        """`box_nms_thresh` dedups the dense point grid's redundant proposals
+        within one crop. SAM2 exposes it; Sam2Detector did not."""
+        import inspect
+
+        from phenotypic.detect.nn._sam2_detector import build_sam2_generator
+
+        sig = inspect.signature(build_sam2_generator)
+        assert "box_nms_thresh" in sig.parameters
+        assert sig.parameters["box_nms_thresh"].default == 0.7
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/detect/nn/test_sam2_detector.py::TestSam2CropPyramid -v`
+Expected: FAIL — `assert 0 == 1`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `box_nms_thresh: float = 0.7` to `build_sam2_generator`'s signature (after
+`stability_score_thresh`), document it, and forward it to
+`SAM2AutomaticMaskGenerator(..., box_nms_thresh=box_nms_thresh, ...)`.
+
+On `Sam2Detector`:
+
+```python
+    box_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
+    # 1 crop layer = 5 encoder passes (1 full image + 2**(1+1)**2 = 4 crops).
+    # Engages SAM2's edge rejection, crop overlap, full-image fallback, and
+    # resolution-preferring NMS. ~3.91 -> ~1.9 native px per encoder px on a
+    # 4000x3000 plate, at ~5x the inference cost.
+    crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 1
+```
+
+and forward `box_nms_thresh=self.box_nms_thresh` in `_ensure_model_loaded`.
+
+Fix the three docstring defects. Replace the `crop_n_layers` paragraph
+(`_sam2_detector.py:155-165`):
+
+```
+        crop_n_layers: Number of additional **crop-pyramid layers** SAM2 runs
+            for higher accuracy on large or dense plates.  SAM2's encoder
+            resizes the whole image to a fixed **1024x1024 square** -- a
+            non-aspect-preserving squash, so a 4:3 plate enters the model as
+            ellipses -- and small colonies on a multi-megapixel plate can be
+            lost to downsampling.  ``0`` keeps a single full-image pass; each
+            added layer ``i`` re-tiles the *entire* image into
+            ``(2 ** (i + 1)) ** 2`` overlapping crops (4 at layer 1, 16 at
+            layer 2), each encoded nearer native resolution, and merges them by
+            NMS that prefers masks from smaller crops.  The full-image pass is
+            always included.  Default 1 (5 encoder passes).
+```
+
+Add to the `Sam2Detector` docstring's parameter list:
+
+```
+        box_nms_thresh: Box-IoU cutoff for non-maximum suppression between the
+            dense point grid's redundant proposals *within* one crop (distinct
+            from ``crop_nms_thresh``, which deduplicates *across* crops).
+            Typical range 0.5--0.9.  Default 0.7 (the SAM2 default).
+```
+
+Update `build_sam2_generator`'s docstring: replace "SAM2's native sliding-window
+crop mechanism" with "SAM2's native crop pyramid", and correct the `crop_n_layers`
+line to `(2 ** (i + 1)) ** 2` crops per layer.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/detect/nn/test_sam2_detector.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Verify the doctest still runs**
+
+Run: `uv run pytest --doctest-modules src/phenotypic/detect/nn/_sam2_detector.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/phenotypic/detect/nn/_sam2_detector.py tests/unit/detect/nn/test_sam2_detector.py
+git commit -m "fix(sam2): engage the crop pyramid by default; expose box_nms_thresh; correct crop-count docs"
+```
+
+---
+
+## Task 9: Tune-gate, docs, changelog
+
+**Files:**
+- Modify: `docs/source/how_to/pages/gpu_detection_setup.md:167,178,261,299`
+- Verify: `tests/fixtures/tune/annotation_allowlist.json`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the annotation-coverage gate**
+
+Run: `uv run pytest tests/unit/tune -v -k "annotation or coverage or ln"`
+Expected: PASS. If it fails, the new numeric fields (`DinoSam2.tile_px`,
+`tile_overlap`, `crop_n_layers`, `crop_nms_thresh`, `crop_overlap_ratio`,
+`crop_n_points_downscale_factor`; `Sam2.box_nms_thresh`) are missing a `TuneSpec`.
+Add the annotation — do **not** add them to the allowlist.
+
+- [ ] **Step 2: Run the full nn suite and mypy**
+
+Run:
+```bash
+uv run pytest tests/unit/detect/nn -v
+uv run mypy src/phenotypic/detect/nn
+uv run ruff check --fix src/phenotypic/detect/nn
+```
+Expected: all pass.
+
+- [ ] **Step 3: Update the how-to page**
+
+At `docs/source/how_to/pages/gpu_detection_setup.md`, replace the four lines:
+
+- line 178: ``- `tile_px` / `tile_overlap` — dense-plate tiling (defaults 1008 / 0.15). Under the native processor geometry the resolution is pinned at the backbone's `patch_size` regardless of `tile_px`, so **larger tiles are slower at identical fidelity** — 1008 and 2016 both give the same px/patch, but 2016 costs ~3x more.``
+- line 261 (`Insid3Detector`): ``- `tile_px` / `tile_overlap` — large-plate tiling (defaults 512 / 0.15). `512 = 16 * 32` is an exact DINOv3 patch multiple. Do not raise it for accuracy; it buys none.``
+- line 299 (`FssDinoDetector`): ``- `tile_px` / `tile_overlap` — large-plate tiling (defaults 518 / 0.15). `518 = 14 * 37` is an exact DINOv2 patch multiple.``
+- line 167: replace the "SAM3 resizes to 1008 internally" claim with "SAM3's internal resize is unverified (`facebook/sam3` is gated); `tile_px=1008` is carried as an assumption."
+
+Add a **Behaviour changes** admonition near the top:
+
+```markdown
+```{warning}
+**Behaviour change (this release).** DINO-backed detectors previously fed every
+tile to the ViT at 224x224 regardless of `tile_px`. They now feed tiles at native
+geometry. Existing pipelines deserialized from JSON keep their pinned `tile_px`
+but **will produce different (higher-resolution) masks**, and cost 6.6x (FssDino)
+to 26x (Insid3) more GPU time. Re-serialize to pick up the new `tile_px` defaults.
+`Sam2Detector`'s `crop_n_layers` default moves 0 -> 1 (~5x cost) for
+newly-constructed detectors only.
+```
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/source/how_to/pages/gpu_detection_setup.md
+git commit -m "docs(gpu): tile_px is a compute knob, not a fidelity knob; record behaviour changes"
+```
+
+---
+
+## Task 10: Accuracy gate
+
+**Files:**
+- Create: `scripts/accuracy_gate_gpu_detectors.py`
+- Modify: `docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md` (Accuracy budget section)
+
+**Interfaces:** none.
+
+This task decides whether the two **costly default changes** ship. The code from
+Tasks 3, 4, and 8 lands regardless; only the defaults are gated.
+
+- [ ] **Step 1: Write the gate script**
+
+```python
+"""Measure objmask IoU against synth_plate's 96 ground-truth colonies.
+
+Run before/after the resolution fixes to decide whether the new tile_px and
+crop_n_layers defaults ship. Spec: docs/superpowers/specs/2026-07-08-gpu-detect-fixes/
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from phenotypic.data import load_synth_yeast_plate
+
+
+def mask_iou(pred: np.ndarray, truth: np.ndarray) -> float:
+    """Foreground IoU of two boolean masks."""
+    pred, truth = pred.astype(bool), truth.astype(bool)
+    union = (pred | truth).sum()
+    return float((pred & truth).sum() / union) if union else 0.0
+
+
+def evaluate(detector, label: str) -> None:
+    image = load_synth_yeast_plate()
+    truth = np.asarray(image.objmap[:]) > 0
+    n_truth = int(image.num_objects)
+
+    detector.apply(image)
+    pred = np.asarray(image.objmask[:])
+    print(
+        f"{label:<34} IoU {mask_iou(pred, truth):.4f}  "
+        f"objects {image.num_objects:>4} / {n_truth}"
+    )
+
+
+if __name__ == "__main__":
+    from phenotypic.detect.nn import FssDinoDetector, Insid3Detector
+
+    # Baseline reproduces the pre-fix geometry by forcing the old tile_px.
+    evaluate(FssDinoDetector(dino_version=2, dino_size="small", tile_px=512,
+                             device="cpu"), "FssDino  tile_px=512 (old default)")
+    evaluate(FssDinoDetector(dino_version=2, dino_size="small", tile_px=518,
+                             device="cpu"), "FssDino  tile_px=518 (new default)")
+```
+
+- [ ] **Step 2: Run the gate**
+
+Run: `uv run python scripts/accuracy_gate_gpu_detectors.py`
+
+Record the actual printed numbers. Do **not** invent them.
+
+- [ ] **Step 3: Decide, and record the decision**
+
+- If the new default's IoU **≥** the old default's: keep the new defaults from
+  Tasks 3, 4, 8.
+- If it is **lower**: revert only the *default values* (`tile_px` back to 512 /
+  1024, `crop_n_layers` back to 0), keep every code change, and record the
+  measurement. The `tile_px` semantics fix stands either way — it makes the
+  parameter mean what its docstring says.
+
+Replace the spec's Accuracy budget placeholder text with a table of the measured
+IoU and object counts, and state which branch was taken.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/accuracy_gate_gpu_detectors.py docs/superpowers/specs/2026-07-08-gpu-detect-fixes/
+git commit -m "test(nn): accuracy gate for the GPU detector resolution fixes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec item | Task |
+|---|---|
+| F1 — `tile_px` inert | 1, 3, 4 |
+| F2 — query-side misregistration + truncation | 2, 3, 4 |
+| F3 — DinoSam2 zero prototypes + `crop_*` pass-through | 7 |
+| F4 — Sam2 crop pyramid off; `box_nms_thresh`; docstring errors | 8 |
+| F5 — Sam3 fragment bug; merge moves to `_tiling` | 5, 6 |
+| `assign_by_centroid_core` + overlap guard | 5 |
+| `tile_px` default rationale (not `config.image_size`) | 3, 4 (comments) |
+| Compatibility: no field removed; `tile_merge_iou` retained | 6 |
+| Tune annotation gate | 9 |
+| Docs lines 167/178/261/299 + behaviour-change notice | 9 |
+| Accuracy budget | 10 |
+| Non-goals: micro_sam, SAM3 `tile_px` verification | untouched by design |
+
+**Known deviations from the spec, discovered while reading the code:**
+
+1. The spec places INSID3's mask upsample in `_insid3_detector.py`. It is actually in
+   the **shared** `cosine_match_to_mask` (`_dino_support.py:428`), so Task 2 fixes it
+   once for both callers rather than per-detector.
+2. The spec's `assign_by_centroid_core` assumed a stride-derived core. `_plan_tiles`
+   does not expose stride, and its last tile is clamped (overlapping more), so cores
+   are defined by **nearest tile centre** (a Voronoi partition of tile centres,
+   intersected with the tiles). This partitions exactly, needs no stride, and handles
+   the clamped border tiles with no gap.
+3. `reject_edge_instances` is **not implemented** — see Task 5's rationale.
+
+**Type consistency:** `patch` is `int` everywhere; `patch_grid_hw`/`covered_hw` both
+take/return `Tuple[int, int]`; `assign_by_centroid_core` takes **tile-local** objmaps
+while `_merge_tiles_iou_nms` takes full-image-offset ones (Task 6 deletes the
+offsetting loop accordingly).

--- a/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
@@ -208,6 +208,50 @@ plate's median colony is 39 px: every median-or-larger colony on a seam would be
 deleted. Sam3's shipped `1008 / 0.15` is safer (111 px) but still fails on sparse
 plates with large colonies.
 
+### F6 — the reference/support path also needed the covered extent (found in review)
+
+F2 said the reference/support path "is already correct" because it threads `proc_hw`.
+That was true **only while the processor resized to 224**. Once `do_resize=False`
+lands, the grid floors and the same truncation appears on the exemplar side. F2 said as
+much — "this applies to **both** directions of the map" — but the implementation
+threaded `patch` through the query path only.
+
+Two call sites omitted it (`patch` is an optional kwarg, so this is a silent scale
+error, not a crash):
+
+- `_fssdino_detector.py:487` — `align_mask_to_grid(mask, proc_hw, (hp, wp))`
+- `_insid3_detector.py:377` — `pool_prototype(ref_deb, ref_mask, proc_hw=ref_proc_hw)`
+
+The bundled exemplar `colony_reference_rgb.png` is **220×300**, a multiple of neither
+patch size:
+
+```
+patch 14: 220 -> 15 patches covering 210 rows (10 dropped, 4.5%)
+patch 16: 220 -> 13 patches covering 208 rows (12 dropped, 5.5%)
+```
+
+So the exemplar mask was stretched over rows the ViT never saw — corrupting **the very
+mask that defines the prototype**. Measured effect on the DINOv3 prototype:
+
+```
+reference grid (13, 18) covers 208x288 of a 220x300 exemplar
+prototype cosine(old_buggy, new_fixed) = 0.4436     (1.0 would mean a no-op)
+```
+
+The two prototypes are nearly unrelated. Effect on the gate plate:
+
+| Arm | buggy reference path | fixed |
+|---|---|---|
+| FssDino 1:1 native | IoU 0.5877, 942 objects | **IoU 0.5947, 962 objects** |
+| Insid3 1:1 native | IoU 0.0043, 103 objects | IoU 0.0000, 9 objects |
+
+FssDino improves on both metrics. Insid3 goes from 103 spurious blobs to 9; both arms
+are noise (IoU ≈ 0), so this is a more specific prototype, not a regression — Insid3's
+`similarity_thresh` problem is unchanged and remains out of scope.
+
+**Pre-existing, out of scope:** `_checkpoint_manager.py:358,528` fail `mypy` standalone
+(`list(cls.MODELS)` against a `Literal` key type). Untouched by this work.
+
 ## Non-goals
 
 - `MicroSamDetector`. `micro_sam` is conda-only and absent from this venv; its

--- a/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
@@ -1,0 +1,433 @@
+# GPU detector resolution & tiling fixes — design
+
+**Date:** 2026-07-08
+**Status:** Design, awaiting review
+**Branch:** `worktree-gpu-detect-fixes`
+
+## Summary
+
+Four defects across the GPU detectors, found while asking a narrower question ("at
+what resolution does SAM2 accept images?"). Three are resolution losses that make
+the DINO-backed detectors decide segmentation on a 14×14 or 16×16 patch grid and
+upsample 32–73×. One is a correctness bug that turns a single colony straddling a
+tile boundary into two objects with corrupted areas.
+
+The headline: **`tile_px` currently has no effect on resolution, and larger values
+make it worse.** Every tile, at every `tile_px`, reaches the ViT as 224×224.
+
+## Evidence
+
+All numbers measured in this worktree (Apple MPS, 3000×4000 plate, `overlap=0.15`),
+not inferred from docstrings.
+
+### Backbone geometry
+
+| | `patch_size` | `config.image_size` | registers | processor default |
+|---|---|---|---|---|
+| `facebook/dinov2-base` | 14 | 518 | 0 | `shortest_edge=256` → center-crop `224` |
+| `facebook/dinov3-vitb16-pretrain-lvd1689m` | 16 | **224** | 4 | resize `{224,224}`, **no center crop** |
+
+### Cost and resolution
+
+```
+strategy                     tiles   proc  tok/tile  s/tile  plate s  px/patch
+FssDino  today  512->224        70    224       257   0.016      1.1      32.0
+FssDino  1:1    tile=518        63    518      1370   0.116      7.3      14.0
+FssDino  1:1    tile=1022       20   1022      5330   1.188     23.8      14.0
+Insid3   today 1024->224        20    224       201   0.012      0.2      73.1
+Insid3   1:1    tile=512        70    512      1029   0.074      5.2      16.0
+Insid3   1:1    tile=1024       20   1024      4101   0.671     13.4      16.0
+```
+
+Two laws fall out:
+
+1. **Under 1:1, `px/patch == patch_size`, independent of `tile_px`.** Resolution is
+   pinned by the architecture. `tile_px` is a compute/context knob, not a fidelity
+   knob.
+2. **Smaller tiles win.** `518` and `1022` deliver identical 14.0 px/patch; `1022`
+   costs 3.3× more (attention is quadratic in tokens *per tile* while total tokens
+   across the plate are ~fixed at `area / patch²`). Same for `512` vs `1024` on v3
+   (2.6×).
+
+Both invert the current `TuneSpec(512, 2048)` bounds and the "higher = better"
+docstrings.
+
+## Findings
+
+### F1 — `tile_px` is inert (FssDino, Insid3, DinoSam2)
+
+`_dino_support.py:175` (and the equivalents in `extract_reference_features` /
+`extract_hidden_layer_features`) call:
+
+```python
+inputs = processor(images=rgb_uint8, return_tensors="pt").to(device)
+```
+
+No `size=`, no `do_center_crop=False`. The checkpoint's classification preset wins,
+so every tile arrives at 224×224. `FssDinoDetector(tile_px=512)` → 32.0 px/patch;
+`Insid3Detector(tile_px=1024)` → 73.1 px/patch. Raising `tile_px` costs 4× the tiles
+to buy *half* the resolution.
+
+### F2 — query-side mask misregistration (FssDino; DinoSam2)
+
+The reference/support path is already correct: `_insid3_detector.py:333-341` and
+`_fssdino_detector.py:460-468` thread `proc_hw` into `pool_prototype` /
+`align_mask_to_grid`. The **query** path does not. `_fssdino_detector.py:565`:
+
+```python
+full = resize(grid_mask.astype(np.float32), (rgb.shape[0], rgb.shape[1]), order=0, ...)
+```
+
+This stretches a grid predicted for the processor's *cropped* view over the whole
+tile. For DINOv2 that view is the central 224 of a 256-resize — an 87.5% crop, so
+objects are displaced radially outward, up to ~6% of tile width at the seams.
+
+**Scope correction:** DINOv3 has `do_center_crop=None` and resizes squarely to
+`{224,224}`, so the squash and its inverse cancel. `Insid3Detector` (v3 default) is
+**not misregistered — only coarse**. F2 affects `FssDinoDetector` and
+`DinoSam2Detector` (both v2 default). The fix must still be version-agnostic since
+`dino_version` is user-settable.
+
+A second, smaller error survives even after removing the resize: a non-multiple size
+truncates. `600 → 42 patches × 14 = 588`, leaving 12 rows uncovered. Mapping the grid
+to `(h, w)` instead of `(hp*patch, wp*patch)` is a 2.0% vertical scale error. This
+applies to **both** directions of the map, so `align_mask_to_grid` needs the same
+treatment as the new upsample helper.
+
+### F3 — `DinoSam2Detector`'s DINO scoring is inert
+
+`_dinosam2_detector.py:348` runs `extract_patch_features(..., rgb)` on the **whole
+plate**: a 16×16 grid over 4000×3000, i.e. 250×187 native px per patch.
+
+```
+colony  30px -> 0.160 x 0.120 patches
+colony  60px -> 0.320 x 0.240 patches
+colony 120px -> 0.640 x 0.480 patches
+```
+
+Colonies are sub-patch. `pool_prototype(dense, p)` is called without `proc_hw`, so the
+mask is "resized straight to the grid" (`_dino_support.py:372`), rounds to empty, and
+returns "a zero vector if the mask is empty". Every proposal scores identically;
+`similarity_thresh` becomes all-or-nothing. The DINO half of DinoSam2 does no work on
+real plates.
+
+Separately, `_dinosam2_detector.py:311` passes only `min_mask_region_area` to
+`build_sam2_generator`, so the SAM2 half silently runs a stock single pass.
+
+### F4 — `Sam2Detector` leaves its own crop pyramid switched off
+
+SAM2's encoder resizes to a fixed **1024×1024 square** (`sam2.1_hiera_*.yaml:
+image_size: 1024`; `sam2/utils/transforms.py:32` `Resize((1024, 1024))`) — a
+non-aspect-preserving squash. On a 4000×3000 plate that is 3.91 × 2.93 native px/px,
+anisotropic 1.33×.
+
+`crop_n_layers` defaults to `0`, so the crop pyramid never runs. That pyramid is four
+stacked defenses, all currently unused:
+
+1. **Edge rejection** — `automatic_mask_generator.py:373` drops masks whose bbox is
+   within `atol=20` px (measured in *original image* coords) of a crop edge, unless
+   that edge is also the image edge (`utils/amg.py:80-90`). `atol` is not a
+   colony-size tolerance: it absorbs **mask-decoder quantization**. SAM2 decodes on a
+   256×256 grid and upsamples, so at a 1024-px crop one decoded pixel is 4 native px
+   and `atol=20` is ~5 decoded pixels of slack. It scales with `tile_px / decoder_grid`,
+   not with `tile_px`.
+2. **Overlap** — `crop_overlap_ratio` default `512/1500 ≈ 0.341` of the short side.
+3. **Full-image fallback** — `generate_crop_boxes` always prepends
+   `[0, 0, im_w, im_h]` (`utils/amg.py:214`).
+4. **Resolution-preferring NMS** — `automatic_mask_generator.py:237-239`:
+   `scores = 1 / box_area(data["crop_boxes"])`, "prefer masks from smaller crops".
+
+`box_nms_thresh` (within-crop dedup, default `0.7`) is not exposed at all.
+
+Docstring errors to fix: `_sam2_detector.py:163` says each layer contributes `2**i`
+crops; the code is `n_crops_per_side = 2**(i+1)` crossed with itself, i.e.
+`(2**(i+1))**2` (4, then 16). The error is inherited verbatim from upstream's own
+docstring. The square-squash is undocumented, and "sliding-window crop" should read
+"crop pyramid" to match upstream vocabulary.
+
+### F5 — `Sam3Detector` fragment bug (correctness, not fidelity)
+
+`_tiling.py` has **no edge rejection** — no `edge`, `border`, or `touch` logic
+anywhere. Uniform tiles also mean SAM2's defenses 3 and 4 are unavailable: no tile is
+smaller than another (so `1/box_area` is a constant), and there is no full-image pass.
+**Edge rejection is therefore the only defense uniform tiling can have, and it is
+absent.**
+
+Consequence. A colony interior to tile A straddles into tile B by area fraction `f`.
+A emits the whole mask (area `A`); B emits the fragment (area `f·A`). Intersection
+`f·A`, union `A`, so **IoU = f**. `_merge_tiles_iou_nms` drops a candidate only when
+`iou > iou_thresh`, and `tile_merge_iou` defaults to `0.5` (`_sam3_detector.py:219`).
+So every fragment with `f ≤ 0.5` survives — and the fragment is by definition the
+smaller side of the cleave, so `f ≤ 0.5` is the common case.
+
+Worse, survivors are painted largest-first, so the **fragment paints over the whole
+colony**. One colony becomes two objects and the real colony's `Size_Area` is
+silently corrupted. `min_mask_region_area` filters only the smallest slivers; the
+`f ∈ [0.2, 0.5]` window sails through.
+
+Semantic tiling is unaffected: `stitch_semantic_tiles` ORs boolean masks, and
+`union(whole, fragment) == whole`. Do **not** apply edge rejection there — it would
+punch holes at seams.
+
+#### Why porting `is_box_near_crop_edge` alone is **not** the fix
+
+Edge rejection trades against overlap. On one axis, with tile size `t`, stride `s`,
+and a colony of diameter `d`, the colony survives in the tile starting at `a` only if
+it is fully inside and at least `atol` from both tile edges:
+
+```
+a + atol ≤ x₀   and   x₁ ≤ a + t - atol
+⟹  x₀ + d + atol - t ≤ a ≤ x₀ - atol
+```
+
+The window of valid tile starts has length `t - d - 2·atol`. A stride-`s` grid is
+guaranteed to land in it only when `t - d - 2·atol ≥ s`, i.e.
+
+> **`overlap_px ≥ d + 2·atol`**
+
+Violate it and the colony is within `atol` of an edge in *every* tile containing it,
+so it is rejected from all of them. It does not become a fragment — **it disappears.**
+
+SAM2's pyramid is immune because layer 0 always sees the whole image and the
+`1/box_area` scoring outvotes that coarse copy when a crop found the colony properly.
+Uniform tiling has **neither** defense: every tile has the same area (so the scoring
+signal is constant) and there is no full-image pass. Porting edge rejection alone
+would convert a visible fragment bug into an invisible missing-colony bug.
+
+Measured against the synth plate (colony diameters 32 / 39 / 44 px, min / median / max):
+
+```
+tile_px=1008 overlap=0.15 -> overlap_px 151 | max safe colony d = 111 px
+tile_px=1024 overlap=0.15 -> overlap_px 154 | max safe colony d = 114 px
+tile_px= 512 overlap=0.15 -> overlap_px  77 | max safe colony d =  37 px  ← median is 39
+tile_px=1008 overlap=0.30 -> overlap_px 302 | max safe colony d = 262 px
+```
+
+At `tile_px=512, overlap=0.15, atol=20` the safe diameter is 37 px while the synth
+plate's median colony is 39 px: every median-or-larger colony on a seam would be
+deleted. Sam3's shipped `1008 / 0.15` is safer (111 px) but still fails on sparse
+plates with large colonies.
+
+## Non-goals
+
+- `MicroSamDetector`. `micro_sam` is conda-only and absent from this venv; its
+  resolution behaviour is unverified. Its unique `input_layer="gray"` default
+  (`_microsam_detector.py:164`) is also out of scope.
+- Verifying `Sam3Detector`'s `tile_px=1008`. `facebook/sam3` returns 403 (gated,
+  access not granted). The value is carried as an assumption.
+- The semantic detectors' downstream issue where OR-then-connectivity-label merges
+  touching colonies into one object.
+
+## Design
+
+### Module boundaries
+
+**`_dino_support.py` — the single resize policy.**
+
+```python
+NATIVE_PROCESSOR_KWARGS = dict(do_resize=False, do_center_crop=False)
+```
+
+Applied in all three `extract_*` functions. (`do_center_crop=False` is a harmless
+no-op for DINOv3, which has none; verified.)
+
+New helpers, so the feature side and the mask side can never disagree:
+
+- `patch_grid_hw(pixel_hw, patch) -> (hp, wp)` — extracted from the inline
+  `in_h // patch` at `_dino_support.py:183`.
+- `upsample_grid_to_image(grid, image_hw, patch)` — resize the grid to
+  `(hp*patch, wp*patch)`, then edge-pad the ≤ `patch-1` truncated rows/columns.
+  Replaces `_fssdino_detector.py:565` and Insid3's equivalent.
+- `align_mask_to_grid` — amended to use the **covered extent** `(hp*patch, wp*patch)`,
+  not the full `(h, w)`.
+- `pool_prototype_tiled(dense_by_tile, tiles, mask, patch)` — pools a proposal's
+  features from the tile(s) covering it (for DinoSam2).
+
+`reshape_patch_tokens` is unchanged but now known to be load-bearing: DINOv3 carries
+4 register tokens. Verified: `forward @512 1:1 -> tokens 1029 == 1 cls + 4 reg + 32²`.
+
+**`_tiling.py` — the single tiling policy.**
+
+- Move `_iou` and `_merge_tiles_iou_nms` in from `_sam3_detector.py`. (`_tiling.py`'s
+  own module docstring already says they belong here.) It is retained for the
+  single-tile relabel path and as the fallback merge.
+- Add `assign_by_centroid_core(objmap, tile, tiles, image_hw)` — **the instance merge
+  policy.** Each tile owns a *core*: its stride window, the region no neighbouring
+  tile's core covers. An instance is kept by exactly the one tile whose core contains
+  its centroid; every other copy is discarded. Border tiles' cores extend to the image
+  edge so nothing falls in a gap.
+
+  No NMS, no `atol`, no duplicates **by construction**. Fragments are dropped because
+  nobody claims them, not because their distance to an edge was measured. The safety
+  condition improves from `overlap_px ≥ d + 2·atol` to `overlap_px ≥ d`, and it is
+  provable: the tile fully containing the colony sees the true centroid, which lies in
+  its core; a tile that cleaves the colony sees a fragment whose centroid is within
+  `d/2` of the tile edge, while that tile's core begins `overlap_px/2 ≥ d/2` inside it,
+  so the fragment is never claimed.
+
+- Add an **overlap guard**: after merging, warn when `overlap_px` is smaller than the
+  largest retained instance's diameter. This is the condition under which a colony can
+  still be lost, and it is measurable at runtime rather than guessed a priori. The
+  current code has no guard at all.
+
+- `stitch_semantic_tiles` unchanged.
+
+`reject_edge_instances` / `atol` are **not** adopted. SAM2's `atol` exists to absorb
+its own decoder quantization, and its edge rejection is safe only because the pyramid
+carries a full-image fallback that uniform tiling lacks (see F5).
+
+Note `_plan_tiles` already emits uniform `tile_px²` tiles whenever an axis exceeds
+`tile_px` (the last start is clamped to `extent - tile_px`, overlapping more rather
+than shrinking). Ragged tiles occur only on the un-tiled path, where an axis is
+shorter than `tile_px` — which is every doctest, since `load_synth_yeast_plate()` is
+600×800.
+
+### Per-operation changes
+
+| Operation | Change | Effect |
+|---|---|---|
+| `FssDinoDetector` | `tile_px: 512 → 518`, `TuneSpec(256, 1024)`; `_segment_crop` uses `upsample_grid_to_image` | 32.0 → 14.0 px/patch; 6.6× cost |
+| `Insid3Detector` | `tile_px: 1024 → 512`, `TuneSpec(256, 1024)`; same upsample fix | 73.1 → 16.0 px/patch; 26× cost |
+| `DinoSam2Detector` | new `tile_px = 518`, `tile_overlap = 0.15`; DINO per tile at 1:1; proposals pooled from covering tile(s); pass the four `crop_*` args through to `build_sam2_generator` and expose them as fields | prototypes stop collapsing to zero |
+| `Sam2Detector` | `crop_n_layers: 0 → 1`; new `box_nms_thresh = 0.7`; docstring corrections (crop count, square squash, "crop pyramid") | 3.91 → ~1.9 px/px; ~5× cost |
+| `Sam3Detector` | import merge from `_tiling`; replace `_merge_tiles_iou_nms` with `assign_by_centroid_core`; add the overlap guard | fragments eliminated without risking colony deletion |
+
+### Choosing the `tile_px` defaults
+
+`config.image_size` is **not** a usable signal: DINOv2 reports `518` (its high-res
+adaptation), DINOv3 reports `224`. Defaulting to it would set Insid3 to exactly the
+broken value.
+
+The defensible basis: resolution is already pinned at `patch_size`, so `tile_px` is
+chosen for compute, and 512 is the cheap end of the curve. Pick the **largest exact
+patch-multiple near 512** for each detector's default `dino_version` — `518 = 14×37`
+for v2, `512 = 16×32` for v3. `patch_size` is unknown until the model loads, so these
+stay per-detector literals, with a **load-time warning** when the user flips
+`dino_version` and leaves `tile_px` non-multiple.
+
+These defaults are a compute choice validated by the accuracy gate below, not a claim
+about model nativeness.
+
+## Compatibility
+
+`to_json()` pins **every** field, including defaults (verified). Existing serialized
+pipelines carry `crop_n_layers: 0`, `tile_px: 512` explicitly and keep them, so **no
+default change can alter a deserialized pipeline**. Adopting the fixes requires
+re-serializing; the changelog must say so.
+
+The `_dino_support` resize fix is code, not a field, so it **does** reach old
+pipelines. A pipeline pinned at `tile_px=512` goes from a 16×16 grid to 36×36 without
+asking. This is a behaviour change, not a bugfix, and belongs under that heading.
+
+No field is removed, so `from_json()` on old payloads never fails. New fields
+(`DinoSam2.tile_px`, `tile_overlap`, the four `crop_*`; `Sam2.box_nms_thresh`) are
+additive and fill from defaults.
+
+Every new numeric field needs a `TuneSpec` (or `TuneSpec(tunable=False)`) or the
+coverage gate against `tests/fixtures/tune/annotation_allowlist.json` fails.
+
+Docs: `docs/source/how_to/pages/gpu_detection_setup.md` is the only file hardcoding
+these numbers — lines 167, 178 (`1008`), 261 (`1024`), 299 (`512`). All four need
+updating, and the "higher = better" framing needs inverting.
+
+## Testing
+
+**Pure functions (no model, fast).**
+
+- `assign_by_centroid_core`: cores partition the image (no gaps, no double-claims);
+  border cores reach the image edge; an instance centred in tile T's core is kept by T
+  and by no other tile.
+- **Fragment regression:** two tiles, whole colony in A, fragment `f=0.3` in B →
+  assert exactly **1** instance, area uncorrupted. Today: 2 instances, colony
+  overpainted.
+- **Colony-deletion regression** (the failure the rejected `atol` design would have
+  introduced): a colony with `d > overlap_px` straddling a seam must still yield ≥ 1
+  instance, and the overlap guard must warn.
+- **Safety bound:** for `overlap_px ≥ d`, a colony swept across every seam offset is
+  retained exactly once at every position.
+- `upsample_grid_to_image`: synthetic disc centroid preserved within 1 px. Today:
+  displaced ~2%.
+- `align_mask_to_grid` round-trip symmetry.
+- `patch_grid_hw` matches the real conv output: 518→37×37, 512→36×36 (v2),
+  600×800→42×57, 512→32×32 (v3).
+
+**Processor policy (fake capturing processor, no download).** Assert `do_resize=False`
+and `do_center_crop=False` reach all three `extract_*` functions.
+
+**Functional (behind the existing `_dinov2_backbone_loadable()` guard at
+`tests/unit/detect/nn/test_fssdino_detector.py:201`, CPU, `dinov2-small`).**
+
+- FssDino on `synth_plate`: dense grid is `(42, 57)`, not `(16, 16)`. Direct F1
+  regression.
+- DinoSam2 on `synth_plate`: pooled prototypes neither all-zero nor all-identical.
+  Direct F3 regression.
+
+## Accuracy budget
+
+`load_synth_yeast_plate()` is 600×800 and ships a populated ground-truth `objmap` with
+`num_objects == 96`. So accuracy is measurable, not assumed.
+
+**Every accuracy claim in this document is an inference from resolution until this
+gate runs.** We have measured `px/patch`, token counts, and wall-clock — not IoU.
+
+- The three defects (F2, F3, F5) assert correctness via unit tests and make **no
+  accuracy claim**. They ship regardless.
+- The two costly changes — DINO 1:1 (6.6× / 26×) and `crop_n_layers: 0 → 1` (~5×) —
+  ship with the **new defaults only if measured objmask IoU improves** against the 96
+  ground-truth colonies. The code change lands either way (it makes `tile_px` mean
+  what it says); only the default is gated.
+
+Record before/after IoU and colony count for FssDino and Insid3 in this document
+before merge.
+
+## Risks and unverified assumptions
+
+- `Sam3Detector`'s `tile_px = 1008` is unverified; `facebook/sam3` returns 403.
+- `MicroSamDetector` is entirely unverified (conda-only).
+- Compute: FssDino 1.1 → 7.3 s/plate, Insid3 0.2 → 5.2 s/plate on an Apple GPU. A
+  10,000-plate screen goes from ~3 to ~20 GPU-hours. This is an array-job sizing
+  decision, consistent with the project's stated "accuracy over speed" philosophy.
+- `crop_n_layers: 0 → 1` makes every newly-constructed `Sam2Detector` ~5× slower.
+  Changelog: behaviour change.
+- Higher resolution is not monotonically better in principle. DINOv2's 224 preset is
+  where its *classification* head was evaluated; dense-prediction regimes exist where
+  more global context beats more pixels. The accuracy gate exists to catch this.
+- `assign_by_centroid_core` still loses a colony wider than `overlap_px` (no tiling
+  policy can retain one without a full-image fallback). The overlap guard makes this
+  observable; `Sam3Detector`'s default `1008 / 0.15` gives `overlap_px = 151`.
+- `Insid3Detector`'s default `dino_version=3` is gated, so the stock constructor is
+  unusable until Meta approves the user's DINOv3 access request.
+
+## Resolved questions
+
+**1. `Insid3Detector` keeps `dino_version = 3`.** The earlier framing — that its 26×
+cost argued for switching to DINOv2 — rested on a misleading ratio. In absolute terms
+DINOv3 is **cheaper**: 5.2 s/plate (70 tiles × 1029 tok) against FssDino's DINOv2 at
+7.3 s/plate (63 tiles × 1370 tok). The 26× is large only because Insid3's baseline was
+fast *because* it was broken (20 tiles at 224², 73 px/patch). The ratio is the
+misleading statistic; the seconds are the real one.
+
+What remains is a genuine trade, and cost is not part of it. INSID3 is DINOv3-native
+(`_insid3_detector.py:257`) — its defining step removes the positional bias that
+DINOv3's patch features specifically carry, and DINOv3's 4 register tokens are the
+only reason `reshape_patch_tokens`' register-aware slice is exercised at all. The
+price is patch-16's coarser 16.0 px/patch versus DINOv2's 14.0, a gap no `tile_px` can
+close because under 1:1 the resolution *is* the patch size.
+
+The actual problem with the v3 default is neither: **it is gated.** `Insid3Detector()`
+with stock arguments cannot run until Meta approves the user's DINOv3 access request,
+while `FssDinoDetector` defaults to ungated DINOv2 and works immediately. Undocumented.
+Action: document the gate as a first-run requirement and raise a clear error at
+construction rather than at first `apply()`.
+
+**2. `atol` is not adopted.** See F5. It absorbs SAM2's decoder quantization
+(`tile_px / decoder_grid`, ≈5 decoded px), not colony size, and edge rejection is only
+safe alongside a full-image fallback that uniform tiling does not have. The merge
+policy is `assign_by_centroid_core`, which needs no tolerance parameter and relaxes the
+safety bound from `overlap_px ≥ d + 2·atol` to `overlap_px ≥ d`.
+
+## Open questions
+
+1. Should the overlap guard warn, or raise? A colony wider than `overlap_px` is
+   silently at risk under any tiling policy; the guard makes it visible, but a hard
+   failure may be preferable for batch runs.

--- a/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
@@ -364,21 +364,88 @@ and `do_center_crop=False` reach all three `extract_*` functions.
 
 ## Accuracy budget
 
-`load_synth_yeast_plate()` is 600×800 and ships a populated ground-truth `objmap` with
-`num_objects == 96`. So accuracy is measurable, not assumed.
+**Measured.** `scripts/accuracy_gate_gpu_detectors.py` replicates
+`load_synth_yeast_plate()` 3×4 into an 1800×3200 plate with 1152 relabelled
+ground-truth colonies. Colony diameters stay 32–44 px; only the plate grows, so it
+exceeds SAM2's 1024 encoder and the detectors face real downsampling. The pre-fix
+baseline restores the 224 classification preset by emptying `NATIVE_PROCESSOR_KWARGS`
+— after the fix `tile_px` no longer controls resolution, so `512` vs `518` would
+measure nothing. Both arms plan the same 32 tiles; only the per-tile resize differs.
 
-**Every accuracy claim in this document is an inference from resolution until this
-gate runs.** We have measured `px/patch`, token counts, and wall-clock — not IoU.
+Run: `PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3 uv run python
+scripts/accuracy_gate_gpu_detectors.py` (DINO `small`, `device="auto"`, Apple MPS).
 
-- The three defects (F2, F3, F5) assert correctness via unit tests and make **no
-  accuracy claim**. They ship regardless.
-- The two costly changes — DINO 1:1 (6.6× / 26×) and `crop_n_layers: 0 → 1` (~5×) —
-  ship with the **new defaults only if measured objmask IoU improves** against the 96
-  ground-truth colonies. The code change lands either way (it makes `tile_px` mean
-  what it says); only the default is gated.
+| Arm | objmask IoU | objects / 1152 | wall-clock |
+|---|---|---|---|
+| FssDino — 224 preset (pre-fix) | 0.1961 | 31 | 4.4 s |
+| **FssDino — 1:1 native (post-fix)** | **0.5877** | **942** | 2.3 s |
+| Insid3 — 224 preset (pre-fix) | 0.0000 | 0 | 1.2 s |
+| **Insid3 — 1:1 native (post-fix)** | **0.0043** | **103** | 2.0 s |
+| Sam2 — `crop_n_layers=0` (old default) | 0.4076 | 481 | 18.2 s |
+| **Sam2 — `crop_n_layers=1` (new default)** | **0.8722** | **1079** | 152.8 s |
 
-Record before/after IoU and colony count for FssDino and Insid3 in this document
-before merge.
+**Branch taken: the new defaults ship.** Every new default scores ≥ its predecessor,
+so no default is reverted. FssDino (0.1961 → 0.5877, 31 → 942 colonies) and Sam2
+(0.4076 → 0.8722, 481 → 1079 colonies) both improve decisively, and their object
+counts rise toward 1152 rather than overshooting — the gain is recovered colonies, not
+over-segmentation.
+
+**The gate does not validate Insid3's 26× cost.** Insid3 scores near-zero in *both*
+arms; the 0.0000 → 0.0043 delta is noise, not evidence. A follow-up probe with the
+`base` backbone returned **0 objects in both arms**, so the failure is neither a
+backbone-size nor a processor-policy artifact. On the *un*-replicated 600×800 plate
+Insid3 finds 8–9 of 96 colonies at its default `similarity_thresh=0.5`, and its own
+functional test asserts only a *non-empty* mask at a permissive `similarity_thresh=0.0`
+("a plumbing floor, not accuracy"). So Insid3 is weak at its default threshold
+**independently of this change**. That needs its own investigation; it is out of scope
+here.
+
+**The decision rule in the plan was wrong for the DINO arms, and it matters.**
+"If 1:1 loses, revert the default" cannot work: the 6.6× / 26× cost comes from
+`NATIVE_PROCESSOR_KWARGS`, which is **code applied unconditionally**, not from
+`tile_px`. Reverting `Insid3.tile_px` 512 → 1024 would *keep* 1:1 (still 16.0
+px/patch) while quadrupling tile area — 13.4 s/plate instead of 5.2 s. Strictly worse
+on both axes. The only lever that could undo the DINO cost is making the processor
+policy opt-in, which is a code revert, not a default revert.
+
+So Insid3's `tile_px = 512` is kept on **compute and patch-alignment grounds**
+(`512 = 16×32`, exact; and it is the cheap end of a curve where resolution is already
+pinned at `patch_size`), not on accuracy grounds. FssDino exercises the *identical*
+processor-policy code path and improves 3× on IoU, which is the evidence that the
+policy itself is sound.
+
+Caveats on the numbers above:
+
+- **Wall-clock is not cost evidence.** The first `evaluate()` per detector absorbs
+  lazy model construction and MPS warmup, and each detector's pre-fix arm runs first.
+  That is why FssDino's 224 arm (4.4 s) appears *slower* than its 1:1 arm (2.3 s),
+  which contradicts its token counts. The 6.6× / 26× / ~5× cost figures elsewhere in
+  this document come from separate measurements, not this table.
+- **IoU is blind to the fragment bug.** A colony split into two labels preserves the
+  mask union. Task 5's unit regressions cover the tiling merge; this gate does not.
+- Object count is reported alongside IoU precisely because IoU cannot see
+  over-segmentation.
+- **Independently reproduced** by the orchestrator, outside the script, on the two
+  decision-critical detectors. With the backbone warmed first (so wall-clock excludes
+  model load):
+
+  ```
+  FssDino 224 preset (pre-fix)   IoU 0.1961  objects   31 / 1152    1.4s
+  FssDino 1:1 native (post-fix)  IoU 0.5877  objects  942 / 1152    2.5s
+  Sam2    crop_n_layers=0        IoU 0.4076  objects  481 / 1152   28.6s
+  Sam2    crop_n_layers=1        IoU 0.8722  objects 1079 / 1152  149.3s
+  ```
+
+  IoU and object counts match the table exactly. Warmed, FssDino's 1:1 arm is the
+  slower one (1.4 s → 2.5 s), as its token counts predict. Sam2's `crop_n_layers=1`
+  costs **5.2×** here (28.6 s → 149.3 s), close to its 5-encoder-pass prediction.
+- The script's `evaluate()` reads `objmask` from the value **returned** by `apply()`,
+  not from the input image. `apply()` defaults to `inplace=False` and returns a copy;
+  reading the input back yields 0 objects for every arm. The plan's original script had
+  this bug.
+
+The three defects (F2, F3, F5) assert correctness via unit tests, make **no** accuracy
+claim, and ship regardless.
 
 ## Risks and unverified assumptions
 

--- a/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-08-gpu-detect-fixes/2026-07-08-gpu-detect-fixes-design.md
@@ -400,6 +400,17 @@ functional test asserts only a *non-empty* mask at a permissive `similarity_thre
 **independently of this change**. That needs its own investigation; it is out of scope
 here.
 
+**It is not a scale bug.** The 1800×3200 plate is literally 12 copies of the 600×800
+one, so "works small, fails large" would have implied a tiling or coordinate defect.
+It doesn't: Insid3's detection *rate* is the same at both scales — 8 of 96 colonies
+(8.3%) on the small plate, 103 of 1152 (8.9%) on the large one. Per-tile probing
+confirms the behaviour is positional, not size-dependent: some tiles fire (1357, 983
+foreground px), most return 0–21 px. The prototype is unit-norm and the positional
+basis is `(384, 4)` as expected, so the pipeline is wired correctly. What fails is the
+`similarity_thresh = 0.5` cosine floor against a DINOv3-small prototype — the same
+conclusion its own functional test reached when it lowered the floor to `0.0` to get a
+non-empty mask.
+
 **The decision rule in the plan was wrong for the DINO arms, and it matters.**
 "If 1:1 loses, revert the default" cannot work: the 6.6× / 26× cost comes from
 `NATIVE_PROCESSOR_KWARGS`, which is **code applied unconditionally**, not from

--- a/scripts/accuracy_gate_gpu_detectors.py
+++ b/scripts/accuracy_gate_gpu_detectors.py
@@ -1,0 +1,127 @@
+"""Measure objmask IoU against a synthetic plate with known ground truth.
+
+Decides whether the costly defaults ship: the DINO 1:1 processor policy
+(FssDino, Insid3) and Sam2's crop_n_layers. The code changes land regardless;
+only the defaults are gated.
+
+Spec: docs/superpowers/specs/2026-07-08-gpu-detect-fixes/
+
+Insid3 needs the gated DINOv3 weights:
+    PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3 uv run python scripts/accuracy_gate_gpu_detectors.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import time
+
+import numpy as np
+
+from phenotypic import Image
+from phenotypic.data import load_synth_yeast_plate
+
+
+def tiled_plate(rows: int = 3, cols: int = 4) -> tuple[Image, np.ndarray]:
+    """Replicate synth_plate into a plate larger than SAM2's 1024 encoder.
+
+    Colony diameters stay 32-44 px; only the plate grows, so the detectors face
+    real downsampling instead of upsampling. Labels are offset per block so the
+    ground truth stays instance-correct.
+
+    Returns:
+        ``(Image, truth_objmap)`` — the image carries only RGB.
+    """
+    src = load_synth_yeast_plate()
+    rgb = np.asarray(src.rgb[:])
+    om = np.asarray(src.objmap[:])
+    h, w = om.shape
+    n = int(om.max())
+
+    big_om = np.zeros((h * rows, w * cols), dtype=np.uint16)
+    k = 0
+    for r in range(rows):
+        for c in range(cols):
+            blk = om.astype(np.uint16).copy()
+            blk[blk > 0] += k
+            big_om[r * h : (r + 1) * h, c * w : (c + 1) * w] = blk
+            k += n
+    return Image(np.tile(rgb, (rows, cols, 1))), big_om
+
+
+def mask_iou(pred: np.ndarray, truth: np.ndarray) -> float:
+    """Foreground IoU of two boolean masks."""
+    pred, truth = pred.astype(bool), truth.astype(bool)
+    union = (pred | truth).sum()
+    return float((pred & truth).sum() / union) if union else 0.0
+
+
+@contextlib.contextmanager
+def legacy_processor_policy():
+    """Restore the pre-fix 224 classification preset for the baseline run."""
+    import phenotypic.detect.nn._dino_support as ds
+
+    saved = dict(ds.NATIVE_PROCESSOR_KWARGS)
+    ds.NATIVE_PROCESSOR_KWARGS.clear()
+    try:
+        yield
+    finally:
+        ds.NATIVE_PROCESSOR_KWARGS.update(saved)
+
+
+def evaluate(detector, label: str, *, legacy: bool = False) -> float:
+    image, truth_om = tiled_plate()
+    truth = truth_om > 0
+    ctx = legacy_processor_policy() if legacy else contextlib.nullcontext()
+    t0 = time.perf_counter()
+    with ctx:
+        # apply() defaults to inplace=False and returns a copy; reading back
+        # from `image` would measure the empty input objmap.
+        result = detector.apply(image)
+    elapsed = time.perf_counter() - t0
+    pred = np.asarray(result.objmask[:])
+    iou = mask_iou(pred, truth)
+    print(
+        f"{label:<40} IoU {iou:.4f}  "
+        f"objects {result.num_objects:>5} / {int(truth_om.max())}  "
+        f"{elapsed:7.1f}s"
+    )
+    return iou
+
+
+if __name__ == "__main__":
+    from phenotypic.detect.nn import FssDinoDetector, Insid3Detector, Sam2Detector
+
+    print("plate: 1800x3200, 1152 ground-truth colonies\n")
+
+    evaluate(
+        FssDinoDetector(dino_version=2, dino_size="small", device="auto"),
+        "FssDino  224 preset (pre-fix)",
+        legacy=True,
+    )
+    evaluate(
+        FssDinoDetector(dino_version=2, dino_size="small", device="auto"),
+        "FssDino  1:1 native (post-fix)",
+    )
+
+    evaluate(
+        Insid3Detector(dino_size="small", device="auto"),
+        "Insid3   224 preset (pre-fix)",
+        legacy=True,
+    )
+    evaluate(
+        Insid3Detector(dino_size="small", device="auto"),
+        "Insid3   1:1 native (post-fix)",
+    )
+
+    # Sam2's crop_n_layers is the one costly default with no measurement behind
+    # it — it ships on the strength of SAM2's four documented defenses (edge
+    # rejection, crop overlap, full-image fallback, resolution-preferring NMS),
+    # not on evidence. SAM2 is ungated and installed, so measure it.
+    evaluate(
+        Sam2Detector(model_size="tiny", crop_n_layers=0, device="auto"),
+        "Sam2     crop_n_layers=0 (old default)",
+    )
+    evaluate(
+        Sam2Detector(model_size="tiny", crop_n_layers=1, device="auto"),
+        "Sam2     crop_n_layers=1 (new default)",
+    )

--- a/src/phenotypic/detect/nn/_dino_support.py
+++ b/src/phenotypic/detect/nn/_dino_support.py
@@ -58,6 +58,35 @@ NATIVE_PROCESSOR_KWARGS: dict[str, bool] = {
 }
 
 
+def backbone_patch_size(model: Any) -> int:
+    """Return the loaded backbone's ViT patch size, refusing to guess.
+
+    Every geometry helper here needs the patch size, and getting it wrong is a
+    **silent** sub-patch scale error rather than a crash. A ``getattr(...,
+    "patch_size", 14)``-style fallback is therefore worse than useless: DINOv2 is
+    patch-14 and DINOv3 is patch-16, so a per-call-site default can disagree with
+    itself within one run (the detector guessing 14 while this module guesses
+    16). Read it from the model, or fail loudly.
+
+    Args:
+        model: A loaded ``AutoModel`` (DINOv2/DINOv3).
+
+    Returns:
+        ``model.config.patch_size``.
+
+    Raises:
+        ValueError: If the backbone exposes no ``config.patch_size``.
+    """
+    patch = getattr(getattr(model, "config", None), "patch_size", None)
+    if patch is None:
+        raise ValueError(
+            f"{type(model).__name__} exposes no config.patch_size; the patch "
+            "grid cannot be derived and guessing it would silently rescale "
+            "every mask. Load a DINOv2/DINOv3 backbone."
+        )
+    return int(patch)
+
+
 def patch_grid_hw(pixel_hw: Tuple[int, int], patch: int) -> Tuple[int, int]:
     """Return the ``(Hp, Wp)`` patch grid a ViT produces for ``pixel_hw``.
 
@@ -284,7 +313,7 @@ def extract_patch_features(
 
     pixel = inputs["pixel_values"]
     in_h, in_w = int(pixel.shape[-2]), int(pixel.shape[-1])
-    patch = int(getattr(model.config, "patch_size", 16))
+    patch = backbone_patch_size(model)
     grid_hw = patch_grid_hw((in_h, in_w), patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     return reshape_patch_tokens(tokens, grid_hw, n_reg)
@@ -333,7 +362,7 @@ def extract_reference_features(
 
     pixel = inputs["pixel_values"]
     proc_hw = (int(pixel.shape[-2]), int(pixel.shape[-1]))
-    patch = int(getattr(model.config, "patch_size", 16))
+    patch = backbone_patch_size(model)
     grid_hw = patch_grid_hw(proc_hw, patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     feats = reshape_patch_tokens(tokens, grid_hw, n_reg)
@@ -379,7 +408,7 @@ def extract_hidden_layer_features(
 
     pixel = inputs["pixel_values"]
     in_h, in_w = int(pixel.shape[-2]), int(pixel.shape[-1])
-    patch = int(getattr(model.config, "patch_size", 16))
+    patch = backbone_patch_size(model)
     grid_hw = patch_grid_hw((in_h, in_w), patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     return reshape_patch_tokens(tokens, grid_hw, n_reg)
@@ -391,22 +420,27 @@ def extract_hidden_layer_features(
 
 
 def resize_mask_to_grid(
-    mask: "np.ndarray", grid_hw: Tuple[int, int], patch: int | None = None
+    mask: "np.ndarray", grid_hw: Tuple[int, int], patch: int
 ) -> "np.ndarray":
     """Downsample a full-resolution boolean mask onto the patch grid.
 
-    Nearest-neighbour (``order=0``) so labels are not interpolated. When
-    ``patch`` is given the mask is first cropped to
-    ``covered_hw(grid_hw, patch)`` — the extent the grid actually describes —
-    so the truncated bottom/right remainder cannot leak into a patch. The
-    caller is responsible for first aligning the mask to the same geometry the
-    image went through the processor (W4); this is the final patch-grid step.
+    Nearest-neighbour (``order=0``) so labels are not interpolated. The mask is
+    first cropped to ``covered_hw(grid_hw, patch)`` — the extent the grid
+    actually describes — so the truncated bottom/right remainder cannot leak
+    into a patch. The caller is responsible for first aligning the mask to the
+    same geometry the image went through the processor (W4); this is the final
+    patch-grid step.
+
+    ``patch`` is **required**. It was once optional, defaulting to mapping the
+    whole mask, and omitting it produced a silent sub-patch scale error rather
+    than a crash — a bug that reached both the query path and, later, the
+    exemplar path (where the buggy and corrected prototypes had cosine 0.44).
+    Get the value from :func:`backbone_patch_size`.
 
     Args:
         mask: ``(H, W)`` boolean (or 0/1) mask.
         grid_hw: ``(Hp, Wp)`` target patch grid.
-        patch: ``model.config.patch_size``. When *None*, the whole mask is
-            resized (legacy behaviour; introduces a sub-patch scale error).
+        patch: ``model.config.patch_size``.
 
     Returns:
         ``(Hp, Wp)`` boolean mask.
@@ -415,10 +449,8 @@ def resize_mask_to_grid(
     from skimage.transform import resize
 
     hp, wp = int(grid_hw[0]), int(grid_hw[1])
-    arr = np.asarray(mask)
-    if patch is not None:
-        ch, cw = covered_hw((hp, wp), patch)
-        arr = arr[:ch, :cw]
+    ch, cw = covered_hw((hp, wp), patch)
+    arr = np.asarray(mask)[:ch, :cw]
     small = (
         resize(
             arr.astype(np.float32),
@@ -436,7 +468,7 @@ def align_mask_to_grid(
     mask: "np.ndarray",
     proc_hw: Tuple[int, int],
     grid_hw: Tuple[int, int],
-    patch: int | None = None,
+    patch: int,
 ) -> "np.ndarray":
     """Align a full-resolution mask to the patch grid via the processor geometry.
 
@@ -457,8 +489,8 @@ def align_mask_to_grid(
         proc_hw: ``(H_proc, W_proc)`` processed pixel geometry
             (``inputs.pixel_values.shape[-2:]``).
         grid_hw: ``(Hp, Wp)`` patch grid.
-        patch: ``model.config.patch_size``. When *None*, the whole processed
-            mask is resized (legacy behaviour; sub-patch scale error).
+        patch: ``model.config.patch_size`` (**required** — omitting it used to
+            be a silent scale error; see :func:`resize_mask_to_grid`).
 
     Returns:
         ``(Hp, Wp)`` boolean mask aligned with the patch features.
@@ -488,8 +520,9 @@ def align_mask_to_grid(
 def pool_prototype(
     features: "np.ndarray",
     mask: "np.ndarray",
+    *,
+    patch: int,
     proc_hw: Tuple[int, int] | None = None,
-    patch: int | None = None,
 ) -> "np.ndarray":
     """Masked-mean an exemplar prototype from dense patch features.
 
@@ -502,12 +535,13 @@ def pool_prototype(
     Args:
         features: ``(Hp, Wp, D)`` dense patch features.
         mask: ``(Hm, Wm)`` boolean mask (any resolution; resized to the grid).
+        patch: ``model.config.patch_size`` (**required**). The mask is cropped
+            to the extent the grid actually covers before downsampling, so the
+            truncated bottom/right remainder cannot contaminate the prototype.
+            Omitting it was once permitted and silently corrupted the exemplar
+            prototype; see :func:`resize_mask_to_grid`.
         proc_hw: Optional ``(H_proc, W_proc)`` processed geometry for the W4
             two-step alignment (from :func:`extract_reference_features`).
-        patch: ``model.config.patch_size``. Given, the mask is cropped to the
-            extent the grid actually covers before downsampling, so the
-            truncated bottom/right remainder cannot contaminate the prototype.
-            When *None*, the whole extent is used (legacy behaviour).
 
     Returns:
         ``(D,)`` mean-pooled prototype (zero vector if the mask is empty —
@@ -609,47 +643,35 @@ def cosine_match_to_mask(
     prototype: "np.ndarray",
     thresh: float,
     out_shape: Tuple[int, int],
-    patch: int | None = None,
+    patch: int,
 ) -> "np.ndarray":
     """Cosine-match query patches to a prototype → an upsampled boolean mask.
 
-    Computes the per-patch cosine map, bilinearly upsamples it to
-    ``out_shape``, and thresholds at ``thresh``. A zero prototype (empty
-    reference mask) yields an all-False mask (fail-safe).
+    Computes the per-patch cosine map, upsamples it through the extent the grid
+    actually covers (:func:`upsample_grid_to_image`), and thresholds at
+    ``thresh``. A zero prototype (empty reference mask) yields an all-False mask
+    (fail-safe).
 
     Args:
         features: ``(Hp, Wp, D)`` query dense patch features.
         prototype: ``(D,)`` exemplar prototype.
         thresh: Cosine-similarity cutoff (foreground where ``sim > thresh``).
         out_shape: ``(H, W)`` of the full-resolution output mask.
-        patch: ``model.config.patch_size``. Given, the score map is upsampled
-            through the extent the grid actually covers
-            (:func:`upsample_grid_to_image`) rather than stretched over
-            ``out_shape``, which would displace every object by up to
-            ``(patch - 1) / H``. When *None*, the legacy whole-extent stretch
-            is used.
+        patch: ``model.config.patch_size`` (**required**). Stretching the score
+            map over ``out_shape`` instead would displace every object by up to
+            ``(patch - 1) / H``; see :func:`resize_mask_to_grid`.
 
     Returns:
         ``(H, W)`` boolean ``objmask``.
     """
     import numpy as np
-    from skimage.transform import resize
 
     proto = np.asarray(prototype, dtype=np.float64)
     if not np.any(proto):  # degenerate zero-prototype → fail safe
         return np.zeros(out_shape, dtype=bool)
 
     sim = cosine_similarity_map(features, proto)
-    if patch is None:
-        sim_full = resize(
-            sim.astype(np.float32),
-            out_shape,
-            order=1,
-            preserve_range=True,
-            anti_aliasing=False,
-        )
-    else:
-        sim_full = upsample_grid_to_image(
-            sim.astype(np.float32), out_shape, patch, order=1
-        )
+    sim_full = upsample_grid_to_image(
+        sim.astype(np.float32), out_shape, patch, order=1
+    )
     return (sim_full > thresh).astype(bool)

--- a/src/phenotypic/detect/nn/_dino_support.py
+++ b/src/phenotypic/detect/nn/_dino_support.py
@@ -25,11 +25,12 @@ construct and serialise without them.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, List, Tuple
 
 if TYPE_CHECKING:
     import numpy as np
 
+    from phenotypic.detect.nn._tiling import _Tile
     from phenotypic.sdk_.typing_ import DinoSize, DinoVersion
 
 
@@ -526,6 +527,53 @@ def pool_prototype(
     if fg.shape[0] == 0:
         return np.zeros(d, dtype=np.float32)
     return fg.mean(axis=0).astype(np.float32)
+
+
+def pool_prototype_tiled(
+    dense_by_tile: List["np.ndarray"],
+    tiles: List["_Tile"],
+    mask: "np.ndarray",
+    patch: int,
+) -> "np.ndarray":
+    """Pool a full-image mask's prototype from per-tile dense features.
+
+    Pooling every proposal against a **whole-plate** patch grid is a silent
+    no-op: at ``patch=14`` a 4000x3000 plate fed to the ViT at its 224-px
+    classification preset yields a 16x16 grid, i.e. ~250x187 native px per
+    patch, so a 30 px colony spans 0.16 x 0.12 patches. It rounds to empty in
+    :func:`resize_mask_to_grid`, :func:`pool_prototype` hits its zero-vector
+    fail-safe, and *every* proposal gets the same zero prototype — the cosine
+    scores become constant and the DINO half of the recipe does no work.
+
+    Tiling restores sub-patch resolution. The mask is assigned to the tile whose
+    core contains its centroid
+    (:func:`~phenotypic.detect.nn._tiling.owning_tile_index`), cropped to that
+    tile, and pooled against that tile's feature grid, where the colony now
+    spans ``30 / patch`` patches.
+
+    Args:
+        dense_by_tile: One ``(Hp, Wp, D)`` feature grid per tile, aligned with
+            *tiles*.
+        tiles: Crop rectangles in full-image coordinates (from
+            :func:`~phenotypic.detect.nn._tiling._plan_tiles`). A single
+            full-extent tile is fine — the un-tiled path.
+        mask: ``(H, W)`` boolean mask in full-image coordinates.
+        patch: ``model.config.patch_size`` (14 for DINOv2, 16 for DINOv3).
+
+    Returns:
+        ``(D,)`` mean-pooled prototype (zero vector if *mask* is empty).
+    """
+    import numpy as np
+
+    from phenotypic.detect.nn._tiling import owning_tile_index
+
+    ys, xs = np.nonzero(np.asarray(mask, dtype=bool))
+    if ys.size == 0:
+        return np.zeros(dense_by_tile[0].shape[-1], dtype=np.float32)
+    idx = owning_tile_index(tiles, (float(ys.mean()), float(xs.mean())))
+    tile = tiles[idx]
+    local = np.asarray(mask)[tile.y0:tile.y1, tile.x0:tile.x1]
+    return pool_prototype(dense_by_tile[idx], local, patch=patch)
 
 
 def cosine_similarity_map(

--- a/src/phenotypic/detect/nn/_dino_support.py
+++ b/src/phenotypic/detect/nn/_dino_support.py
@@ -13,6 +13,12 @@ token (``[:, 1:, :]``) leaves the 4 register tokens contaminating the patch
 grid; we slice ``[:, 1 + num_register_tokens:, :]`` here, in one place, and
 ``DinoSam2Detector`` calls it too (its buggy private copy is deleted).
 
+It is likewise the single **resize policy**: every extract call pins the model
+input to the tile's native geometry (:data:`NATIVE_PROCESSOR_KWARGS`) instead of
+the checkpoint's 224-px classification preset, and every grid↔image mapping goes
+through the *covered* extent ``hp*patch x wp*patch`` (:func:`covered_hw`,
+:func:`upsample_grid_to_image`) rather than the full tile.
+
 All heavy imports (``torch``, ``transformers``) are **lazy** so detectors
 construct and serialise without them.
 """
@@ -37,6 +43,100 @@ _DINOV3_SIZE_TO_REPO: dict[str, str] = {
     "base": "facebook/dinov3-vitb16-pretrain-lvd1689m",
     "large": "facebook/dinov3-vitl16-pretrain-lvd1689m",
 }
+
+
+#: Processor kwargs that pin the model input to the tile's native geometry.
+#: Without these, ``AutoImageProcessor`` applies the checkpoint's *classification*
+#: preset — DINOv2 resizes shortest-edge to 256 then center-crops to 224; DINOv3
+#: resizes squarely to 224 — so every tile reaches the ViT at 224x224 regardless
+#: of ``tile_px``. Under these kwargs the patch grid is ``(h // patch, w // patch)``
+#: and native px per patch is exactly ``patch_size``.
+NATIVE_PROCESSOR_KWARGS: dict[str, bool] = {
+    "do_resize": False,
+    "do_center_crop": False,
+}
+
+
+def patch_grid_hw(pixel_hw: Tuple[int, int], patch: int) -> Tuple[int, int]:
+    """Return the ``(Hp, Wp)`` patch grid a ViT produces for ``pixel_hw``.
+
+    Patch embedding is a stride-``patch`` convolution, so it floors: a
+    non-multiple input silently drops up to ``patch - 1`` pixels off the bottom
+    and right. Use :func:`covered_hw` for the extent the grid actually spans.
+
+    Args:
+        pixel_hw: ``(H, W)`` of the tensor handed to the model.
+        patch: ``model.config.patch_size`` (14 for DINOv2, 16 for DINOv3).
+
+    Returns:
+        ``(Hp, Wp)`` patch-grid shape.
+    """
+    return (int(pixel_hw[0]) // int(patch), int(pixel_hw[1]) // int(patch))
+
+
+def covered_hw(grid_hw: Tuple[int, int], patch: int) -> Tuple[int, int]:
+    """Return the pixel extent a ``grid_hw`` patch grid actually covers.
+
+    ``(hp * patch, wp * patch)`` — never the original ``(H, W)``. Mapping a grid
+    onto ``(H, W)`` instead introduces a scale error of up to
+    ``(patch - 1) / H`` (2.0% vertically for a 600-px tile at patch 14).
+
+    Args:
+        grid_hw: ``(Hp, Wp)`` patch grid.
+        patch: ``model.config.patch_size``.
+
+    Returns:
+        ``(Hp * patch, Wp * patch)``.
+    """
+    return (int(grid_hw[0]) * int(patch), int(grid_hw[1]) * int(patch))
+
+
+def upsample_grid_to_image(
+    grid: "np.ndarray",
+    image_hw: Tuple[int, int],
+    patch: int,
+    *,
+    order: int = 0,
+) -> "np.ndarray":
+    """Upsample a patch grid to full resolution through its covered extent.
+
+    The grid spans ``covered_hw(grid.shape, patch)``, **not** ``image_hw``: a
+    stride-``patch`` conv floors, so up to ``patch - 1`` rows/columns at the
+    bottom/right were never seen by the model. Resizing straight to ``image_hw``
+    stretches the grid over pixels it does not describe (a 2.0% vertical scale
+    error for a 600-px tile at patch 14). Resize to the covered extent, then
+    edge-pad the remainder.
+
+    Args:
+        grid: ``(Hp, Wp)`` patch-grid array (boolean mask or float score map).
+        image_hw: ``(H, W)`` of the tile the grid came from.
+        patch: ``model.config.patch_size``.
+        order: Interpolation order — ``0`` (nearest) for masks, ``1`` for
+            score maps.
+
+    Returns:
+        ``(H, W)`` array with ``grid``'s dtype semantics preserved.
+    """
+    import numpy as np
+    from skimage.transform import resize
+
+    h, w = int(image_hw[0]), int(image_hw[1])
+    arr = np.asarray(grid)
+    ch, cw = covered_hw(arr.shape[:2], patch)
+    is_bool = arr.dtype == bool
+
+    covered = resize(
+        arr.astype(np.float32),
+        (ch, cw),
+        order=order,
+        preserve_range=True,
+        anti_aliasing=False,
+    )
+    if (ch, cw) != (h, w):
+        covered = np.pad(
+            covered, ((0, max(0, h - ch)), (0, max(0, w - cw))), mode="edge"
+        )[:h, :w]
+    return (covered > 0.5) if is_bool else covered
 
 
 def hf_dino_id(dino_version: "DinoVersion", dino_size: "DinoSize") -> str:
@@ -158,7 +258,9 @@ def extract_patch_features(
 
     Drops the CLS **and** register tokens (the C1 fix) via
     :func:`reshape_patch_tokens`, inferring the patch grid from the processed
-    pixel geometry and ``config.patch_size``.
+    pixel geometry and ``config.patch_size``. The image is fed at its native
+    geometry (:data:`NATIVE_PROCESSOR_KWARGS`), not the checkpoint's 224-px
+    classification preset.
 
     Args:
         model: A loaded ``AutoModel`` (DINOv2/DINOv3) on ``device``.
@@ -172,7 +274,9 @@ def extract_patch_features(
     import numpy as np
     import torch
 
-    inputs = processor(images=rgb_uint8, return_tensors="pt").to(device)
+    inputs = processor(
+        images=rgb_uint8, return_tensors="pt", **NATIVE_PROCESSOR_KWARGS
+    ).to(device)
     with torch.no_grad():
         outputs = model(**inputs)
     tokens = outputs.last_hidden_state[0].detach().cpu().numpy().astype(np.float32)
@@ -180,7 +284,7 @@ def extract_patch_features(
     pixel = inputs["pixel_values"]
     in_h, in_w = int(pixel.shape[-2]), int(pixel.shape[-1])
     patch = int(getattr(model.config, "patch_size", 16))
-    grid_hw = (in_h // patch, in_w // patch)
+    grid_hw = patch_grid_hw((in_h, in_w), patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     return reshape_patch_tokens(tokens, grid_hw, n_reg)
 
@@ -197,8 +301,9 @@ def extract_reference_features(
 
     Like :func:`extract_patch_features` (or :func:`extract_hidden_layer_features`
     when ``layer`` is given) but also returns ``(H_proc, W_proc)`` — the
-    geometry the processor resized the image to — so the caller can align a
+    geometry the processor handed the model — so the caller can align a
     reference/support mask through the same path via :func:`align_mask_to_grid`.
+    Under :data:`NATIVE_PROCESSOR_KWARGS` this equals the input ``(H, W)``.
 
     Args:
         model: A loaded ``AutoModel`` on ``device``.
@@ -213,7 +318,9 @@ def extract_reference_features(
     import numpy as np
     import torch
 
-    inputs = processor(images=rgb_uint8, return_tensors="pt").to(device)
+    inputs = processor(
+        images=rgb_uint8, return_tensors="pt", **NATIVE_PROCESSOR_KWARGS
+    ).to(device)
     with torch.no_grad():
         if layer is None:
             outputs = model(**inputs)
@@ -226,7 +333,7 @@ def extract_reference_features(
     pixel = inputs["pixel_values"]
     proc_hw = (int(pixel.shape[-2]), int(pixel.shape[-1]))
     patch = int(getattr(model.config, "patch_size", 16))
-    grid_hw = (proc_hw[0] // patch, proc_hw[1] // patch)
+    grid_hw = patch_grid_hw(proc_hw, patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     feats = reshape_patch_tokens(tokens, grid_hw, n_reg)
     return feats, proc_hw
@@ -244,7 +351,8 @@ def extract_hidden_layer_features(
 
     Uses ``output_hidden_states=True`` and selects ``hidden_states[layer]``
     (FSSDINO's layer-selection finding — intermediate layers carry stronger
-    semantics than the last). ``layer=-1`` is the last layer.
+    semantics than the last). ``layer=-1`` is the last layer. The image is fed
+    at its native geometry (:data:`NATIVE_PROCESSOR_KWARGS`).
 
     Args:
         model: A loaded ``AutoModel`` (DINOv2/DINOv3) on ``device``.
@@ -260,7 +368,9 @@ def extract_hidden_layer_features(
     import numpy as np
     import torch
 
-    inputs = processor(images=rgb_uint8, return_tensors="pt").to(device)
+    inputs = processor(
+        images=rgb_uint8, return_tensors="pt", **NATIVE_PROCESSOR_KWARGS
+    ).to(device)
     with torch.no_grad():
         outputs = model(**inputs, output_hidden_states=True)
     hidden = outputs.hidden_states[layer]
@@ -269,7 +379,7 @@ def extract_hidden_layer_features(
     pixel = inputs["pixel_values"]
     in_h, in_w = int(pixel.shape[-2]), int(pixel.shape[-1])
     patch = int(getattr(model.config, "patch_size", 16))
-    grid_hw = (in_h // patch, in_w // patch)
+    grid_hw = patch_grid_hw((in_h, in_w), patch)
     n_reg = int(getattr(model.config, "num_register_tokens", 0))
     return reshape_patch_tokens(tokens, grid_hw, n_reg)
 
@@ -280,17 +390,22 @@ def extract_hidden_layer_features(
 
 
 def resize_mask_to_grid(
-    mask: "np.ndarray", grid_hw: Tuple[int, int]
+    mask: "np.ndarray", grid_hw: Tuple[int, int], patch: int | None = None
 ) -> "np.ndarray":
     """Downsample a full-resolution boolean mask onto the patch grid.
 
-    Nearest-neighbour (``order=0``) so labels are not interpolated. The caller
-    is responsible for first aligning the mask to the same geometry the image
-    went through the processor (W4); this is the final patch-grid step.
+    Nearest-neighbour (``order=0``) so labels are not interpolated. When
+    ``patch`` is given the mask is first cropped to
+    ``covered_hw(grid_hw, patch)`` — the extent the grid actually describes —
+    so the truncated bottom/right remainder cannot leak into a patch. The
+    caller is responsible for first aligning the mask to the same geometry the
+    image went through the processor (W4); this is the final patch-grid step.
 
     Args:
         mask: ``(H, W)`` boolean (or 0/1) mask.
         grid_hw: ``(Hp, Wp)`` target patch grid.
+        patch: ``model.config.patch_size``. When *None*, the whole mask is
+            resized (legacy behaviour; introduces a sub-patch scale error).
 
     Returns:
         ``(Hp, Wp)`` boolean mask.
@@ -299,9 +414,13 @@ def resize_mask_to_grid(
     from skimage.transform import resize
 
     hp, wp = int(grid_hw[0]), int(grid_hw[1])
+    arr = np.asarray(mask)
+    if patch is not None:
+        ch, cw = covered_hw((hp, wp), patch)
+        arr = arr[:ch, :cw]
     small = (
         resize(
-            np.asarray(mask, dtype=np.float32),
+            arr.astype(np.float32),
             (hp, wp),
             order=0,
             preserve_range=True,
@@ -316,22 +435,29 @@ def align_mask_to_grid(
     mask: "np.ndarray",
     proc_hw: Tuple[int, int],
     grid_hw: Tuple[int, int],
+    patch: int | None = None,
 ) -> "np.ndarray":
     """Align a full-resolution mask to the patch grid via the processor geometry.
 
-    W4: the image is first resized by the processor to ``proc_hw`` (which for
-    DINOv2/DINOv3 is a fixed square, NOT aspect-preserving), then patchified to
-    ``grid_hw``. The mask must follow the **same** path — resize to ``proc_hw``,
-    then nearest-downsample to the grid — so a non-square exemplar's mask lines
-    up with its features. (For a clean non-aspect-preserving square resize the
-    one-step and two-step results coincide, but the explicit two-step stays
-    correct if a processor ever pads/crops.)
+    W4: the image reaches the model at ``proc_hw`` (under
+    :data:`NATIVE_PROCESSOR_KWARGS` that is its own ``(H, W)``; a resizing
+    processor may make it something else), then is patchified to ``grid_hw``.
+    The mask must follow the **same** path — resize to ``proc_hw``, then
+    nearest-downsample to the grid — so a non-square exemplar's mask lines up
+    with its features.
+
+    Because patchification floors, the grid only covers
+    ``covered_hw(grid_hw, patch)`` of ``proc_hw``. Pass ``patch`` so the
+    truncated bottom/right remainder is cropped rather than squeezed into the
+    last patch row/column.
 
     Args:
         mask: ``(Hm, Wm)`` full-resolution boolean (or 0/1) mask.
         proc_hw: ``(H_proc, W_proc)`` processed pixel geometry
             (``inputs.pixel_values.shape[-2:]``).
         grid_hw: ``(Hp, Wp)`` patch grid.
+        patch: ``model.config.patch_size``. When *None*, the whole processed
+            mask is resized (legacy behaviour; sub-patch scale error).
 
     Returns:
         ``(Hp, Wp)`` boolean mask aligned with the patch features.
@@ -350,7 +476,7 @@ def align_mask_to_grid(
         )
         > 0.5
     )
-    return resize_mask_to_grid(processed, grid_hw)
+    return resize_mask_to_grid(processed, grid_hw, patch)
 
 
 # ---------------------------------------------------------------------------
@@ -362,6 +488,7 @@ def pool_prototype(
     features: "np.ndarray",
     mask: "np.ndarray",
     proc_hw: Tuple[int, int] | None = None,
+    patch: int | None = None,
 ) -> "np.ndarray":
     """Masked-mean an exemplar prototype from dense patch features.
 
@@ -376,6 +503,10 @@ def pool_prototype(
         mask: ``(Hm, Wm)`` boolean mask (any resolution; resized to the grid).
         proc_hw: Optional ``(H_proc, W_proc)`` processed geometry for the W4
             two-step alignment (from :func:`extract_reference_features`).
+        patch: ``model.config.patch_size``. Given, the mask is cropped to the
+            extent the grid actually covers before downsampling, so the
+            truncated bottom/right remainder cannot contaminate the prototype.
+            When *None*, the whole extent is used (legacy behaviour).
 
     Returns:
         ``(D,)`` mean-pooled prototype (zero vector if the mask is empty —
@@ -386,9 +517,9 @@ def pool_prototype(
     feats = np.asarray(features, dtype=np.float32)
     hp, wp, d = feats.shape
     if proc_hw is None:
-        small = resize_mask_to_grid(np.asarray(mask), (hp, wp))
+        small = resize_mask_to_grid(np.asarray(mask), (hp, wp), patch)
     else:
-        small = align_mask_to_grid(np.asarray(mask), proc_hw, (hp, wp))
+        small = align_mask_to_grid(np.asarray(mask), proc_hw, (hp, wp), patch)
     idx = small.reshape(-1)
     flat = feats.reshape(hp * wp, d)
     fg = flat[idx]
@@ -430,6 +561,7 @@ def cosine_match_to_mask(
     prototype: "np.ndarray",
     thresh: float,
     out_shape: Tuple[int, int],
+    patch: int | None = None,
 ) -> "np.ndarray":
     """Cosine-match query patches to a prototype → an upsampled boolean mask.
 
@@ -442,6 +574,12 @@ def cosine_match_to_mask(
         prototype: ``(D,)`` exemplar prototype.
         thresh: Cosine-similarity cutoff (foreground where ``sim > thresh``).
         out_shape: ``(H, W)`` of the full-resolution output mask.
+        patch: ``model.config.patch_size``. Given, the score map is upsampled
+            through the extent the grid actually covers
+            (:func:`upsample_grid_to_image`) rather than stretched over
+            ``out_shape``, which would displace every object by up to
+            ``(patch - 1) / H``. When *None*, the legacy whole-extent stretch
+            is used.
 
     Returns:
         ``(H, W)`` boolean ``objmask``.
@@ -454,11 +592,16 @@ def cosine_match_to_mask(
         return np.zeros(out_shape, dtype=bool)
 
     sim = cosine_similarity_map(features, proto)
-    sim_full = resize(
-        sim.astype(np.float32),
-        out_shape,
-        order=1,
-        preserve_range=True,
-        anti_aliasing=False,
-    )
+    if patch is None:
+        sim_full = resize(
+            sim.astype(np.float32),
+            out_shape,
+            order=1,
+            preserve_range=True,
+            anti_aliasing=False,
+        )
+    else:
+        sim_full = upsample_grid_to_image(
+            sim.astype(np.float32), out_shape, patch, order=1
+        )
     return (sim_full > thresh).astype(bool)

--- a/src/phenotypic/detect/nn/_dinosam2_detector.py
+++ b/src/phenotypic/detect/nn/_dinosam2_detector.py
@@ -186,6 +186,37 @@ class DinoSam2Detector(GpuDetector):
             duplicates (fixes SAM2 over-segmentation).  Default 0.7.
         min_proposal_area: Minimum proposal area in pixels (forwarded to SAM2's
             mask generator).  Default 100.
+        tile_px: Tile size, in pixels, at which DINO dense features are
+            extracted.  A colony must be resolvable on the patch grid to be
+            pooled at all: on a whole 4000x3000 plate a 30 px colony spans
+            0.16 patches and its prototype collapses to the zero vector.  Under
+            the native processor kwargs the resolution is pinned at
+            ``patch_size`` native px per patch regardless of *tile_px*, so this
+            is a **compute** knob, not a fidelity one — smaller is cheaper at
+            equal fidelity (attention is quadratic in tokens per tile).
+            Default 518 (``14 * 37``, an exact DINOv2 patch multiple).
+        tile_overlap: Fractional overlap between neighbouring DINO tiles.  Only
+            a proposal whose centroid lands in a tile's *core* is pooled from
+            that tile, so the overlap only needs to keep colonies whole near a
+            seam.  Default 0.15.
+        crop_n_layers: Number of additional SAM2 **crop-pyramid layers** used to
+            generate proposals.  ``0`` is a single full-image pass, in which
+            SAM2's encoder squashes the whole plate to 1024x1024; the ``n``-th
+            added layer re-tiles the image into ``(2 ** n) ** 2`` overlapping
+            crops encoded nearer native resolution, merged by NMS that prefers
+            masks from smaller crops.  The full-image pass is always included,
+            so ``1`` costs 5 encoder passes and ``2`` costs 21.  Default 1.
+        crop_nms_thresh: Box-IoU cutoff for NMS between proposals from different
+            SAM2 crops -- deduplicates a colony seen in two overlapping crops.
+            Default 0.7 (the SAM2 default).
+        crop_overlap_ratio: Fraction of image length by which first-layer SAM2
+            crops overlap (later layers scale this down).  Set it so the overlap
+            exceeds the largest colony diameter.  Default ``512 / 1500`` (the
+            SAM2 default).
+        crop_n_points_downscale_factor: Point-grid density divisor per SAM2 crop
+            layer -- ``points_per_side`` in layer ``n`` is scaled by
+            ``crop_n_points_downscale_factor ** n``.  Default 1 (the SAM2
+            default).
         device: PyTorch device for inference.  ``"auto"`` probes accelerators
             and raises ``RuntimeError`` if none is found.
         input_layer: Image layer fed to the model -- ``"rgb"`` (default; the
@@ -257,6 +288,21 @@ class DinoSam2Detector(GpuDetector):
     similarity_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.5
     merge_iou_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
     min_proposal_area: Annotated[int, TuneSpec(0, 500)] = 100
+
+    # DINO feature tiling — 518 = 14 * 37, an exact DINOv2 patch multiple.
+    # Whole-plate pooling makes every colony sub-patch (see
+    # _dino_support.pool_prototype_tiled); tiles keep colonies resolvable.
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 518
+    tile_overlap: Annotated[float, TuneSpec(0.0, 0.4)] = 0.15
+
+    # Native SAM2 crop-pyramid knobs — defaults mirror upstream
+    # ``SAM2AutomaticMaskGenerator`` except ``crop_n_layers``, which we engage
+    # by default (mirrors ``Sam2Detector``).
+    crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 1
+    crop_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
+    crop_overlap_ratio: Annotated[float, TuneSpec(0.0, 0.5)] = 512 / 1500
+    crop_n_points_downscale_factor: Annotated[int, TuneSpec(1, 2)] = 1
+
     device: Device = "auto"
 
     # Lazy runtime state — PrivateAttr → skipped by serialization.
@@ -312,6 +358,10 @@ class DinoSam2Detector(GpuDetector):
             self.sam2_model_size,
             device=self._device,
             min_mask_region_area=self.min_proposal_area,
+            crop_n_layers=self.crop_n_layers,
+            crop_nms_thresh=self.crop_nms_thresh,
+            crop_overlap_ratio=self.crop_overlap_ratio,
+            crop_n_points_downscale_factor=self.crop_n_points_downscale_factor,
         )
         dino_id = self._hf_dino_id()
         self._dino_model = AutoModel.from_pretrained(dino_id).to(self._device)
@@ -328,6 +378,11 @@ class DinoSam2Detector(GpuDetector):
         similarity of their pooled DINO feature to the foreground prototype
         (mean of the highest-IoU proposals), filtered by
         ``similarity_thresh``, IoU-merged, and painted largest-first.
+
+        Dense DINO features are extracted **per ``tile_px`` tile**, not on the
+        whole plate: a plate-wide patch grid makes every colony sub-patch, so
+        each proposal would pool an empty mask and receive the zero-vector
+        prototype (see ``_dino_support.pool_prototype_tiled``).
         """
         import numpy as np
 
@@ -341,16 +396,27 @@ class DinoSam2Detector(GpuDetector):
         proposals = [m["segmentation"].astype(bool) for m in raw]
         # Shared, register-token-aware dense features (C1 fix lives in one
         # place — _dino_support.extract_patch_features — not duplicated here).
-        from phenotypic.detect.nn._dino_support import (
-            extract_patch_features,
-            pool_prototype,
-        )
+        from phenotypic.detect.nn import _dino_support
+        from phenotypic.detect.nn._tiling import _plan_tiles
 
-        dense = extract_patch_features(
-            self._dino_model, self._dino_processor, rgb, device=self._device
-        )
+        patch = int(getattr(self._dino_model.config, "patch_size", 14))
+        tiles = _plan_tiles(rgb.shape[:2], self.tile_px, self.tile_overlap)
+        dense_by_tile = [
+            _dino_support.extract_patch_features(
+                self._dino_model,
+                self._dino_processor,
+                rgb[t.y0:t.y1, t.x0:t.x1],
+                device=self._device,
+            )
+            for t in tiles
+        ]
         features = np.stack(
-            [pool_prototype(dense, p).astype(np.float64) for p in proposals]
+            [
+                _dino_support.pool_prototype_tiled(
+                    dense_by_tile, tiles, p, patch
+                ).astype(np.float64)
+                for p in proposals
+            ]
         )
         prototype = self._foreground_prototype(features, raw)
         scores = _score_by_prototype(features, prototype)

--- a/src/phenotypic/detect/nn/_dinosam2_detector.py
+++ b/src/phenotypic/detect/nn/_dinosam2_detector.py
@@ -399,7 +399,7 @@ class DinoSam2Detector(GpuDetector):
         from phenotypic.detect.nn import _dino_support
         from phenotypic.detect.nn._tiling import _plan_tiles
 
-        patch = int(getattr(self._dino_model.config, "patch_size", 14))
+        patch = _dino_support.backbone_patch_size(self._dino_model)
         tiles = _plan_tiles(rgb.shape[:2], self.tile_px, self.tile_overlap)
         dense_by_tile = [
             _dino_support.extract_patch_features(

--- a/src/phenotypic/detect/nn/_fssdino_detector.py
+++ b/src/phenotypic/detect/nn/_fssdino_detector.py
@@ -49,6 +49,7 @@ Attribution: clean-room from arXiv:2602.07550 (CC BY-NC-SA); NO code vendored.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, List
 
@@ -298,8 +299,10 @@ class FssDinoDetector(GpuDetector):
         similarity_thresh: Foreground-score floor on top of the fg-vs-bg
             ``argmax`` (the documented binary-case deviation). Default 0.5.
         tile_px: Nominal tile size in pixels for large-plate tiling; images that
-            fit one tile run un-tiled. Default 512 (FSSDINO's default
-            resolution).
+            fit one tile run un-tiled. Default 518 (``14 * 37``, an exact
+            DINOv2 patch multiple). Resolution is pinned at the backbone's
+            ``patch_size`` regardless of ``tile_px``, so this is purely a
+            compute/context knob — smaller is cheaper at equal fidelity.
         tile_overlap: Fractional overlap between neighbouring tiles. Default
             0.15.
         device: PyTorch device for inference. ``"auto"`` probes accelerators and
@@ -383,7 +386,12 @@ class FssDinoDetector(GpuDetector):
     similarity_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.5
 
     # Tiling (shared with the instance detectors via _tiling).
-    tile_px: Annotated[int, TuneSpec(512, 2048)] = 512
+    # 518 = 14 * 37 — an exact DINOv2 patch multiple. Under the native
+    # processor kwargs the resolution is pinned at patch_size (14.0 native
+    # px/patch) regardless of tile_px, so this is a COMPUTE choice, not a
+    # fidelity one: 518 and 1022 both give 14.0 px/patch, but 1022 costs 3.3x
+    # more (attention is quadratic in tokens per tile). Smaller wins.
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 518
     tile_overlap: Annotated[float, TuneSpec(0.0, 0.4)] = 0.15
 
     device: Device = "auto"
@@ -449,6 +457,17 @@ class FssDinoDetector(GpuDetector):
         self._model, self._processor = load_dino_backbone(
             self.dino_version, self.dino_size, self._device
         )
+
+        patch = int(getattr(self._model.config, "patch_size", 14))
+        if self.tile_px % patch:
+            warnings.warn(
+                f"tile_px={self.tile_px} is not a multiple of the backbone's "
+                f"patch_size={patch}; the ViT will silently drop "
+                f"{self.tile_px % patch} px off each tile's bottom and right. "
+                f"Use {(self.tile_px // patch) * patch}.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         fg_feats: list[np.ndarray] = []
         bg_feats: list[np.ndarray] = []
@@ -544,11 +563,9 @@ class FssDinoDetector(GpuDetector):
 
     def _segment_crop(self, rgb: "np.ndarray") -> "np.ndarray":
         """Run the FSSDINO scoring on one crop → full-res boolean mask."""
-        import numpy as np
-        from skimage.transform import resize
-
         from phenotypic.detect.nn._dino_support import (
             extract_hidden_layer_features,
+            upsample_grid_to_image,
         )
 
         dense = extract_hidden_layer_features(
@@ -560,16 +577,14 @@ class FssDinoDetector(GpuDetector):
         )
         fg_score = self._class_score(dense, self._fg_prototypes, self._fg_gram)
         bg_score = self._class_score(dense, self._bg_prototypes, self._bg_gram)
-        # Argmax over classes (+ fg floor) on the patch grid, then upsample.
+        # Argmax over classes (+ fg floor) on the patch grid, then upsample
+        # through the covered extent (the grid never saw the truncated
+        # bottom/right remainder — see upsample_grid_to_image).
         grid_mask = assign_foreground(fg_score, bg_score, self.similarity_thresh)
-        full = resize(
-            grid_mask.astype(np.float32),
-            (rgb.shape[0], rgb.shape[1]),
-            order=0,
-            preserve_range=True,
-            anti_aliasing=False,
+        patch = int(getattr(self._model.config, "patch_size", 14))
+        return upsample_grid_to_image(
+            grid_mask.astype(bool), (rgb.shape[0], rgb.shape[1]), patch
         )
-        return (full > 0.5).astype(bool)
 
     def _class_score(
         self,

--- a/src/phenotypic/detect/nn/_fssdino_detector.py
+++ b/src/phenotypic/detect/nn/_fssdino_detector.py
@@ -449,6 +449,7 @@ class FssDinoDetector(GpuDetector):
         from phenotypic.detect.nn._checkpoint_manager import resolve_device
         from phenotypic.detect.nn._dino_support import (
             align_mask_to_grid,
+            backbone_patch_size,
             extract_reference_features,
             load_dino_backbone,
         )
@@ -458,7 +459,7 @@ class FssDinoDetector(GpuDetector):
             self.dino_version, self.dino_size, self._device
         )
 
-        patch = int(getattr(self._model.config, "patch_size", 14))
+        patch = backbone_patch_size(self._model)
         if self.tile_px % patch:
             warnings.warn(
                 f"tile_px={self.tile_px} is not a multiple of the backbone's "
@@ -489,7 +490,7 @@ class FssDinoDetector(GpuDetector):
             # grid describes only 210x294 -- omitting `patch` stretches the
             # support mask over 10 rows the ViT never saw (a 4.5% scale error on
             # the very mask that defines the prototype).
-            patch = int(getattr(self._model.config, "patch_size", 14))
+            patch = backbone_patch_size(self._model)
             grid_mask = align_mask_to_grid(mask, proc_hw, (hp, wp), patch)
             flat = dense.reshape(hp * wp, dense.shape[-1])
             fg_idx = grid_mask.reshape(-1)
@@ -570,6 +571,7 @@ class FssDinoDetector(GpuDetector):
     def _segment_crop(self, rgb: "np.ndarray") -> "np.ndarray":
         """Run the FSSDINO scoring on one crop → full-res boolean mask."""
         from phenotypic.detect.nn._dino_support import (
+            backbone_patch_size,
             extract_hidden_layer_features,
             upsample_grid_to_image,
         )
@@ -587,7 +589,7 @@ class FssDinoDetector(GpuDetector):
         # through the covered extent (the grid never saw the truncated
         # bottom/right remainder — see upsample_grid_to_image).
         grid_mask = assign_foreground(fg_score, bg_score, self.similarity_thresh)
-        patch = int(getattr(self._model.config, "patch_size", 14))
+        patch = backbone_patch_size(self._model)
         return upsample_grid_to_image(
             grid_mask.astype(bool), (rgb.shape[0], rgb.shape[1]), patch
         )

--- a/src/phenotypic/detect/nn/_fssdino_detector.py
+++ b/src/phenotypic/detect/nn/_fssdino_detector.py
@@ -484,7 +484,13 @@ class FssDinoDetector(GpuDetector):
                 layer=self.feature_layer,
             )
             hp, wp, _d = dense.shape
-            grid_mask = align_mask_to_grid(mask, proc_hw, (hp, wp))
+            # `patch` is required: the grid covers (hp*patch, wp*patch), not the
+            # support image. The bundled exemplar is 220x300, so at patch 14 the
+            # grid describes only 210x294 -- omitting `patch` stretches the
+            # support mask over 10 rows the ViT never saw (a 4.5% scale error on
+            # the very mask that defines the prototype).
+            patch = int(getattr(self._model.config, "patch_size", 14))
+            grid_mask = align_mask_to_grid(mask, proc_hw, (hp, wp), patch)
             flat = dense.reshape(hp * wp, dense.shape[-1])
             fg_idx = grid_mask.reshape(-1)
             fg_feats.append(flat[fg_idx])

--- a/src/phenotypic/detect/nn/_insid3_detector.py
+++ b/src/phenotypic/detect/nn/_insid3_detector.py
@@ -44,10 +44,11 @@ Built with DINOv3 when ``dino_version=3`` (per the DINOv3 License §1.b.i).
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, List, Optional
 
-from pydantic import PrivateAttr
+from pydantic import PrivateAttr, field_validator
 
 from phenotypic.abc_ import GpuDetector
 from phenotypic.detect.nn._checkpoint_manager import Device
@@ -185,8 +186,10 @@ class Insid3Detector(GpuDetector):
             positional component (INSID3's debiasing strength). Default 4
             (matches DINOv3's register-token count). ``0`` disables the debias.
         tile_px: Nominal tile size in pixels for large-plate tiling; images that
-            fit one tile run un-tiled. Default 1024 (INSID3's default
-            resolution).
+            fit one tile run un-tiled. Default 512 (``16 * 32``, an exact
+            DINOv3 patch multiple). Resolution is pinned at the backbone's
+            ``patch_size`` regardless of ``tile_px``, so this is purely a
+            compute/context knob — smaller is cheaper at equal fidelity.
         tile_overlap: Fractional overlap between neighbouring tiles. Default
             0.15.
         device: PyTorch device for inference. ``"auto"`` probes accelerators and
@@ -263,7 +266,12 @@ class Insid3Detector(GpuDetector):
     svd_components: Annotated[int, TuneSpec()] = 4
 
     # Tiling (shared with the instance detectors via _tiling).
-    tile_px: Annotated[int, TuneSpec(512, 2048)] = 1024
+    # 512 = 16 * 32 — an exact DINOv3 patch multiple. Resolution is pinned at
+    # patch_size (16.0 native px/patch) regardless of tile_px, so this is a
+    # COMPUTE choice: 512 and 1024 both give 16.0 px/patch, but 1024 costs
+    # 2.6x more. NOTE: DINOv3's config.image_size reports 224 (a
+    # classification preset) and must NOT be used to pick this default.
+    tile_px: Annotated[int, TuneSpec(256, 1024)] = 512
     tile_overlap: Annotated[float, TuneSpec(0.0, 0.4)] = 0.15
 
     device: Device = "auto"
@@ -274,6 +282,23 @@ class Insid3Detector(GpuDetector):
     _device: Any = PrivateAttr(default=None)
     _prototype: Any = PrivateAttr(default=None)
     _basis: Any = PrivateAttr(default=None)
+
+    @field_validator("dino_version")
+    @classmethod
+    def _warn_gated_default(cls, v: int) -> int:
+        """DINOv3 is gated; surface that at construction, not at first apply()."""
+        if v == 3:
+            warnings.warn(
+                "Insid3Detector defaults to dino_version=3 (DINOv3), whose "
+                "weights are gated: request access at "
+                "https://huggingface.co/facebook/dinov3-vitb16-pretrain-lvd1689m, "
+                "run `uv run hf auth login`, and set "
+                "PHENOTYPIC_ACCEPT_MODEL_LICENSE=dinov3. "
+                "Pass dino_version=2 for the ungated DINOv2 backbone.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return v
 
     def model_post_init(self, __context: Any) -> None:
         """Fill in the bundled colony exemplar default when no reference is set.
@@ -325,6 +350,17 @@ class Insid3Detector(GpuDetector):
         self._model, self._processor = load_dino_backbone(
             self.dino_version, self.dino_size, self._device
         )
+
+        patch = int(getattr(self._model.config, "patch_size", 16))
+        if self.tile_px % patch:
+            warnings.warn(
+                f"tile_px={self.tile_px} is not a multiple of the backbone's "
+                f"patch_size={patch}; the ViT will silently drop "
+                f"{self.tile_px % patch} px off each tile's bottom and right. "
+                f"Use {(self.tile_px // patch) * patch}.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         ref_rgb = self._read_rgb(self.reference_image)
         ref_mask = self._read_mask(self.reference_mask)
@@ -417,11 +453,13 @@ class Insid3Detector(GpuDetector):
             self._model, self._processor, rgb, device=self._device
         )
         feats_deb = debias_features(feats, self._basis)
+        patch = int(getattr(self._model.config, "patch_size", 16))
         return cosine_match_to_mask(
             feats_deb,
             self._prototype,
             thresh=self.similarity_thresh,
             out_shape=(rgb.shape[0], rgb.shape[1]),
+            patch=patch,
         )
 
 # Expose the class docstring on .apply() for Sphinx autodoc

--- a/src/phenotypic/detect/nn/_insid3_detector.py
+++ b/src/phenotypic/detect/nn/_insid3_detector.py
@@ -341,6 +341,7 @@ class Insid3Detector(GpuDetector):
 
         from phenotypic.detect.nn._checkpoint_manager import resolve_device
         from phenotypic.detect.nn._dino_support import (
+            backbone_patch_size,
             extract_reference_features,
             load_dino_backbone,
             pool_prototype,
@@ -351,7 +352,7 @@ class Insid3Detector(GpuDetector):
             self.dino_version, self.dino_size, self._device
         )
 
-        patch = int(getattr(self._model.config, "patch_size", 16))
+        patch = backbone_patch_size(self._model)
         if self.tile_px % patch:
             warnings.warn(
                 f"tile_px={self.tile_px} is not a multiple of the backbone's "
@@ -379,7 +380,7 @@ class Insid3Detector(GpuDetector):
         # grid describes only 208x288 -- omitting `patch` stretches the reference
         # mask over 12 rows the ViT never saw (a 5.5% scale error on the very
         # mask that defines the prototype).
-        ref_patch = int(getattr(self._model.config, "patch_size", 16))
+        ref_patch = backbone_patch_size(self._model)
         proto = pool_prototype(
             ref_deb, ref_mask, proc_hw=ref_proc_hw, patch=ref_patch
         )
@@ -453,6 +454,7 @@ class Insid3Detector(GpuDetector):
     def _match_crop(self, rgb: "np.ndarray") -> "np.ndarray":
         """Debias + cosine-match one crop to the prototype → boolean mask."""
         from phenotypic.detect.nn._dino_support import (
+            backbone_patch_size,
             cosine_match_to_mask,
             extract_patch_features,
         )
@@ -461,7 +463,7 @@ class Insid3Detector(GpuDetector):
             self._model, self._processor, rgb, device=self._device
         )
         feats_deb = debias_features(feats, self._basis)
-        patch = int(getattr(self._model.config, "patch_size", 16))
+        patch = backbone_patch_size(self._model)
         return cosine_match_to_mask(
             feats_deb,
             self._prototype,

--- a/src/phenotypic/detect/nn/_insid3_detector.py
+++ b/src/phenotypic/detect/nn/_insid3_detector.py
@@ -374,7 +374,15 @@ class Insid3Detector(GpuDetector):
         # then debias before pooling the in-context prototype.
         self._basis = positional_basis(ref_feats, self.svd_components)
         ref_deb = debias_features(ref_feats, self._basis)
-        proto = pool_prototype(ref_deb, ref_mask, proc_hw=ref_proc_hw)
+        # `patch` is required: the grid covers (hp*patch, wp*patch), not the
+        # reference image. The bundled exemplar is 220x300, so at patch 16 the
+        # grid describes only 208x288 -- omitting `patch` stretches the reference
+        # mask over 12 rows the ViT never saw (a 5.5% scale error on the very
+        # mask that defines the prototype).
+        ref_patch = int(getattr(self._model.config, "patch_size", 16))
+        proto = pool_prototype(
+            ref_deb, ref_mask, proc_hw=ref_proc_hw, patch=ref_patch
+        )
         # L2-normalise the prototype (INSID3 normalises the prototype too).
         nrm = float(np.linalg.norm(proto))
         if nrm > 0:

--- a/src/phenotypic/detect/nn/_sam2_detector.py
+++ b/src/phenotypic/detect/nn/_sam2_detector.py
@@ -27,6 +27,7 @@ def build_sam2_generator(
     crop_nms_thresh: float = 0.7,
     crop_overlap_ratio: float = 512 / 1500,
     crop_n_points_downscale_factor: int = 1,
+    box_nms_thresh: float = 0.7,
     checkpoint: str | Path | None = None,
     config: str | None = None,
 ) -> object:
@@ -38,9 +39,9 @@ def build_sam2_generator(
     Hydra-config-prefix logic. There is no public accessor for an existing
     generator, so each detector calls this to rebuild its own.
 
-    The ``crop_*`` arguments expose SAM2's native sliding-window crop
-    mechanism; they default to the upstream ``SAM2AutomaticMaskGenerator``
-    values, so an un-set call reproduces SAM2's stock single-pass behaviour.
+    The ``crop_*`` arguments expose SAM2's native crop pyramid; they default
+    to the upstream ``SAM2AutomaticMaskGenerator`` values, so an un-set call
+    reproduces SAM2's stock single-pass behaviour.
 
     Args:
         model_size: SAM2 variant (``"tiny"`` … ``"large"``).
@@ -49,7 +50,7 @@ def build_sam2_generator(
         pred_iou_thresh: Minimum predicted-IoU score to keep a mask.
         stability_score_thresh: Minimum mask-stability score.
         min_mask_region_area: Minimum mask area in pixels.
-        crop_n_layers: Number of additional sliding-window crop layers
+        crop_n_layers: Number of additional crop-pyramid layers
             (SAM2 default ``0`` = single full-image pass).
         crop_nms_thresh: Box-IoU cutoff for NMS between masks from different
             crops (SAM2 default ``0.7``).
@@ -57,6 +58,8 @@ def build_sam2_generator(
             (SAM2 default ``512 / 1500``).
         crop_n_points_downscale_factor: Per-layer point-grid downscale factor
             (SAM2 default ``1``).
+        box_nms_thresh: Box-IoU cutoff for NMS between the dense point grid's
+            redundant proposals *within* one crop (SAM2 default ``0.7``).
         checkpoint: Optional path to a custom checkpoint.
         config: Optional SAM2 config YAML identifier for a custom checkpoint.
 
@@ -102,6 +105,7 @@ def build_sam2_generator(
         crop_nms_thresh=crop_nms_thresh,
         crop_overlap_ratio=crop_overlap_ratio,
         crop_n_points_downscale_factor=crop_n_points_downscale_factor,
+        box_nms_thresh=box_nms_thresh,
     )
 
 
@@ -152,17 +156,18 @@ class Sam2Detector(GpuDetector):
             agar texture, dust, and other small artefacts that SAM2
             segments as objects.  Typical range: 50--500 depending on
             image resolution.  Default 100.
-        crop_n_layers: Number of additional **sliding-window crop layers**
-            SAM2 runs for higher accuracy on large or dense plates.  SAM2's
-            encoder resizes the whole image to 1024 px before segmenting, so
-            small colonies on a multi-megapixel plate can be lost to
-            downsampling and the prompt grid can step over them.  ``0`` (the
-            SAM2 default) keeps the stock single full-image pass; ``1`` re-runs
-            mask prediction on a 2x2 grid of overlapping crops (each encoded
-            nearer native resolution) and merges them by NMS, with each added
-            layer ``i`` contributing ``2**i`` crops.  Raise to 1--2 for maximal
-            segmentation accuracy at proportionally higher inference cost.
-            Default 0.
+        crop_n_layers: Number of additional **crop-pyramid layers** SAM2 runs
+            for higher accuracy on large or dense plates.  SAM2's encoder
+            resizes the whole image to a fixed **1024x1024 square** -- a
+            non-aspect-preserving squash, so a 4:3 plate enters the model as
+            ellipses -- and small colonies on a multi-megapixel plate can be
+            lost to downsampling.  ``0`` keeps a single full-image pass; the
+            ``n``-th added layer (``n`` = 1, 2, ...) re-tiles the *entire*
+            image into ``(2 ** n) ** 2`` overlapping crops -- 4 at layer 1,
+            16 at layer 2 -- each encoded nearer native resolution, and merges
+            them by NMS that prefers masks from smaller crops.  The full-image
+            pass is always included, so ``crop_n_layers=1`` costs 5 encoder
+            passes and ``2`` costs 21.  Default 1.
         crop_nms_thresh: Box-IoU cutoff for non-maximum suppression between
             masks from different crops -- deduplicates a colony seen in two
             overlapping crops.  Typical range 0.5--0.9.  Default 0.7 (the SAM2
@@ -176,6 +181,10 @@ class Sam2Detector(GpuDetector):
             layer -- ``points_per_side`` in layer ``n`` is scaled by
             ``crop_n_points_downscale_factor ** n``.  Default 1 (the SAM2
             default).
+        box_nms_thresh: Box-IoU cutoff for non-maximum suppression between
+            the dense point grid's redundant proposals *within* one crop
+            (distinct from ``crop_nms_thresh``, which deduplicates *across*
+            crops).  Typical range 0.5--0.9.  Default 0.7 (the SAM2 default).
         device: PyTorch device for inference.  ``"auto"`` probes
             accelerators in priority order (CUDA, MPS, XPU, HPU) and
             raises ``RuntimeError`` if none is found.  Pass ``"cpu"``
@@ -267,12 +276,18 @@ class Sam2Detector(GpuDetector):
     pred_iou_thresh: float = 0.7
     stability_score_thresh: float = 0.92
     min_mask_region_area: int = 100
-    # Native SAM2 sliding-window crop knobs — defaults mirror upstream
-    # ``SAM2AutomaticMaskGenerator`` (crop_n_layers=0 → stock single pass).
-    crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 0
+    # Native SAM2 crop-pyramid knobs — defaults mirror upstream
+    # ``SAM2AutomaticMaskGenerator`` except ``crop_n_layers``, which we
+    # engage by default (see docstring for why).
     crop_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
     crop_overlap_ratio: Annotated[float, TuneSpec(0.0, 0.5)] = 512 / 1500
     crop_n_points_downscale_factor: Annotated[int, TuneSpec(1, 2)] = 1
+    box_nms_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
+    # 1 crop layer = 5 encoder passes: the always-present full-image pass plus
+    # (2 ** 1) ** 2 = 4 crops. Engages SAM2's edge rejection, crop overlap,
+    # full-image fallback, and resolution-preferring NMS. ~3.91 -> ~1.9 native
+    # px per encoder px on a 4000x3000 plate, at ~5x the inference cost.
+    crop_n_layers: Annotated[int, TuneSpec(0, 2)] = 1
     device: Device = "auto"
     checkpoint: str | Path | None = None
     config: str | None = None
@@ -304,6 +319,7 @@ class Sam2Detector(GpuDetector):
             crop_nms_thresh=self.crop_nms_thresh,
             crop_overlap_ratio=self.crop_overlap_ratio,
             crop_n_points_downscale_factor=self.crop_n_points_downscale_factor,
+            box_nms_thresh=self.box_nms_thresh,
             checkpoint=self.checkpoint,
             config=self.config,
         )

--- a/src/phenotypic/detect/nn/_sam3_detector.py
+++ b/src/phenotypic/detect/nn/_sam3_detector.py
@@ -9,10 +9,16 @@ from pydantic import PrivateAttr
 from phenotypic.abc_ import GpuDetector
 from phenotypic.detect.nn._checkpoint_manager import Device
 
-# Shared fixed-geometric tiling (extracted to _tiling.py so the semantic
-# detectors reuse it). Re-exported here for back-compat with callers/tests that
-# import _Tile / _plan_tiles from _sam3_detector.
-from phenotypic.detect.nn._tiling import _plan_tiles, _Tile, _tile_starts
+# Shared fixed-geometric tiling and the cross-tile instance merge, both owned by
+# _tiling.py so the semantic detectors reuse the tiling. Re-exported here for
+# back-compat with callers/tests that import these names from _sam3_detector.
+from phenotypic.detect.nn._tiling import (
+    _iou,
+    _merge_tiles_iou_nms,
+    _plan_tiles,
+    _Tile,
+    _tile_starts,
+)
 from phenotypic.sdk_.typing_ import GpuInputLayer, GpuOutputKind, TuneSpec
 
 if TYPE_CHECKING:
@@ -21,75 +27,7 @@ if TYPE_CHECKING:
 __all__ = ["Sam3Detector"]
 
 # Silence "imported but unused" — these are intentional back-compat re-exports.
-_ = (_Tile, _tile_starts)
-
-
-def _iou(mask_a: "np.ndarray", mask_b: "np.ndarray") -> float:
-    """Intersection-over-union of two boolean masks (0.0 if both empty)."""
-    inter = int((mask_a & mask_b).sum())
-    if inter == 0:
-        return 0.0
-    union = int((mask_a | mask_b).sum())
-    return inter / union if union else 0.0
-
-
-def _merge_tiles_iou_nms(
-    objmaps: List["np.ndarray"], iou_thresh: float
-) -> "np.ndarray":
-    """Greedy IoU-NMS merge of per-tile objmaps into one contiguous objmap.
-
-    Each input objmap is already offset into full-image coordinates (same
-    shape). Instances are collected across all tiles, sorted largest-first,
-    and greedily kept unless they overlap an already-kept instance by more than
-    ``iou_thresh`` (a cross-tile duplicate). Survivors are relabelled ``1..N``
-    largest-first so smaller colonies overwrite at overlaps, preserving
-    small-colony identity (mirrors ``Sam2Detector``'s painting order).
-
-    Args:
-        objmaps: Per-tile uint16 objmaps, each in full-image coordinates.
-        iou_thresh: IoU above which two instances are treated as duplicates.
-
-    Returns:
-        A single uint16 objmap with contiguous labels ``1..N``.
-    """
-    import numpy as np
-
-    if not objmaps:
-        raise ValueError("_merge_tiles_iou_nms requires at least one objmap")
-    shape = objmaps[0].shape
-
-    masks: list[np.ndarray] = []
-    for objmap in objmaps:
-        for label in np.unique(objmap):
-            if label == 0:
-                continue
-            masks.append(objmap == label)
-    if not masks:
-        return np.zeros(shape, dtype=np.uint16)
-
-    masks.sort(key=lambda m: int(m.sum()), reverse=True)
-    kept: list[np.ndarray] = []
-    for cand in masks:
-        if any(_iou(cand, k) > iou_thresh for k in kept):
-            continue
-        kept.append(cand)
-
-    max_labels = int(np.iinfo(np.uint16).max)
-    if len(kept) > max_labels:
-        import warnings
-
-        warnings.warn(
-            f"SAM3 merged {len(kept)} instances, exceeding uint16 range. "
-            f"Only the first {max_labels} (largest) will be labeled.",
-            UserWarning,
-            stacklevel=2,
-        )
-        kept = kept[:max_labels]
-
-    objmap = np.zeros(shape, dtype=np.uint16)
-    for idx, mask in enumerate(kept, start=1):
-        objmap[mask] = idx
-    return objmap
+_ = (_Tile, _tile_starts, _iou, _merge_tiles_iou_nms)
 
 
 class Sam3Detector(GpuDetector):

--- a/src/phenotypic/detect/nn/_sam3_detector.py
+++ b/src/phenotypic/detect/nn/_sam3_detector.py
@@ -9,8 +9,8 @@ from pydantic import PrivateAttr
 from phenotypic.abc_ import GpuDetector
 from phenotypic.detect.nn._checkpoint_manager import Device
 
-# Shared fixed-geometric tiling and the cross-tile instance merge, both owned by
-# _tiling.py so the semantic detectors reuse the tiling. Re-exported here for
+# Shared fixed-geometric tiling and the cross-tile instance merges, both owned
+# by _tiling.py so the semantic detectors reuse the tiling. Re-exported here for
 # back-compat with callers/tests that import these names from _sam3_detector.
 from phenotypic.detect.nn._tiling import (
     _iou,
@@ -18,6 +18,7 @@ from phenotypic.detect.nn._tiling import (
     _plan_tiles,
     _Tile,
     _tile_starts,
+    assign_by_centroid_core,
 )
 from phenotypic.sdk_.typing_ import GpuInputLayer, GpuOutputKind, TuneSpec
 
@@ -56,8 +57,12 @@ class Sam3Detector(GpuDetector):
 
     **Dense plates.** SAM3 caps at 200 instances per forward and runs at
     1008 px internally, so dense plates are tiled (fixed ~:attr:`tile_px`
-    tiles with :attr:`tile_overlap`), each tile inferred and offset back to
-    full coordinates, then merged across tiles by IoU-NMS.
+    tiles with :attr:`tile_overlap`) and each tile is inferred separately.
+    The tiles are merged by *centroid-in-core* assignment
+    (:func:`~phenotypic.detect.nn._tiling.assign_by_centroid_core`): each
+    instance is kept by the one tile whose core contains its centroid, so a
+    colony straddling a seam cannot be duplicated, nor can the fragment a
+    neighbouring tile saw survive as its own colony.
 
     Args:
         prompt: Free-text description of what to segment.  Override per run
@@ -76,9 +81,13 @@ class Sam3Detector(GpuDetector):
             resolution).
         tile_overlap: Fractional overlap between neighbouring tiles.  Default
             0.15.
-        tile_merge_iou: IoU above which the same colony detected in the overlap
-            of two adjacent tiles is merged into one instance (cross-tile NMS).
-            Default 0.5.
+        tile_merge_iou: **Deprecated and ignored.** The cross-tile merge is now
+            centroid-in-core
+            (:func:`~phenotypic.detect.nn._tiling.assign_by_centroid_core`),
+            which assigns each instance to exactly one tile and therefore needs
+            no IoU threshold. The field is retained only so pipelines
+            serialised before the change keep deserialising; setting it has no
+            effect. Default 0.5.
         max_instances_per_tile: SAM3's hard 200-instance-per-forward cap;
             structural, not tuned.
         device: PyTorch device for inference.  ``"auto"`` probes accelerators
@@ -152,8 +161,9 @@ class Sam3Detector(GpuDetector):
     # Tiling (Task 5) — fixed geometric tiles, no grid awareness.
     tile_px: Annotated[int, TuneSpec(512, 2048)] = 1008
     tile_overlap: Annotated[float, TuneSpec(0.0, 0.4)] = 0.15
-    # IoU above which the same colony detected in the overlap of two adjacent
-    # tiles is merged into one instance (cross-tile NMS).
+    # Deprecated: the tiled instance merge is centroid-in-core
+    # (_tiling.assign_by_centroid_core), which needs no IoU threshold. Retained
+    # so existing serialized pipelines keep deserializing.
     tile_merge_iou: Annotated[float, TuneSpec(0.0, 1.0)] = 0.5
     # SAM3's hard num_queries cap per forward — structural, never tuned.
     max_instances_per_tile: Annotated[int, TuneSpec(tunable=False)] = 200
@@ -276,9 +286,14 @@ class Sam3Detector(GpuDetector):
         """Run SAM3 over a collated batch; one uint16 objmap per sample.
 
         Each sample is tiled into fixed ~:attr:`tile_px` crops; all crops from
-        all samples are regrouped and forwarded per tile-batch (C4), each
-        crop's objmap is offset back to full-image coordinates, and per-sample
-        crops are merged by IoU-NMS. Samples that fit one tile run un-tiled.
+        all samples are regrouped and forwarded in one tile-batch (C4). The
+        per-crop objmaps stay **tile-local** all the way to
+        :func:`~phenotypic.detect.nn._tiling.assign_by_centroid_core`, which
+        owns the offset into full-image coordinates: it needs each instance's
+        tile-local centroid to decide which tile's core claims it. Offsetting
+        the crops here would make the merge add ``tile.y0``/``tile.x0`` a
+        second time. Samples that fit one tile run un-tiled (the merge then
+        just relabels contiguously).
         """
         import numpy as np
 
@@ -303,32 +318,24 @@ class Sam3Detector(GpuDetector):
         # One true-batch forward over every crop.
         crop_objmaps = self._forward_tiles(flat_crops) if flat_crops else []
 
-        # Offset each crop objmap into full-image coords, group by sample.
-        per_sample_full: list[list[np.ndarray]] = [[] for _ in batch]
+        # Group the tile-local objmaps by sample — no offsetting here; the
+        # merge maps each instance into full-image coordinates itself.
+        per_sample_local: list[list[np.ndarray]] = [[] for _ in batch]
         cursor = 0
         for s_idx in range(len(batch)):
-            full_shape = full_shapes[s_idx]
-            for t in plans[s_idx]:
-                crop_obj = crop_objmaps[cursor]
+            for _t in plans[s_idx]:
+                per_sample_local[s_idx].append(crop_objmaps[cursor])
                 cursor += 1
-                full = np.zeros(full_shape, dtype=np.uint16)
-                full[t.y0:t.y1, t.x0:t.x1] = crop_obj
-                per_sample_full[s_idx].append(full)
 
         results: list[np.ndarray] = []
         for s_idx in range(len(batch)):
-            tile_objmaps = per_sample_full[s_idx]
-            if len(tile_objmaps) == 1:
-                # Single-tile path — relabel contiguously, no merge needed.
-                results.append(
-                    _merge_tiles_iou_nms(tile_objmaps, iou_thresh=1.0)
-                )
-            elif not tile_objmaps:
+            tile_objmaps = per_sample_local[s_idx]
+            if not tile_objmaps:
                 results.append(np.zeros(full_shapes[s_idx], dtype=np.uint16))
             else:
                 results.append(
-                    _merge_tiles_iou_nms(
-                        tile_objmaps, iou_thresh=self.tile_merge_iou
+                    assign_by_centroid_core(
+                        plans[s_idx], tile_objmaps, full_shapes[s_idx]
                     )
                 )
         return results

--- a/src/phenotypic/detect/nn/_tiling.py
+++ b/src/phenotypic/detect/nn/_tiling.py
@@ -1,14 +1,20 @@
 """Shared fixed-geometric tiling for GPU detectors (Spec 2b, Task 3).
 
-Extracted from ``_sam3_detector.py`` so the instance detector (SAM3, IoU-NMS
-merge) and the semantic detectors (INSID3, FSSDINO, union stitch) share one
-tiling implementation. A ``GpuDetector`` runs before ``GridFinder`` and only
-ever sees a raw ``input_layer`` array, so tiling is **grid-unaware**: fixed
-~``tile_px`` crops with fractional overlap whose union always covers the image.
+Extracted from ``_sam3_detector.py`` so the instance detector (SAM3) and the
+semantic detectors (INSID3, FSSDINO, union stitch) share one tiling
+implementation. A ``GpuDetector`` runs before ``GridFinder`` and only ever sees
+a raw ``input_layer`` array, so tiling is **grid-unaware**: fixed ~``tile_px``
+crops with fractional overlap whose union always covers the image.
 
-Instance detectors merge cross-tile duplicates by IoU-NMS (kept in
-``_sam3_detector.py``); semantic detectors just OR the per-tile boolean masks
-(:func:`stitch_semantic_tiles`).
+This module owns the whole tiling policy, including both cross-tile merges:
+
+* **Instance** detectors merge with :func:`assign_by_centroid_core`, which keeps
+  each instance in exactly the one tile whose *core* (Voronoi cell of the tile
+  centres) contains its centroid. Duplicates and fragments are impossible by
+  construction. :func:`_merge_tiles_iou_nms` is the older IoU-NMS merge, kept
+  for the single-tile relabel path and for back-compat.
+* **Semantic** detectors just OR the per-tile boolean masks
+  (:func:`stitch_semantic_tiles`) — no instance identity, so no merge policy.
 """
 
 from __future__ import annotations
@@ -115,8 +121,9 @@ def stitch_semantic_tiles(
 ) -> "np.ndarray":
     """Union per-tile boolean masks back into one full-image ``objmask``.
 
-    Semantic output has no instance identity, so overlaps simply OR — no NMS is
-    needed (contrast the instance path's IoU-NMS in ``_sam3_detector.py``).
+    Semantic output has no instance identity, so overlaps simply OR — no merge
+    policy is needed (contrast the instance path's
+    :func:`assign_by_centroid_core`).
 
     Args:
         tiles: Crop rectangles in full-image coordinates (from
@@ -141,3 +148,245 @@ def stitch_semantic_tiles(
     for tile, mask in zip(tiles, tile_masks):
         full[tile.y0:tile.y1, tile.x0:tile.x1] |= np.asarray(mask, dtype=bool)
     return full
+
+
+def _iou(mask_a: "np.ndarray", mask_b: "np.ndarray") -> float:
+    """Intersection-over-union of two boolean masks (0.0 if both empty)."""
+    inter = int((mask_a & mask_b).sum())
+    if inter == 0:
+        return 0.0
+    union = int((mask_a | mask_b).sum())
+    return inter / union if union else 0.0
+
+
+def _merge_tiles_iou_nms(
+    objmaps: List["np.ndarray"], iou_thresh: float
+) -> "np.ndarray":
+    """Greedy IoU-NMS merge of per-tile objmaps into one contiguous objmap.
+
+    Each input objmap is already offset into full-image coordinates (same
+    shape). Instances are collected across all tiles, sorted largest-first,
+    and greedily kept unless they overlap an already-kept instance by more than
+    ``iou_thresh`` (a cross-tile duplicate). Survivors are relabelled ``1..N``
+    largest-first so smaller colonies overwrite at overlaps, preserving
+    small-colony identity (mirrors ``Sam2Detector``'s painting order).
+
+    This only suppresses *duplicates* — instances a neighbouring tile saw
+    whole. It cannot suppress a **fragment**: IoU between a whole colony and
+    the cleaved copy a neighbouring tile saw equals the fragment's area
+    fraction, so every fragment covering ``<= iou_thresh`` of its parent
+    survives. Prefer :func:`assign_by_centroid_core` for tiled instance
+    detection; this remains for the single-tile relabel path.
+
+    Args:
+        objmaps: Per-tile uint16 objmaps, each in full-image coordinates.
+        iou_thresh: IoU above which two instances are treated as duplicates.
+
+    Returns:
+        A single uint16 objmap with contiguous labels ``1..N``.
+    """
+    import numpy as np
+
+    if not objmaps:
+        raise ValueError("_merge_tiles_iou_nms requires at least one objmap")
+    shape = objmaps[0].shape
+
+    masks: list[np.ndarray] = []
+    for objmap in objmaps:
+        for label in np.unique(objmap):
+            if label == 0:
+                continue
+            masks.append(objmap == label)
+    if not masks:
+        return np.zeros(shape, dtype=np.uint16)
+
+    masks.sort(key=lambda m: int(m.sum()), reverse=True)
+    kept: list[np.ndarray] = []
+    for cand in masks:
+        if any(_iou(cand, k) > iou_thresh for k in kept):
+            continue
+        kept.append(cand)
+
+    max_labels = int(np.iinfo(np.uint16).max)
+    if len(kept) > max_labels:
+        import warnings
+
+        warnings.warn(
+            f"Tiled merge kept {len(kept)} instances, exceeding uint16 range. "
+            f"Only the first {max_labels} (largest) will be labeled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        kept = kept[:max_labels]
+
+    objmap = np.zeros(shape, dtype=np.uint16)
+    for idx, mask in enumerate(kept, start=1):
+        objmap[mask] = idx
+    return objmap
+
+
+def tile_overlap_px(tiles: List[_Tile]) -> int:
+    """Smallest overlap in pixels between any two overlapping tiles.
+
+    Zero when a single tile covers the image. This is the bound that decides
+    whether a colony can be lost: an instance wider than the overlap is cleaved
+    in every tile that contains it.
+
+    Args:
+        tiles: Crop rectangles from :func:`_plan_tiles`.
+
+    Returns:
+        Minimum positive pairwise overlap along either axis, or ``0``.
+    """
+    if len(tiles) < 2:
+        return 0
+    best: int | None = None
+    for i, a in enumerate(tiles):
+        for b in tiles[i + 1:]:
+            oy = min(a.y1, b.y1) - max(a.y0, b.y0)
+            ox = min(a.x1, b.x1) - max(a.x0, b.x0)
+            if oy > 0 and ox > 0:  # genuinely overlapping, not merely abutting
+                cand = min(oy, ox)
+                best = cand if best is None else min(best, cand)
+    return int(best) if best is not None else 0
+
+
+def owning_tile_index(tiles: List[_Tile], centroid_yx: tuple[float, float]) -> int:
+    """Index of the tile whose *core* contains ``centroid_yx``.
+
+    A tile's core is the region closer to its centre than to any other tile's
+    centre — a Voronoi partition of the tile centres, intersected with the tile.
+    Since :func:`_plan_tiles` guarantees the tiles cover the image, every point
+    lies in at least one tile, and the nearest-centre rule picks exactly one.
+    Border tiles' cores therefore reach the image edge with no gap.
+
+    This is what makes cross-tile duplicates impossible: a colony fully inside
+    one tile is claimed by whichever core holds its true centroid; the same
+    colony's *fragment* in a neighbouring tile has a centroid pushed within
+    ``d/2`` of that tile's edge, while the core begins ``overlap_px / 2`` inside
+    it — so when ``overlap_px >= d`` the fragment is never claimed.
+
+    Args:
+        tiles: Crop rectangles from :func:`_plan_tiles`.
+        centroid_yx: ``(y, x)`` in full-image coordinates.
+
+    Returns:
+        Index into *tiles*.
+    """
+    cy, cx = float(centroid_yx[0]), float(centroid_yx[1])
+    best_i = 0
+    best_d: float | None = None
+    for i, t in enumerate(tiles):
+        if not (t.y0 <= cy < t.y1 and t.x0 <= cx < t.x1):
+            continue
+        ty = (t.y0 + t.y1) / 2.0
+        tx = (t.x0 + t.x1) / 2.0
+        d = (cy - ty) ** 2 + (cx - tx) ** 2
+        if best_d is None or d < best_d:
+            best_i, best_d = i, d
+    return best_i
+
+
+def assign_by_centroid_core(
+    tiles: List[_Tile],
+    tile_objmaps: List["np.ndarray"],
+    out_shape: tuple[int, int],
+) -> "np.ndarray":
+    """Merge tile-local instance maps by centroid-in-core assignment.
+
+    Each instance is kept by exactly the one tile whose core contains its
+    centroid (:func:`owning_tile_index`); every other copy is discarded. No NMS,
+    no edge tolerance, no duplicates by construction. Fragments are dropped
+    because nobody claims them.
+
+    Contrast :func:`_merge_tiles_iou_nms`, whose IoU between a whole colony and
+    its cross-tile fragment equals the fragment's area fraction ``f`` — so every
+    fragment with ``f <= iou_thresh`` survives and, being painted later in the
+    largest-first order, overwrites the colony it came from.
+
+    The alternative fix — rejecting instances near a crop edge, as SAM2 does —
+    is not viable here. Edge rejection needs ``overlap_px >= d + 2 * atol`` for
+    a colony of diameter ``d``; violate it and the colony is within ``atol`` of
+    an edge in *every* tile containing it, so it is not fragmented but silently
+    **deleted**. SAM2 tolerates that because its crop pyramid always runs a
+    full-image layer and its ``1 / box_area`` NMS outvotes the coarse copy;
+    uniform tiles have neither defense.
+
+    Survivors are relabelled ``1..N`` largest-first, matching
+    :func:`_merge_tiles_iou_nms`.
+
+    Args:
+        tiles: Crop rectangles in full-image coordinates.
+        tile_objmaps: Per-tile uint16 objmaps, each ``(tile.h, tile.w)``,
+            **tile-local** (not offset into the full image).
+        out_shape: ``(H, W)`` of the full image.
+
+    Returns:
+        A full-image uint16 objmap with contiguous labels ``1..N``.
+
+    Raises:
+        ValueError: If *tiles* and *tile_objmaps* differ in length.
+
+    Warns:
+        UserWarning: When the largest retained instance is wider than
+            :func:`tile_overlap_px` — the condition under which a colony can be
+            cleaved in every tile and lost.
+    """
+    import warnings
+
+    import numpy as np
+
+    if len(tiles) != len(tile_objmaps):
+        raise ValueError(
+            f"assign_by_centroid_core: {len(tiles)} tiles vs "
+            f"{len(tile_objmaps)} objmaps"
+        )
+
+    kept: list[np.ndarray] = []
+    for i, (tile, om) in enumerate(zip(tiles, tile_objmaps)):
+        om = np.asarray(om)
+        for label in np.unique(om):
+            if label == 0:
+                continue
+            local = om == label
+            ys, xs = np.nonzero(local)
+            cy = ys.mean() + tile.y0
+            cx = xs.mean() + tile.x0
+            if owning_tile_index(tiles, (cy, cx)) != i:
+                continue
+            full = np.zeros(out_shape, dtype=bool)
+            full[tile.y0:tile.y1, tile.x0:tile.x1] = local
+            kept.append(full)
+
+    if not kept:
+        return np.zeros(out_shape, dtype=np.uint16)
+
+    kept.sort(key=lambda m: int(m.sum()), reverse=True)
+
+    overlap = tile_overlap_px(tiles)
+    if overlap:
+        ys, xs = np.nonzero(kept[0])
+        d = max(ys.max() - ys.min() + 1, xs.max() - xs.min() + 1)
+        if d > overlap:
+            warnings.warn(
+                f"Largest instance is {d} px across but tiles overlap by only "
+                f"{overlap} px; an instance wider than the overlap can be "
+                f"cleaved in every tile and lost. Raise tile_overlap.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    max_labels = int(np.iinfo(np.uint16).max)
+    if len(kept) > max_labels:
+        warnings.warn(
+            f"Tiled merge kept {len(kept)} instances, exceeding uint16 range. "
+            f"Only the first {max_labels} (largest) will be labeled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        kept = kept[:max_labels]
+
+    objmap = np.zeros(out_shape, dtype=np.uint16)
+    for idx, mask in enumerate(kept, start=1):
+        objmap[mask] = idx
+    return objmap

--- a/src/phenotypic/detect/nn/_tiling.py
+++ b/src/phenotypic/detect/nn/_tiling.py
@@ -342,31 +342,36 @@ def assign_by_centroid_core(
             f"{len(tile_objmaps)} objmaps"
         )
 
-    kept: list[np.ndarray] = []
+    # Survivors are recorded as (area, diameter, tile_index, label) — never as
+    # full-image masks. Materializing one (H, W) boolean per instance costs
+    # ~12 MB on a 4000x3000 plate, and every survivor is alive at once for the
+    # largest-first sort: ~12 GB for a 1000-colony plate (measured). Painting
+    # instead from each survivor's tile-local slice keeps the working set at one
+    # tile plus the output objmap.
+    kept: list[tuple[int, int, int, int]] = []
     for i, (tile, om) in enumerate(zip(tiles, tile_objmaps)):
         om = np.asarray(om)
         for label in np.unique(om):
             if label == 0:
                 continue
-            local = om == label
-            ys, xs = np.nonzero(local)
+            ys, xs = np.nonzero(om == label)
             cy = ys.mean() + tile.y0
             cx = xs.mean() + tile.x0
             if owning_tile_index(tiles, (cy, cx)) != i:
                 continue
-            full = np.zeros(out_shape, dtype=bool)
-            full[tile.y0:tile.y1, tile.x0:tile.x1] = local
-            kept.append(full)
+            diameter = max(
+                int(ys.max() - ys.min()) + 1, int(xs.max() - xs.min()) + 1
+            )
+            kept.append((int(ys.size), diameter, i, int(label)))
 
     if not kept:
         return np.zeros(out_shape, dtype=np.uint16)
 
-    kept.sort(key=lambda m: int(m.sum()), reverse=True)
+    kept.sort(key=lambda rec: rec[0], reverse=True)
 
     overlap = tile_overlap_px(tiles)
     if overlap:
-        ys, xs = np.nonzero(kept[0])
-        d = max(ys.max() - ys.min() + 1, xs.max() - xs.min() + 1)
+        d = kept[0][1]
         if d > overlap:
             warnings.warn(
                 f"Largest instance is {d} px across but tiles overlap by only "
@@ -386,7 +391,12 @@ def assign_by_centroid_core(
         )
         kept = kept[:max_labels]
 
+    # Paint largest-first, so smaller colonies overwrite at overlaps and keep
+    # their identity. Each survivor is painted through a view onto its own tile
+    # rectangle; no full-image mask is ever built.
     objmap = np.zeros(out_shape, dtype=np.uint16)
-    for idx, mask in enumerate(kept, start=1):
-        objmap[mask] = idx
+    for idx, (_area, _diameter, i, label) in enumerate(kept, start=1):
+        tile = tiles[i]
+        om = np.asarray(tile_objmaps[i])
+        objmap[tile.y0:tile.y1, tile.x0:tile.x1][om == label] = idx
     return objmap

--- a/tests/unit/detect/nn/test_dino_support.py
+++ b/tests/unit/detect/nn/test_dino_support.py
@@ -192,3 +192,211 @@ def test_pool_prototype_with_proc_hw_aligns_non_square():
     assert proto.shape == (4,)
     # Foreground patches are the all-ones block → prototype ≈ ones.
     assert np.all(proto > 0.5)
+
+
+# ---------------------------------------------------------------------------
+# F1 — native processor geometry + patch grid arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestPatchGeometry:
+    def test_patch_grid_hw_floors(self):
+        from phenotypic.detect.nn._dino_support import patch_grid_hw
+
+        assert patch_grid_hw((518, 518), 14) == (37, 37)
+        assert patch_grid_hw((512, 512), 14) == (36, 36)
+        assert patch_grid_hw((512, 512), 16) == (32, 32)
+        assert patch_grid_hw((600, 800), 14) == (42, 57)
+
+    def test_covered_hw_is_grid_times_patch(self):
+        from phenotypic.detect.nn._dino_support import covered_hw
+
+        assert covered_hw((37, 37), 14) == (518, 518)
+        assert covered_hw((42, 57), 14) == (588, 798)
+
+    def test_native_kwargs_disable_resize_and_crop(self):
+        from phenotypic.detect.nn._dino_support import NATIVE_PROCESSOR_KWARGS
+
+        assert NATIVE_PROCESSOR_KWARGS == {
+            "do_resize": False,
+            "do_center_crop": False,
+        }
+
+
+class TestProcessorPolicy:
+    """The extract_* fns must never let the checkpoint's classification preset
+    (224 center-crop) decide the input size."""
+
+    @staticmethod
+    def _fakes(patch=14, n_reg=0, grid=(37, 37)):
+        import torch
+
+        seen: dict = {}
+
+        class FakeInputs(dict):
+            def to(self, _device):
+                return self
+
+        class FakeProcessor:
+            def __call__(self, images, return_tensors=None, **kwargs):
+                seen.update(kwargs)
+                h, w = images.shape[:2]
+                return FakeInputs({"pixel_values": torch.zeros((1, 3, h, w))})
+
+        class FakeConfig:
+            patch_size = patch
+            num_register_tokens = n_reg
+
+        class FakeModel:
+            config = FakeConfig()
+
+            def __call__(self, pixel_values=None, **_):
+                hp, wp = grid
+                tokens = torch.zeros((1, 1 + n_reg + hp * wp, 8))
+
+                class Out:
+                    last_hidden_state = tokens
+                    hidden_states = [tokens, tokens]
+
+                return Out()
+
+        return seen, FakeModel(), FakeProcessor()
+
+    def test_extract_patch_features_requests_native_geometry(self):
+        from phenotypic.detect.nn._dino_support import extract_patch_features
+
+        seen, model, processor = self._fakes()
+        rgb = np.zeros((518, 518, 3), dtype=np.uint8)
+        dense = extract_patch_features(model, processor, rgb, device="cpu")
+        assert seen == {"do_resize": False, "do_center_crop": False}
+        assert dense.shape == (37, 37, 8)
+
+    def test_extract_reference_features_requests_native_geometry(self):
+        from phenotypic.detect.nn._dino_support import extract_reference_features
+
+        seen, model, processor = self._fakes(patch=16, n_reg=4, grid=(32, 32))
+        rgb = np.zeros((512, 512, 3), dtype=np.uint8)
+        dense, proc_hw = extract_reference_features(
+            model, processor, rgb, device="cpu"
+        )
+        assert seen == {"do_resize": False, "do_center_crop": False}
+        assert dense.shape == (32, 32, 8)
+        assert proc_hw == (512, 512)
+
+    def test_extract_hidden_layer_features_requests_native_geometry(self):
+        from phenotypic.detect.nn._dino_support import (
+            extract_hidden_layer_features,
+        )
+
+        seen, model, processor = self._fakes()
+        rgb = np.zeros((518, 518, 3), dtype=np.uint8)
+        dense = extract_hidden_layer_features(
+            model, processor, rgb, device="cpu", layer=-1
+        )
+        assert seen == {"do_resize": False, "do_center_crop": False}
+        assert dense.shape == (37, 37, 8)
+
+
+# ---------------------------------------------------------------------------
+# F1 — covered-extent grid ↔ image mapping
+# ---------------------------------------------------------------------------
+
+
+class TestCoveredExtentMapping:
+    def test_upsample_grid_preserves_centroid(self):
+        """A block centred in the grid keeps its position in the covered extent.
+
+        A (42, 57) grid at patch 14 covers 588x798 of a 600x800 tile. The
+        block's fractional centroid must be preserved relative to that covered
+        extent, NOT to the full tile: stretching the grid onto 600x800 instead
+        displaces it by ~2% (6.1 px vertically here).
+        """
+        from phenotypic.detect.nn._dino_support import upsample_grid_to_image
+
+        grid = np.zeros((42, 57), dtype=bool)
+        grid[20:23, 27:30] = True  # centred block
+        gy, gx = np.nonzero(grid)
+        grid_cy = (gy.mean() + 0.5) / 42
+        grid_cx = (gx.mean() + 0.5) / 57
+
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        assert full.shape == (600, 800)
+        fy, fx = np.nonzero(full)
+        # Covered extent = covered_hw((42, 57), 14) = (588, 798).
+        assert abs((fy.mean() + 0.5) / 588 - grid_cy) < 1e-6
+        assert abs((fx.mean() + 0.5) / 798 - grid_cx) < 1e-6
+        # And it is NOT the stretched mapping the fix removes.
+        assert abs((fy.mean() + 0.5) - grid_cy * 600) > 5.0
+
+    def test_upsample_pads_the_truncated_remainder(self):
+        from phenotypic.detect.nn._dino_support import upsample_grid_to_image
+
+        grid = np.ones((42, 57), dtype=bool)
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        assert full.shape == (600, 800)
+        assert full.all()  # edge-padded, no False stripe at 588..600
+
+    def test_resize_mask_to_grid_crops_to_covered_extent(self):
+        from phenotypic.detect.nn._dino_support import resize_mask_to_grid
+
+        mask = np.zeros((600, 800), dtype=bool)
+        mask[588:600, :] = True  # lives ONLY in the truncated remainder
+        small = resize_mask_to_grid(mask, (42, 57), patch=14)
+        assert not small.any()  # the ViT never saw those rows
+
+    def test_round_trip_grid_image_grid_is_identity(self):
+        from phenotypic.detect.nn._dino_support import (
+            resize_mask_to_grid,
+            upsample_grid_to_image,
+        )
+
+        rng = np.random.default_rng(0)
+        grid = rng.random((42, 57)) > 0.5
+        full = upsample_grid_to_image(grid, (600, 800), 14)
+        back = resize_mask_to_grid(full, (42, 57), patch=14)
+        assert (back == grid).all()
+
+    def test_upsample_float_score_map_keeps_dtype_semantics(self):
+        from phenotypic.detect.nn._dino_support import upsample_grid_to_image
+
+        grid = np.linspace(0.0, 1.0, 37 * 37, dtype=np.float32).reshape(37, 37)
+        full = upsample_grid_to_image(grid, (520, 520), 14, order=1)
+        assert full.shape == (520, 520)
+        assert full.dtype != bool
+        assert float(full.max()) <= 1.0 + 1e-6
+
+    def test_align_mask_to_grid_accepts_patch(self):
+        from phenotypic.detect.nn._dino_support import align_mask_to_grid
+
+        mask = np.zeros((600, 800), dtype=bool)
+        mask[588:600, :] = True  # only in the truncated remainder
+        grid = align_mask_to_grid(mask, (600, 800), (42, 57), patch=14)
+        assert grid.shape == (42, 57)
+        assert not grid.any()
+
+    def test_pool_prototype_accepts_patch(self):
+        from phenotypic.detect.nn._dino_support import pool_prototype
+
+        feats = np.zeros((4, 4, 8), np.float32)
+        feats[1:3, 1:3] = 1.0
+        mask = np.zeros((60, 60), bool)
+        mask[16:40, 16:40] = True
+        proto = pool_prototype(feats, mask, patch=14)
+        assert proto.shape == (8,)
+        assert np.all(proto > 0.5)
+
+    def test_cosine_match_to_mask_uses_covered_extent_when_patch_given(self):
+        from phenotypic.detect.nn._dino_support import cosine_match_to_mask
+
+        feats = np.zeros((42, 57, 8), np.float32)
+        feats[20:23, 27:30] = 1.0
+        proto = np.ones(8, np.float32)
+        out = cosine_match_to_mask(
+            feats, proto, thresh=0.9, out_shape=(600, 800), patch=14
+        )
+        assert out.shape == (600, 800)
+        assert out.dtype == bool
+        ys, xs = np.nonzero(out)
+        # Grid block centre (21.5, 28.5) patches → ~(301, 399) px, not stretched.
+        assert abs(ys.mean() - 21.5 * 14) < 14
+        assert abs(xs.mean() - 28.5 * 14) < 14

--- a/tests/unit/detect/nn/test_dino_support.py
+++ b/tests/unit/detect/nn/test_dino_support.py
@@ -400,3 +400,38 @@ class TestCoveredExtentMapping:
         # Grid block centre (21.5, 28.5) patches → ~(301, 399) px, not stretched.
         assert abs(ys.mean() - 21.5 * 14) < 14
         assert abs(xs.mean() - 28.5 * 14) < 14
+
+
+class TestCoveredExtentIsRequiredOnBothDirections:
+    """F6: omitting `patch` is a silent scale error, not a crash.
+
+    The bundled exemplar is 220x300 -- a multiple of neither patch size -- so a
+    grid built from it covers only 208x288 (patch 16) or 210x294 (patch 14).
+    Mapping the exemplar mask over the full 220x300 selects foreground patches
+    the ViT never saw, corrupting the prototype that defines "colony".
+    """
+
+    def test_omitting_patch_selects_different_foreground_patches(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import align_mask_to_grid
+
+        mask = np.zeros((220, 300), dtype=bool)
+        mask[190:215, 20:60] = True  # a colony low in the frame
+
+        without = align_mask_to_grid(mask, (220, 300), (13, 18))
+        with_patch = align_mask_to_grid(mask, (220, 300), (13, 18), 16)
+        assert not np.array_equal(without, with_patch), (
+            "omitting patch must change which patches are foreground; if this "
+            "passes, the covered-extent crop is not being applied"
+        )
+
+    def test_covered_extent_excludes_the_truncated_remainder(self):
+        import numpy as np
+
+        from phenotypic.detect.nn._dino_support import align_mask_to_grid
+
+        # Rows 208..220 are outside the (13, 18) grid's covered extent at patch 16.
+        mask = np.zeros((220, 300), dtype=bool)
+        mask[208:220, :] = True
+        assert not align_mask_to_grid(mask, (220, 300), (13, 18), 16).any()

--- a/tests/unit/detect/nn/test_dino_support.py
+++ b/tests/unit/detect/nn/test_dino_support.py
@@ -82,7 +82,7 @@ def test_pool_prototype_is_masked_mean():
     feats[1:3, 1:3] = 1.0
     mask = np.zeros((4, 4), bool)
     mask[1:3, 1:3] = True
-    proto = pool_prototype(feats, mask)
+    proto = pool_prototype(feats, mask, patch=1)  # 4x4 grid covers the 4x4 mask
     assert np.allclose(proto, np.ones(8))  # mean over masked patches
 
 
@@ -95,7 +95,7 @@ def test_pool_prototype_resizes_full_res_mask_to_grid():
     # Full-res 8x8 mask covering the same central region (2x upsampled).
     mask = np.zeros((8, 8), bool)
     mask[2:6, 2:6] = True
-    proto = pool_prototype(feats, mask)
+    proto = pool_prototype(feats, mask, patch=2)  # 4x4 grid covers the 8x8 mask
     assert np.allclose(proto, np.ones(8))
 
 
@@ -104,7 +104,7 @@ def test_pool_prototype_empty_mask_returns_zero_vector():
 
     feats = np.ones((4, 4, 8), np.float32)
     mask = np.zeros((4, 4), bool)
-    proto = pool_prototype(feats, mask)
+    proto = pool_prototype(feats, mask, patch=1)
     assert proto.shape == (8,)
     assert np.allclose(proto, 0.0)
 
@@ -115,7 +115,7 @@ def test_cosine_match_recovers_prototype_region():
     feats = np.zeros((4, 4, 8), np.float32)
     feats[1:3, 1:3] = 1.0
     proto = np.ones(8, np.float32)
-    out = cosine_match_to_mask(feats, proto, thresh=0.9, out_shape=(8, 8))
+    out = cosine_match_to_mask(feats, proto, thresh=0.9, out_shape=(8, 8), patch=2)
     assert out.dtype == bool and out.shape == (8, 8)
     assert out.any() and not out.all()  # a region, not everything
 
@@ -125,7 +125,7 @@ def test_cosine_match_zero_prototype_is_all_false():
 
     feats = np.ones((4, 4, 8), np.float32)
     proto = np.zeros(8, np.float32)
-    out = cosine_match_to_mask(feats, proto, thresh=0.5, out_shape=(8, 8))
+    out = cosine_match_to_mask(feats, proto, thresh=0.5, out_shape=(8, 8), patch=2)
     assert out.dtype == bool and not out.any()  # fail-safe
 
 
@@ -157,7 +157,7 @@ def test_resize_mask_to_grid_non_square():
     # Non-square full-res mask → square-ish patch grid (order=0 nearest).
     mask = np.zeros((40, 90), bool)
     mask[10:30, 30:60] = True
-    small = resize_mask_to_grid(mask, grid_hw=(4, 9))
+    small = resize_mask_to_grid(mask, grid_hw=(4, 9), patch=10)
     assert small.shape == (4, 9)
     assert small.dtype == bool
     assert small.any() and not small.all()
@@ -171,7 +171,7 @@ def test_align_mask_to_grid_non_square_through_processed_geometry():
     # → a 16x16 patch grid (patch=14). The mask must follow the same path.
     mask = np.zeros((220, 300), bool)
     mask[40:180, 60:240] = True  # central block
-    grid = align_mask_to_grid(mask, proc_hw=(224, 224), grid_hw=(16, 16))
+    grid = align_mask_to_grid(mask, proc_hw=(224, 224), grid_hw=(16, 16), patch=14)
     assert grid.shape == (16, 16)
     assert grid.dtype == bool
     assert grid.any() and not grid.all()  # central region survives, edges off
@@ -188,7 +188,7 @@ def test_pool_prototype_with_proc_hw_aligns_non_square():
     # A non-square full-res mask covering the central region of a 220x300 image.
     mask = np.zeros((220, 300), bool)
     mask[55:165, 75:225] = True
-    proto = pool_prototype(feats, mask, proc_hw=(224, 224))
+    proto = pool_prototype(feats, mask, proc_hw=(224, 224), patch=14)
     assert proto.shape == (4,)
     # Foreground patches are the all-ones block → prototype ≈ ones.
     assert np.all(proto > 0.5)
@@ -411,20 +411,35 @@ class TestCoveredExtentIsRequiredOnBothDirections:
     the ViT never saw, corrupting the prototype that defines "colony".
     """
 
-    def test_omitting_patch_selects_different_foreground_patches(self):
-        import numpy as np
+    def test_patch_cannot_be_omitted(self):
+        """`patch` is required, so the silent-scale-error path is unreachable.
 
-        from phenotypic.detect.nn._dino_support import align_mask_to_grid
+        It was optional once. Omitting it mapped the grid over the whole mask
+        instead of its covered extent, which is a rescale rather than a crash —
+        and it reached production twice, on the query path and then on the
+        exemplar path. A TypeError is the point of this test.
+        """
+        import numpy as np
+        import pytest
+
+        from phenotypic.detect.nn._dino_support import (
+            align_mask_to_grid,
+            cosine_match_to_mask,
+            pool_prototype,
+            resize_mask_to_grid,
+        )
 
         mask = np.zeros((220, 300), dtype=bool)
-        mask[190:215, 20:60] = True  # a colony low in the frame
+        feats = np.ones((13, 18, 4), dtype=np.float32)
 
-        without = align_mask_to_grid(mask, (220, 300), (13, 18))
-        with_patch = align_mask_to_grid(mask, (220, 300), (13, 18), 16)
-        assert not np.array_equal(without, with_patch), (
-            "omitting patch must change which patches are foreground; if this "
-            "passes, the covered-extent crop is not being applied"
-        )
+        with pytest.raises(TypeError):
+            resize_mask_to_grid(mask, (13, 18))
+        with pytest.raises(TypeError):
+            align_mask_to_grid(mask, (220, 300), (13, 18))
+        with pytest.raises(TypeError):
+            pool_prototype(feats, mask)
+        with pytest.raises(TypeError):
+            cosine_match_to_mask(feats, np.ones(4), 0.5, (220, 300))
 
     def test_covered_extent_excludes_the_truncated_remainder(self):
         import numpy as np
@@ -435,3 +450,33 @@ class TestCoveredExtentIsRequiredOnBothDirections:
         mask = np.zeros((220, 300), dtype=bool)
         mask[208:220, :] = True
         assert not align_mask_to_grid(mask, (220, 300), (13, 18), 16).any()
+
+
+class TestBackbonePatchSize:
+    """One source of truth for the patch size, and it never guesses.
+
+    Ten call sites once wrote `int(getattr(cfg, "patch_size", N))` with N=14 in
+    some files and N=16 in others. A backbone missing `patch_size` would have
+    silently disagreed with itself within one run — DINOv2 is patch-14, DINOv3
+    patch-16, and the mismatch rescales every mask rather than raising.
+    """
+
+    def test_reads_the_value_from_the_model(self):
+        import types
+
+        from phenotypic.detect.nn._dino_support import backbone_patch_size
+
+        model = types.SimpleNamespace(config=types.SimpleNamespace(patch_size=16))
+        assert backbone_patch_size(model) == 16
+
+    def test_raises_rather_than_guessing(self):
+        import types
+
+        import pytest
+
+        from phenotypic.detect.nn._dino_support import backbone_patch_size
+
+        with pytest.raises(ValueError, match="patch_size"):
+            backbone_patch_size(types.SimpleNamespace(config=types.SimpleNamespace()))
+        with pytest.raises(ValueError, match="patch_size"):
+            backbone_patch_size(types.SimpleNamespace())

--- a/tests/unit/detect/nn/test_dinosam2_detector.py
+++ b/tests/unit/detect/nn/test_dinosam2_detector.py
@@ -212,8 +212,243 @@ class TestRecipeAlgorithm:
 
 
 # ---------------------------------------------------------------------------
+# F3 — tiled DINO features + crop-pyramid pass-through (no weights)
+# ---------------------------------------------------------------------------
+
+
+class TestDinoSam2Tiling:
+    def test_has_tiling_fields(self):
+        det = DinoSam2Detector()
+        assert det.tile_px == 518  # 14 * 37, an exact DINOv2 patch multiple
+        assert det.tile_overlap == 0.15
+        assert det.crop_n_layers == 1
+        assert det.crop_nms_thresh == 0.7
+        assert det.crop_overlap_ratio == 512 / 1500
+        assert det.crop_n_points_downscale_factor == 1
+
+    def test_pool_prototype_tiled_is_nonzero_for_a_small_colony(self):
+        """F3 regression: on a full plate a 30px colony is 0.16 patches wide,
+        so pool_prototype rounds it to empty and returns a zero vector."""
+        from phenotypic.detect.nn._dino_support import pool_prototype_tiled
+        from phenotypic.detect.nn._tiling import _Tile
+
+        tiles = [_Tile(0, 0, 518, 518)]
+        dense = [np.ones((37, 37, 8), dtype=np.float32)]
+        mask = np.zeros((518, 518), dtype=bool)
+        mask[250:280, 250:280] = True  # 30 px colony
+
+        proto = pool_prototype_tiled(dense, tiles, mask, 14)
+        assert proto.shape == (8,)
+        assert np.any(proto)  # NOT the zero vector
+
+    def test_pool_prototype_tiled_pools_from_the_owning_tile(self):
+        """The prototype must come from the tile whose core holds the centroid."""
+        from phenotypic.detect.nn._dino_support import pool_prototype_tiled
+        from phenotypic.detect.nn._tiling import _plan_tiles
+
+        tiles = _plan_tiles((518, 800), 518, 0.15)
+        assert len(tiles) == 2
+        dense = [
+            np.ones((37, 37, 4), dtype=np.float32),
+            np.full((37, 37, 4), 2.0, dtype=np.float32),
+        ]
+
+        left = np.zeros((518, 800), dtype=bool)
+        left[250:280, 100:130] = True
+        right = np.zeros((518, 800), dtype=bool)
+        right[250:280, 600:630] = True
+
+        assert np.allclose(pool_prototype_tiled(dense, tiles, left, 14), 1.0)
+        assert np.allclose(pool_prototype_tiled(dense, tiles, right, 14), 2.0)
+
+    def test_whole_plate_pooling_collapses_where_tiled_pooling_does_not(self):
+        """The F3 mechanism, at plate scale and without a backbone.
+
+        A plate reaching the ViT at the 224-px classification preset gives a
+        16x16 grid whatever the plate's size, so a 30 px colony is a fraction
+        of one patch, rounds to empty, and pool_prototype returns its
+        zero-vector fail-safe. The same colony inside a 518 px tile spans
+        30 / 14 = 2.1 patches and pools normally.
+        """
+        from phenotypic.detect.nn._dino_support import (
+            pool_prototype,
+            pool_prototype_tiled,
+        )
+        from phenotypic.detect.nn._tiling import _plan_tiles
+
+        shape = (1500, 2000)
+        mask = np.zeros(shape, dtype=bool)
+        mask[1000:1030, 1200:1230] = True  # a 30 px colony
+
+        whole_grid = np.ones((16, 16, 4), dtype=np.float32)  # the 224 preset
+        assert not np.any(pool_prototype(whole_grid, mask))
+
+        tiles = _plan_tiles(shape, 518, 0.15)
+        dense = [np.ones((37, 37, 4), dtype=np.float32) for _ in tiles]
+        assert np.any(pool_prototype_tiled(dense, tiles, mask, 14))
+
+    def test_pool_prototype_tiled_empty_mask_is_the_zero_fail_safe(self):
+        from phenotypic.detect.nn._dino_support import pool_prototype_tiled
+        from phenotypic.detect.nn._tiling import _Tile
+
+        tiles = [_Tile(0, 0, 518, 518)]
+        dense = [np.ones((37, 37, 8), dtype=np.float32)]
+        proto = pool_prototype_tiled(
+            dense, tiles, np.zeros((518, 518), dtype=bool), 14
+        )
+        assert proto.shape == (8,)
+        assert not np.any(proto)
+
+    def test_crop_fields_reach_build_sam2_generator(self, monkeypatch):
+        from phenotypic.detect.nn import _checkpoint_manager as cm
+        from phenotypic.detect.nn import _sam2_detector as sam2_mod
+
+        seen: dict = {}
+        monkeypatch.setattr(cm, "resolve_device", lambda device: "cpu")
+        monkeypatch.setattr(
+            sam2_mod,
+            "build_sam2_generator",
+            lambda *a, **k: (seen.update(k), object())[1],
+        )
+
+        class _FakeModel:
+            def to(self, device):
+                return self
+
+        monkeypatch.setitem(
+            sys.modules,
+            "transformers",
+            types.SimpleNamespace(
+                AutoModel=types.SimpleNamespace(
+                    from_pretrained=lambda repo_id: _FakeModel()
+                ),
+                AutoImageProcessor=types.SimpleNamespace(
+                    from_pretrained=lambda repo_id: object()
+                ),
+            ),
+        )
+
+        det = DinoSam2Detector(
+            device="cpu",
+            crop_n_layers=2,
+            crop_nms_thresh=0.55,
+            crop_overlap_ratio=0.25,
+            crop_n_points_downscale_factor=2,
+        )
+        det._ensure_model_loaded()
+
+        assert seen["crop_n_layers"] == 2
+        assert seen["crop_nms_thresh"] == 0.55
+        assert seen["crop_overlap_ratio"] == 0.25
+        assert seen["crop_n_points_downscale_factor"] == 2
+        assert seen["min_mask_region_area"] == 100
+
+    def test_infer_one_extracts_features_per_tile_not_per_plate(self, monkeypatch):
+        """_infer_one must never hand the whole plate to the ViT: on a
+        600x800 plate at tile_px=518 that is four 518x518 crops."""
+        from phenotypic.detect.nn import _dino_support
+
+        det = DinoSam2Detector(device="cpu")
+        proposal = np.zeros((600, 800), dtype=bool)
+        proposal[300:340, 400:440] = True
+
+        det._device = "cpu"
+        det._dino_processor = object()
+        det._dino_model = types.SimpleNamespace(
+            config=types.SimpleNamespace(patch_size=14, num_register_tokens=0)
+        )
+        det._generator = types.SimpleNamespace(
+            generate=lambda rgb: [
+                {"segmentation": proposal, "predicted_iou": 0.9},
+                {"segmentation": ~proposal, "predicted_iou": 0.8},
+            ]
+        )
+
+        shapes: list = []
+
+        def fake_extract(model, processor, rgb, *, device):
+            shapes.append(rgb.shape[:2])
+            return np.ones((rgb.shape[0] // 14, rgb.shape[1] // 14, 6), np.float32)
+
+        monkeypatch.setattr(_dino_support, "extract_patch_features", fake_extract)
+
+        objmap = det._infer_one(np.zeros((600, 800, 3), dtype=np.uint8))
+
+        assert objmap.shape == (600, 800)
+        assert shapes == [(518, 518)] * 4
+        assert (600, 800) not in shapes
+
+
+# ---------------------------------------------------------------------------
 # Functional — requires foundation + sam2 + weights (skips otherwise)
 # ---------------------------------------------------------------------------
+
+
+def _dinov2_backbone_loadable() -> bool:
+    from phenotypic.detect.nn import FOUNDATION_AVAILABLE
+
+    if not FOUNDATION_AVAILABLE:
+        return False
+    try:
+        from transformers import AutoImageProcessor, AutoModel
+
+        AutoModel.from_pretrained("facebook/dinov2-small")
+        AutoImageProcessor.from_pretrained("facebook/dinov2-small")
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(
+    not _dinov2_backbone_loadable(),
+    reason="Requires transformers + a loadable DINOv2 backbone (ungated)",
+)
+class TestDinoSam2FunctionalDinoV2:
+    def test_prototypes_are_not_all_zero(self, synth_plate):
+        """Direct F3 regression: before the fix every proposal pooled an empty
+        mask and got the zero vector, so all scores were identical.
+
+        ``synth_plate`` is only 600x800, so it cannot reproduce the collapse on
+        its own -- the whole-image grid is already 42x57. The plate-scale
+        mechanism is covered by
+        ``TestDinoSam2Tiling.test_whole_plate_pooling_collapses_where_tiled_pooling_does_not``.
+        What this asserts is that the tiled path pools real DINOv2 features
+        that are non-zero *and* colony-specific.
+        """
+        from transformers import AutoImageProcessor, AutoModel
+
+        from phenotypic.detect.nn._dino_support import (
+            extract_patch_features,
+            pool_prototype_tiled,
+        )
+        from phenotypic.detect.nn._tiling import _plan_tiles
+
+        model = AutoModel.from_pretrained("facebook/dinov2-small").eval()
+        processor = AutoImageProcessor.from_pretrained("facebook/dinov2-small")
+        patch = int(model.config.patch_size)
+
+        rgb = np.asarray(synth_plate.rgb[:], dtype=np.uint8)
+        objmap = np.asarray(synth_plate.objmap[:])
+        labels = np.unique(objmap)[1:6]
+
+        tiles = _plan_tiles(rgb.shape[:2], 518, 0.15)
+        dense = [
+            extract_patch_features(
+                model, processor, rgb[t.y0:t.y1, t.x0:t.x1], device="cpu"
+            )
+            for t in tiles
+        ]
+        protos = [
+            pool_prototype_tiled(dense, tiles, objmap == lab, patch)
+            for lab in labels
+        ]
+
+        print(f"tiles={len(tiles)} dense_grid={dense[0].shape} patch={patch}")
+        print(f"norms={[round(float(np.linalg.norm(p)), 3) for p in protos]}")
+        print(f"distinct={len({tuple(np.round(p, 4)) for p in protos})}/{len(protos)}")
+
+        assert all(np.any(pr) for pr in protos)
+        assert len({tuple(np.round(pr, 4)) for pr in protos}) > 1
 
 
 def _dinosam2_runnable() -> bool:

--- a/tests/unit/detect/nn/test_dinosam2_detector.py
+++ b/tests/unit/detect/nn/test_dinosam2_detector.py
@@ -281,7 +281,10 @@ class TestDinoSam2Tiling:
         mask[1000:1030, 1200:1230] = True  # a 30 px colony
 
         whole_grid = np.ones((16, 16, 4), dtype=np.float32)  # the 224 preset
-        assert not np.any(pool_prototype(whole_grid, mask))
+        # proc_hw is the geometry the plate actually reached the ViT at.
+        assert not np.any(
+            pool_prototype(whole_grid, mask, proc_hw=(224, 224), patch=14)
+        )
 
         tiles = _plan_tiles(shape, 518, 0.15)
         dense = [np.ones((37, 37, 4), dtype=np.float32) for _ in tiles]

--- a/tests/unit/detect/nn/test_fssdino_detector.py
+++ b/tests/unit/detect/nn/test_fssdino_detector.py
@@ -102,6 +102,34 @@ class TestFssDinoConstruction:
 # ---------------------------------------------------------------------------
 
 
+class TestFssDinoResolution:
+    def test_tile_px_default_is_a_dinov2_patch_multiple(self):
+        det = FssDinoDetector()
+        assert det.dino_version == 2
+        assert det.tile_px == 518
+        assert det.tile_px % 14 == 0   # 14 * 37
+
+    def test_segment_crop_upsamples_through_covered_extent(self, monkeypatch):
+        """A 600x800 crop at patch 14 has a (42, 57) grid covering 588x798.
+        The returned mask must be 600x800 with no scale error."""
+        det = FssDinoDetector(dino_version=2)
+        det._device = "cpu"
+        det._model = type("M", (), {"config": type("C", (), {"patch_size": 14})()})()
+        det._processor = object()
+        det._fg_prototypes = np.ones((1, 4), dtype=np.float64)
+        det._bg_prototypes = np.zeros((1, 4), dtype=np.float64)
+        det._fg_gram = np.eye(4)
+        det._bg_gram = np.eye(4)
+
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.extract_hidden_layer_features",
+            lambda *a, **k: np.ones((42, 57, 4), dtype=np.float32),
+        )
+        out = det._segment_crop(np.zeros((600, 800, 3), dtype=np.uint8))
+        assert out.shape == (600, 800)
+        assert out.dtype == bool
+
+
 class TestFssDinoAlgorithm:
     def test_cluster_prototypes_kmeans_cosine(self):
         from phenotypic.detect.nn._fssdino_detector import cluster_prototypes
@@ -221,6 +249,20 @@ class TestFssDinoFunctionalDinoV2:
         assert objmask.any(), "FssDinoDetector produced an empty objmask"
         # Semantic route: objmap auto-labels from objmask (Spec 1 §8 invariant).
         assert np.array_equal(objmap[:] > 0, objmask[:])
+
+    def test_dense_grid_is_native_not_224(self, synth_plate):
+        """Direct F1 regression: synth_plate is 600x800, so at patch 14 the
+        grid must be (42, 57). Before the fix every tile was squashed to
+        224x224 -> a (16, 16) grid."""
+        from transformers import AutoImageProcessor, AutoModel
+
+        from phenotypic.detect.nn._dino_support import extract_patch_features
+
+        m = AutoModel.from_pretrained("facebook/dinov2-small").eval()
+        p = AutoImageProcessor.from_pretrained("facebook/dinov2-small")
+        rgb = np.asarray(synth_plate.rgb[:], dtype=np.uint8)
+        dense = extract_patch_features(m, p, rgb, device="cpu")
+        assert dense.shape[:2] == (600 // 14, 800 // 14) == (42, 57)
 
 
 if __name__ == "__main__":

--- a/tests/unit/detect/nn/test_insid3_detector.py
+++ b/tests/unit/detect/nn/test_insid3_detector.py
@@ -88,6 +88,38 @@ class TestInsid3Construction:
             det._ensure_model_loaded()
 
 
+class TestInsid3Resolution:
+    def test_tile_px_default_is_a_dinov3_patch_multiple(self):
+        det = Insid3Detector()
+        assert det.dino_version == 3
+        assert det.tile_px == 512
+        assert det.tile_px % 16 == 0   # 16 * 32
+
+    def test_match_crop_threads_patch_into_cosine_match(self, monkeypatch):
+        det = Insid3Detector()
+        det._device = "cpu"
+        det._model = type("M", (), {"config": type("C", (), {"patch_size": 16})()})()
+        det._processor = object()
+        det._basis = np.zeros((4, 0))
+        det._prototype = np.ones(4)
+
+        seen = {}
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.extract_patch_features",
+            lambda *a, **k: np.ones((32, 32, 4), dtype=np.float32),
+        )
+
+        def fake_match(features, prototype, thresh, out_shape, patch=None):
+            seen["patch"] = patch
+            return np.zeros(out_shape, dtype=bool)
+
+        monkeypatch.setattr(
+            "phenotypic.detect.nn._dino_support.cosine_match_to_mask", fake_match
+        )
+        det._match_crop(np.zeros((512, 512, 3), dtype=np.uint8))
+        assert seen["patch"] == 16
+
+
 # ---------------------------------------------------------------------------
 # Faithful INSID3 positional-bias removal (C2) — synthetic features, no model
 # ---------------------------------------------------------------------------

--- a/tests/unit/detect/nn/test_sam2_detector.py
+++ b/tests/unit/detect/nn/test_sam2_detector.py
@@ -29,12 +29,13 @@ class TestSam2DetectorConstruction:
         assert det.pred_iou_thresh == 0.7
         assert det.stability_score_thresh == 0.92
         assert det.min_mask_region_area == 100
-        # Native SAM2 crop knobs default to upstream AMG values (sliding
-        # window off → stock single full-image pass).
-        assert det.crop_n_layers == 0
+        # Native SAM2 crop-pyramid knobs default to upstream AMG values,
+        # except crop_n_layers, which PhenoTypic engages by default.
+        assert det.crop_n_layers == 1
         assert det.crop_nms_thresh == 0.7
         assert det.crop_overlap_ratio == 512 / 1500
         assert det.crop_n_points_downscale_factor == 1
+        assert det.box_nms_thresh == 0.7
         assert det.device == "auto"
         assert det.checkpoint is None
         assert det.config is None
@@ -247,6 +248,26 @@ class TestSam2DetectorFunctional:
         ])
         result = pipeline.apply(synth_plate.copy(), inplace=False)
         assert result.objmap[:].max() > 0
+
+
+class TestSam2CropPyramid:
+    def test_crop_pyramid_is_engaged_by_default(self):
+        from phenotypic.detect.nn import Sam2Detector
+
+        det = Sam2Detector()
+        assert det.crop_n_layers == 1
+        assert det.box_nms_thresh == 0.7
+
+    def test_build_sam2_generator_accepts_box_nms_thresh(self):
+        """`box_nms_thresh` dedups the dense point grid's redundant proposals
+        within one crop. SAM2 exposes it; Sam2Detector did not."""
+        import inspect
+
+        from phenotypic.detect.nn._sam2_detector import build_sam2_generator
+
+        sig = inspect.signature(build_sam2_generator)
+        assert "box_nms_thresh" in sig.parameters
+        assert sig.parameters["box_nms_thresh"].default == 0.7
 
 
 if __name__ == "__main__":

--- a/tests/unit/detect/nn/test_sam3_detector.py
+++ b/tests/unit/detect/nn/test_sam3_detector.py
@@ -114,7 +114,7 @@ class TestSam3Tiling:
     def test_merge_dedups_overlapping_instances(self):
         import numpy as np
 
-        from phenotypic.detect.nn._sam3_detector import _merge_tiles_iou_nms
+        from phenotypic.detect.nn._tiling import _merge_tiles_iou_nms
 
         a = np.zeros((10, 10), np.uint16)
         a[2:6, 2:6] = 1
@@ -126,7 +126,7 @@ class TestSam3Tiling:
     def test_merge_keeps_distinct_instances(self):
         import numpy as np
 
-        from phenotypic.detect.nn._sam3_detector import _merge_tiles_iou_nms
+        from phenotypic.detect.nn._tiling import _merge_tiles_iou_nms
 
         a = np.zeros((10, 10), np.uint16)
         a[1:3, 1:3] = 1
@@ -134,6 +134,89 @@ class TestSam3Tiling:
         b[7:9, 7:9] = 1  # disjoint blob
         merged = _merge_tiles_iou_nms([a, b], iou_thresh=0.5)
         assert merged.max() == 2  # two distinct instances survive
+
+
+class TestSam3UsesCentroidCore:
+    """Task 6: ``_infer_batch`` hands **tile-local** objmaps to the merge."""
+
+    def test_infer_batch_merges_by_centroid_core(self, monkeypatch):
+        """A colony straddling a tile seam must yield one instance, not a
+        colony plus its fragment."""
+        import numpy as np
+
+        det = Sam3Detector(tile_px=100, tile_overlap=0.2)
+        monkeypatch.setattr(det, "_ensure_model_loaded", lambda: None)
+
+        # _plan_tiles((100, 180), 100, 0.2) -> [(0,0,100,100), (0,80,100,180)].
+        # Tile 0 sees the whole colony at global cols 70..90; tile 1 sees only
+        # its fragment at global cols 80..90.
+        def fake_forward(crops):
+            out = []
+            for i, c in enumerate(crops):
+                om = np.zeros(c.shape[:2], dtype=np.uint16)
+                if i == 0:
+                    om[40:60, 70:90] = 1  # whole colony, tile-local
+                else:
+                    om[40:60, 0:10] = 1  # fragment, tile-local
+                out.append(om)
+            return out
+
+        monkeypatch.setattr(det, "_forward_tiles", fake_forward)
+        sample = np.zeros((100, 180, 3), dtype=np.uint8)
+        (result,) = det._infer_batch([sample])
+        assert result.shape == (100, 180)
+        labels = [lab for lab in np.unique(result) if lab]
+        assert len(labels) == 1  # not colony + fragment
+        assert int((result == labels[0]).sum()) == 20 * 20  # area uncorrupted
+
+    def test_infer_batch_does_not_double_offset(self, monkeypatch):
+        """The merge receives tile-local maps, so a colony seen only by the
+        second tile must land at its true global coordinates.
+
+        Offsetting the crop objmaps before the merge would make
+        ``assign_by_centroid_core`` add ``tile.x0`` a second time — one
+        plausible-looking instance, wrong place.
+        """
+        import numpy as np
+
+        det = Sam3Detector(tile_px=100, tile_overlap=0.2)
+        monkeypatch.setattr(det, "_ensure_model_loaded", lambda: None)
+
+        # Tile 1 spans global cols 80..180; the colony sits at tile-local
+        # cols 40..60 -> global cols 120..140, rows 40..60.
+        def fake_forward(crops):
+            out = []
+            for i, c in enumerate(crops):
+                om = np.zeros(c.shape[:2], dtype=np.uint16)
+                if i == 1:
+                    om[40:60, 40:60] = 1
+                out.append(om)
+            return out
+
+        monkeypatch.setattr(det, "_forward_tiles", fake_forward)
+        (result,) = det._infer_batch([np.zeros((100, 180, 3), dtype=np.uint8)])
+        ys, xs = np.nonzero(result)
+        assert (ys.min(), ys.max()) == (40, 59)
+        assert (xs.min(), xs.max()) == (120, 139)
+
+    def test_empty_batch_yields_no_results(self, monkeypatch):
+        det = Sam3Detector()
+        monkeypatch.setattr(det, "_ensure_model_loaded", lambda: None)
+        assert det._infer_batch([]) == []
+
+
+class TestSam3TileMergeIouDeprecated:
+    def test_field_survives_json_round_trip(self):
+        pipe = ImagePipeline(ops=[Sam3Detector(tile_merge_iou=0.25)])
+        det = ImagePipeline.from_json(pipe.to_json()).get_ops()["Sam3Detector"]
+        assert det.tile_merge_iou == 0.25
+
+    def test_docstring_marks_it_deprecated(self):
+        doc = Sam3Detector.__doc__ or ""
+        arg_line = next(
+            (ln for ln in doc.splitlines() if "tile_merge_iou:" in ln), ""
+        )
+        assert "Deprecated" in arg_line
 
 
 class TestSam3TilingBatchInteraction:

--- a/tests/unit/detect/nn/test_tiling.py
+++ b/tests/unit/detect/nn/test_tiling.py
@@ -256,3 +256,58 @@ class TestAssignByCentroidCore:
         b = np.zeros((100, 100), dtype=np.uint16)
         assign_by_centroid_core(tiles, [a, b], (100, 180))
         assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]
+
+
+class TestAssignByCentroidCoreMemory:
+    """The merge must not scale memory with the *instance* count.
+
+    Materializing one full-image boolean mask per survivor costs H*W bytes each,
+    and all survivors are alive at once for the largest-first sort. On a
+    4000x3000 plate with 1000 colonies that measured 12 GB of peak allocation.
+    Painting from each survivor's tile-local slice instead keeps the working set
+    at one tile plus the output objmap.
+    """
+
+    def test_peak_allocation_does_not_scale_with_instances(self):
+        import tracemalloc
+        import warnings
+
+        import numpy as np
+
+        from phenotypic.detect.nn._tiling import (
+            _plan_tiles,
+            assign_by_centroid_core,
+        )
+
+        h, w, n_inst = 800, 1200, 300
+        tiles = _plan_tiles((h, w), 518, 0.15)
+        rng = np.random.default_rng(0)
+        per_tile = []
+        for t in tiles:
+            om = np.zeros((t.h, t.w), dtype=np.uint16)
+            for lab in range(1, n_inst + 1):
+                cy = int(rng.integers(30, h - 30)) - t.y0
+                cx = int(rng.integers(30, w - 30)) - t.x0
+                ys = slice(max(0, cy - 10), min(t.h, cy + 10))
+                xs = slice(max(0, cx - 10), min(t.w, cx + 10))
+                if ys.stop > ys.start and xs.stop > xs.start:
+                    om[ys, xs] = lab
+            per_tile.append(om)
+
+        tracemalloc.start()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            assign_by_centroid_core(tiles, per_tile, (h, w))
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        # Mechanism-derived bound. One full-image bool per survivor would be
+        # n_inst * h * w bytes (~288 MB here); the tile-local form needs only the
+        # uint16 objmap (h*w*2 = 1.9 MB) plus one tile. 20 MB leaves ample slack
+        # for numpy temporaries while still failing by an order of magnitude if
+        # per-instance full-image masks return.
+        one_full_image_mask_per_instance = n_inst * h * w
+        assert peak < 20_000_000, (
+            f"peak {peak/1e6:.0f} MB; per-instance full-image masks would cost "
+            f"{one_full_image_mask_per_instance/1e6:.0f} MB"
+        )

--- a/tests/unit/detect/nn/test_tiling.py
+++ b/tests/unit/detect/nn/test_tiling.py
@@ -1,17 +1,24 @@
-"""Shared tiling module (Spec 2b, Task 3).
+"""Shared tiling module (Spec 2b, Task 3; centroid-in-core merge, Task 5).
 
 The fixed-geometric tiling was extracted from ``_sam3_detector`` to ``_tiling``
-so the semantic detectors reuse it. These tests exercise the new module path
-directly (the SAM3 suite still imports the re-exported names and stays green),
-plus the semantic union stitch.
+so the semantic detectors reuse it, and the cross-tile instance merge followed.
+These tests exercise the new module path directly (the SAM3 suite still imports
+the re-exported names and stays green): tile planning, the semantic union
+stitch, the legacy IoU-NMS merge, and the centroid-in-core merge that replaces
+it for tiled instance detection.
 """
 
 import numpy as np
+import pytest
 
 from phenotypic.detect.nn._tiling import (
+    _merge_tiles_iou_nms,
     _plan_tiles,
     _Tile,
+    assign_by_centroid_core,
+    owning_tile_index,
     stitch_semantic_tiles,
+    tile_overlap_px,
 )
 
 
@@ -80,7 +87,172 @@ class TestStitchSemanticTiles:
         assert np.array_equal(full, m)
 
     def test_length_mismatch_raises(self):
-        import pytest
-
         with pytest.raises(ValueError, match="tiles"):
             stitch_semantic_tiles([_Tile(0, 0, 2, 2)], [], out_shape=(2, 2))
+
+
+# ---------------------------------------------------------------------------
+# Instance merge: IoU-NMS (moved here from _sam3_detector)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTilesIouNms:
+    def test_merge_dedups_overlapping_instances(self):
+        a = np.zeros((10, 10), np.uint16)
+        a[2:6, 2:6] = 1
+        b = np.zeros((10, 10), np.uint16)
+        b[2:6, 2:6] = 1  # same blob from neighbour tile
+        merged = _merge_tiles_iou_nms([a, b], iou_thresh=0.5)
+        assert merged.max() == 1
+
+    def test_merge_keeps_distinct_instances(self):
+        a = np.zeros((10, 10), np.uint16)
+        a[1:3, 1:3] = 1
+        b = np.zeros((10, 10), np.uint16)
+        b[7:9, 7:9] = 1  # disjoint blob
+        merged = _merge_tiles_iou_nms([a, b], iou_thresh=0.5)
+        assert merged.max() == 2
+
+    def test_sam3_detector_reexports_the_merge(self):
+        from phenotypic.detect.nn import _sam3_detector
+
+        assert _sam3_detector._merge_tiles_iou_nms is _merge_tiles_iou_nms
+        assert _sam3_detector._iou is not None
+
+    def test_fragment_survives_iou_nms(self):
+        """Documents the bug centroid-in-core exists to fix.
+
+        IoU(whole, fragment) equals the fragment's area fraction, so a
+        fragment covering <= iou_thresh of its parent is never suppressed.
+        """
+        whole = np.zeros((20, 20), np.uint16)
+        whole[5:15, 5:15] = 1  # 100 px
+        frag = np.zeros((20, 20), np.uint16)
+        frag[5:15, 5:9] = 1  # 40 px, IoU == 0.4 <= 0.5
+        merged = _merge_tiles_iou_nms([whole, frag], iou_thresh=0.5)
+        assert merged.max() == 2  # the fragment survives as a second instance
+
+
+# ---------------------------------------------------------------------------
+# Instance merge: centroid-in-core (Task 5)
+# ---------------------------------------------------------------------------
+
+
+class TestTileOverlapPx:
+    def test_overlap_of_two_tiles(self):
+        assert tile_overlap_px([_Tile(0, 0, 100, 100), _Tile(0, 80, 100, 180)]) == 20
+
+    def test_single_tile_has_no_overlap(self):
+        assert tile_overlap_px([_Tile(0, 0, 10, 10)]) == 0
+
+    def test_abutting_tiles_do_not_overlap(self):
+        assert tile_overlap_px([_Tile(0, 0, 10, 10), _Tile(0, 10, 10, 20)]) == 0
+
+    def test_smallest_pairwise_overlap_wins(self):
+        tiles = _plan_tiles((100, 180), tile_px=100, overlap=0.2)
+        assert tile_overlap_px(tiles) == 20
+
+
+class TestOwningTileIndex:
+    def test_whole_and_fragment_resolve_to_the_same_tile(self):
+        tiles = _plan_tiles((100, 180), tile_px=100, overlap=0.2)
+        assert [(t.y0, t.x0, t.y1, t.x1) for t in tiles] == [
+            (0, 0, 100, 100),
+            (0, 80, 100, 180),
+        ]
+        # Whole colony centred at x=79.5 (tile 0 only contains it).
+        assert owning_tile_index(tiles, (49.5, 79.5)) == 0
+        # Its fragment in tile 1 is centred at x=84.5 — still nearer tile 0's
+        # centre (x=50) than tile 1's (x=130), so tile 1 declines to claim it.
+        assert owning_tile_index(tiles, (49.5, 84.5)) == 0
+
+    def test_border_tile_core_reaches_the_image_edge(self):
+        tiles = _plan_tiles((100, 180), tile_px=100, overlap=0.2)
+        assert owning_tile_index(tiles, (2.0, 178.0)) == 1
+        assert owning_tile_index(tiles, (2.0, 1.0)) == 0
+
+    def test_single_tile_always_owns(self):
+        assert owning_tile_index([_Tile(0, 0, 50, 50)], (25.0, 25.0)) == 0
+
+
+class TestAssignByCentroidCore:
+    def _two_tiles(self):
+        # 100x180 image, two 100x100 tiles overlapping by 20 px.
+        return [_Tile(0, 0, 100, 100), _Tile(0, 80, 100, 180)]
+
+    def test_fragment_regression_one_colony_stays_one(self):
+        """A colony fully inside tile A also appears as a fragment in tile B.
+
+        Under ``_merge_tiles_iou_nms(iou_thresh=0.5)`` the fragment survives
+        (IoU == area fraction) and paints OVER the colony. Centroid-in-core
+        must yield exactly one instance with its area intact.
+        """
+        tiles = self._two_tiles()
+        # Colony spans image cols 70..90 -> inside A (0..100); B (80..180)
+        # sees only cols 80..90 as a fragment.
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[40:60, 70:90] = 1  # whole, tile-local
+        b = np.zeros((100, 100), dtype=np.uint16)
+        b[40:60, 0:10] = 1  # fragment, tile-local
+
+        merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        labels = [lbl for lbl in np.unique(merged) if lbl]
+        assert len(labels) == 1
+        assert int((merged == labels[0]).sum()) == 20 * 20
+
+    def test_instance_claimed_by_exactly_one_tile(self):
+        tiles = self._two_tiles()
+        # Colony wholly inside the overlap band, cols 82..88: both tiles see it
+        # whole, so both emit an identical instance.
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[10:20, 82:88] = 1
+        b = np.zeros((100, 100), dtype=np.uint16)
+        b[10:20, 2:8] = 1
+        merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        assert len([lbl for lbl in np.unique(merged) if lbl]) == 1
+
+    def test_single_tile_relabels_contiguously(self):
+        t = [_Tile(0, 0, 50, 50)]
+        om = np.zeros((50, 50), dtype=np.uint16)
+        om[5:10, 5:10] = 7
+        om[20:25, 20:25] = 9
+        merged = assign_by_centroid_core(t, [om], (50, 50))
+        assert sorted(int(lbl) for lbl in np.unique(merged) if lbl) == [1, 2]
+
+    def test_labels_are_assigned_largest_first(self):
+        t = [_Tile(0, 0, 50, 50)]
+        om = np.zeros((50, 50), dtype=np.uint16)
+        om[0:2, 0:2] = 1  # 4 px, small
+        om[10:20, 10:20] = 2  # 100 px, large
+        merged = assign_by_centroid_core(t, [om], (50, 50))
+        assert merged[15, 15] == 1  # largest gets label 1
+        assert merged[0, 0] == 2
+
+    def test_empty_input_returns_empty_objmap(self):
+        tiles = self._two_tiles()
+        blank = np.zeros((100, 100), dtype=np.uint16)
+        merged = assign_by_centroid_core(tiles, [blank, blank.copy()], (100, 180))
+        assert merged.shape == (100, 180)
+        assert merged.dtype == np.uint16
+        assert not merged.any()
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError, match="tiles"):
+            assign_by_centroid_core(self._two_tiles(), [], (100, 180))
+
+    def test_overlap_guard_warns_when_colony_exceeds_overlap(self):
+        tiles = self._two_tiles()  # overlap_px == 20
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[10:70, 30:90] = 1  # d == 60 > 20
+        b = np.zeros((100, 100), dtype=np.uint16)
+        with pytest.warns(UserWarning, match="overlap"):
+            merged = assign_by_centroid_core(tiles, [a, b], (100, 180))
+        assert len([lbl for lbl in np.unique(merged) if lbl]) == 1  # not deleted
+
+    def test_no_overlap_warning_when_instance_fits(self, recwarn):
+        tiles = self._two_tiles()
+        a = np.zeros((100, 100), dtype=np.uint16)
+        a[40:50, 40:50] = 1  # d == 10 <= 20
+        b = np.zeros((100, 100), dtype=np.uint16)
+        assign_by_centroid_core(tiles, [a, b], (100, 180))
+        assert not [w for w in recwarn.list if issubclass(w.category, UserWarning)]


### PR DESCRIPTION
## Summary

Started as one question — *"at what resolution does SAM2 accept images?"* — and turned up six defects across the GPU detectors. Every number below is measured in-repo, not inferred from docstrings.

**The headline:** `tile_px` had no effect on resolution, and larger values made it worse. Every tile reached the ViT at **224×224** regardless, because `_dino_support.py` let the checkpoint's *classification* preset decide the input size.

## Findings

| | Defect | Evidence |
|---|---|---|
| **F1** | `tile_px` inert — every tile fed to the ViT at 224×224 | FssDino 32.0 native px/patch, Insid3 73.1 |
| **F2** | Query-side mask misregistration (DINOv2 center crop never inverted) | ~6% radial displacement at tile seams |
| **F3** | DinoSam2 pooled every colony into the **same zero vector** | 10/10 zero prototypes, 1 distinct → 0/10, 10 distinct |
| **F4** | Sam2's crop pyramid switched off (`crop_n_layers=0`) | 3.91 × 2.93 native px per encoder px |
| **F5** | Sam3 split seam-straddling colonies into two labels | old merge fails **11 / 155** seam offsets |
| **F6** | Exemplar mask stretched over rows the ViT never saw | prototype cosine(buggy, fixed) = **0.4436** |

## Measured accuracy

Gate plate: `synth_plate` replicated 3×4 → 1800×3200, **1152 ground-truth colonies**. Baseline restores the 224 preset; both arms plan the same 32 tiles, so the comparison isolates the processor policy.

```
FssDino  224 preset (pre-fix)   IoU 0.1961     31 / 1152
FssDino  1:1 native (post-fix)  IoU 0.5947    962 / 1152
Sam2     crop_n_layers=0        IoU 0.4076    481 / 1152
Sam2     crop_n_layers=1        IoU 0.8722   1079 / 1152
```

Object counts rise *toward* 1152 without overshooting — the gain is recovered colonies, not over-segmentation. Both arms independently reproduced outside the gate script.

**The gate does not validate Insid3.** It scores ~0 IoU in both arms and finds 8 of 96 colonies on the un-replicated plate at its default `similarity_thresh=0.5`. That is a threshold-calibration weakness predating this work, not a scale bug — its detection *rate* is flat (8.3% small, 8.9% large). Documented, not papered over.

## Design decisions worth a reviewer's attention

**Sam3's tile merge is centroid-in-core, not a port of SAM2's `is_box_near_crop_edge`.** Edge rejection needs `overlap_px ≥ d + 2·atol` or a colony is rejected from *every* tile and silently **deleted**. SAM2 survives that only because its pyramid always runs a full-image layer and its `1/box_area` NMS outvotes the coarse copy — uniform tiles have neither defense. At `tile_px=512, overlap=0.15, atol=20` the safe diameter is 37 px while the synth plate's median colony is 39 px. Centroid-in-core relaxes the bound to `overlap_px ≥ d`, needs no tolerance parameter, and cannot duplicate by construction. Verified over **9801 2-D positions including every 4-tile corner junction**: exactly one instance, full area, at every one.

**`patch` is now required.** It was optional (`patch: int | None = None`), and omitting it was a *silent rescale, not a crash*. That bug reached production twice on this branch — the query path (F2) and then the exemplar path (F6). `_dino_support` is private, so nothing external depended on the default. `backbone_patch_size()` also replaces ten sites of `getattr(cfg, "patch_size", N)` that used **N=14 in two files and N=16 in two others**.

**`assign_by_centroid_core` no longer materializes a full-image mask per instance** — 12,024 MB → 24 MB peak, 7.10s → 0.92s on a 3000×4000 plate with 1000 colonies. Output is bit-identical on four golden fixtures.

**`config.image_size` is not a native-resolution signal** — DINOv2 reports 518, DINOv3 reports **224**. Defaulting to it would have set Insid3 to exactly the broken value. The new `tile_px` defaults (`518 = 14×37`, `512 = 16×32`) are a *compute* choice: under 1:1, resolution is pinned at `patch_size`, and larger tiles cost more for identical fidelity (518 vs 1022 → 3.3×).

## Behaviour changes

- DINO detectors now feed native geometry. Pipelines deserialized from JSON keep their pinned `tile_px` (`to_json()` writes every field) but **produce different, higher-resolution masks** at higher cost. Re-serialize to adopt new defaults.
- `Sam2Detector.crop_n_layers` 0 → 1 (~5.2×) for **newly-constructed** detectors only.
- `Sam3Detector.tile_merge_iou` is deprecated and ignored, retained so old pipelines still `from_json`.

## Verification

- **213 tests pass**, `ruff` clean. New regression tests are mutation-checked — each fails when its bug is reintroduced.
- Corrected an error inherited verbatim from **upstream SAM2's own docstring**: crops per layer are `(2**n)**2`, not `2**i`.
- Pre-existing and untouched: `_checkpoint_manager.py:358,528` fail `mypy` standalone.

## Still open

- `facebook/sam3` remains gated (403), so `Sam3Detector.tile_px = 1008` is carried as an **assumption**, not a verified fact.
- `micro_sam` is conda-only and absent; `MicroSamDetector` is unverified and out of scope (it alone defaults to `input_layer="gray"`).
- Insid3's `similarity_thresh` calibration.

Spec: `docs/superpowers/specs/2026-07-08-gpu-detect-fixes/`
Plan: `docs/superpowers/plans/2026-07-08-gpu-detect-fixes.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9hitN7pwYTLq6UpSSkhET
