### PR TITLE
docs: add CLI execution modes tutorial; remove dead --gpu-batch-size flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,6 @@
     - `--gpu-shards N` (default 1) — parallel whole-GPU Stage-2 tasks (SLURM-only).
     - `--gpu-workers-per-gpu W` (default 1) — replicas packed per GPU (small-model
       fill).
-    - `--gpu-batch-size N|auto` (default 1) — images/forward (batchable models; `auto`
-      VRAM-probe lands in Spec 2).
 - `uv run python -m phenotypic.tune run spec.json -i <images> -o <out>` —
   hyperparameter tuning (grid/random + Optuna), distributed via `--slurm`/
   `--storage-url`

--- a/docs/source/api_reference/cli_reference.rst
+++ b/docs/source/api_reference/cli_reference.rst
@@ -3,6 +3,9 @@ CLI Reference
 
 PhenoTypic provides a command-line interface for batch processing plate images.
 
+For a guided walkthrough of the execution modes and the parameters worth
+knowing, see the :doc:`CLI Execution Modes tutorial </tutorials/pages/cli_modes>`.
+
 Usage
 -----
 
@@ -31,22 +34,27 @@ Image Options
 -------------
 
 ``--image-type {Image,GridImage}``
-   Image class to use for loading. Default: ``Image``.
+   Image class to use for loading. Case-insensitive. Default: ``GridImage``.
 
 ``--nrows N``
-   Number of grid rows (GridImage only). Default: 8.
+   Number of grid rows (GridImage only). Overrides any pipeline-level preset;
+   when omitted, the pipeline preset is used, falling back to 8.
 
 ``--ncols N``
-   Number of grid columns (GridImage only). Default: 12.
+   Number of grid columns (GridImage only). Overrides any pipeline-level preset;
+   when omitted, the pipeline preset is used, falling back to 12.
 
 ``--bit-depth {8,16}``
    Force bit depth. Default: auto-detect.
 
 ``--detect-mode MODE``
-   Detection matrix source channel. Default: ``gray``.
+   Detection matrix source channel. One of ``gray``, ``red``, ``green``,
+   ``blue``, ``MinRGB``, ``HsvS``, ``HsvV``, ``InvS``, ``LabL``, ``LabA``,
+   ``LabB``. Default: ``gray``.
 
 ``--ext EXT``
-   File extension filter (e.g., ``.png``, ``.jpg``). Default: all supported formats.
+   Deprecated for HDF output. Forward runs write a single ``.h5`` per image;
+   only overlay PNG rendering still consults this value. Default: ``tiff``.
 
 Execution Options
 -----------------
@@ -59,21 +67,27 @@ Execution Options
 
    ``measure``
       Re-run measurements from HDF files in an existing output root. Requires
-      ``--pipeline`` and ``--output``. Rejects ``--input`` and ``--dry-run``.
+      ``--pipeline`` and ``--output``. Rejects ``--input``, ``--dry-run``,
+      ``--resume``, ``--restart``, ``--retry-failures``, ``--overwrite``, and
+      ``--sample``.
 
    ``recompile``
       Rebuild aggregate deliverables from an existing output root. Requires
       ``--output``. Rejects ``--pipeline``, ``--input``, and ``--dry-run``.
 
    ``process``
-      Apply the pipeline and export one image layer per input. Requires
-      ``--pipeline``, ``--input``, ``--output``, and ``--layer``.
+      Apply the pipeline and export one image layer per input, mirroring the
+      input tree. Requires ``--pipeline``, ``--input``, ``--output``, and
+      ``--layer``. Warns that ``--metadata``, ``--no-qc``, and
+      ``--no-dataset-column`` are ignored.
 
 ``--layer {rgb,gray,detect_mat,objmap}``
-   Image layer exported by ``--mode process``. Rejected in other modes.
+   Image layer exported by ``--mode process``; required there and rejected in
+   other modes. ``rgb`` writes an integer TIFF at the source bit depth,
+   ``gray``/``detect_mat`` a float TIFF, ``objmap`` a 16-bit raw-label PNG.
 
 ``--njobs N``
-   Number of parallel worker processes. Default: all available CPUs.
+   Number of parallel jobs for local execution. Default: ``-1`` (all cores).
 
 ``--force-local``
    Run locally even if SLURM is available.
@@ -83,7 +97,7 @@ Execution Options
    ``full`` and ``process`` modes; rejected by ``measure`` and ``recompile``.
 
 ``--sample N``
-   Process only N random images (for testing).
+   Process only N random images per dataset (for testing).
 
 ``--random-seed SEED``
    Random seed for ``--sample`` reproducibility.
@@ -104,29 +118,68 @@ Resume and Recovery
    Reprocess all images. Mutually exclusive with ``--resume``.
 
 ``--checkpoint-interval N``
-   Save checkpoint state every N images. Default: 100.
+   Insert checkpoint tasks every N images in SLURM arrays. Default:
+   auto-estimate.
 
 SLURM Options
 -------------
 
 ``--slurm KEY=VALUE``
    Pass SLURM scheduling parameters as repeated key-value pairs (e.g.,
-   ``--slurm time=04:00:00 --slurm partition=gpu``).
+   ``--slurm slurm_partition=compute --slurm mem_gb=16 --slurm time=120``).
+   Use the ``slurm_`` prefix for standard SBATCH directives, or the convenience
+   keys ``mem_gb`` and ``time``. ``time`` is an **integer number of minutes**.
+   The deprecated ``time_min`` key is auto-migrated to ``time``.
 
 ``--wait``
-   Wait for SLURM jobs to complete before returning.
+   Wait for SLURM jobs to complete before returning. Without it, the CLI returns
+   as soon as the jobs are submitted.
+
+GPU Staging Options
+-------------------
+
+A pipeline containing a ``GpuDetector`` runs as three stages (CPU preprocess →
+resident-model GPU detect → CPU measure). These flags tune Stage 2.
+
+``--gpu-slurm KEY=VALUE``
+   Stage-2 SBATCH resources. Inherits and deltas over ``--slurm`` (the CPU
+   profile for Stages 1 and 3); auto-adds ``slurm_gpus_per_node=1``.
+
+``--gpu-shards N``
+   Parallel Stage-2 GPU tasks, one whole GPU each. SLURM-only; ignored locally.
+   Default: 1.
+
+``--gpu-workers-per-gpu W``
+   Model replicas packed per physical GPU, to fill a GPU with a small model.
+   Default: 1.
+
+``--gpu-batch-size N``
+   Images per GPU forward pass. Integer, or ``auto`` (VRAM-probe, not yet
+   implemented). Effective only for batchable detectors. Default: 1.
 
 Output Options
 --------------
 
 ``--overlay-alpha FLOAT``
-   Opacity of detection overlay in saved images. Default: 0.3.
+   Alpha transparency of the label overlay (0.0-1.0). Default: 0.3.
 
-``--include-dataset-column``
-   Add a dataset column to measurement CSV output.
+``--no-dataset-column``
+   Exclude the ``MetadataExperiment_Dataset`` column from
+   ``master_measurements.csv``. The column is included by default.
 
-``--metadata-csv PATH``
-   Path to a CSV file with additional metadata to merge into results.
+``--metadata PATH``
+   CSV file to inner-join onto ``master_measurements.csv`` on shared columns.
+
+``--study PATH``
+   Optional ``study.yaml`` of REMBI Study-level fields (Title, License, Author,
+   ...) folded into ``deliverables/rembi.yaml``; overrides constant
+   ``Metadata_*`` columns. Applies to ``full`` and ``measure`` modes only —
+   it is silently ignored by ``--mode recompile``.
+
+``--no-qc``
+   Skip the QC compute step in finalize. QC otherwise runs whenever the pipeline
+   has a non-empty ``qc`` section, writing the ``qc/`` artifact and resetting
+   GUI review progress.
 
 ``--skip-validation``
    Skip pipeline validation before processing.

--- a/docs/source/api_reference/cli_reference.rst
+++ b/docs/source/api_reference/cli_reference.rst
@@ -153,10 +153,6 @@ resident-model GPU detect → CPU measure). These flags tune Stage 2.
    Model replicas packed per physical GPU, to fill a GPU with a small model.
    Default: 1.
 
-``--gpu-batch-size N``
-   Images per GPU forward pass. Integer, or ``auto`` (VRAM-probe, not yet
-   implemented). Effective only for batchable detectors. Default: 1.
-
 Output Options
 --------------
 

--- a/docs/source/how_to/index.rst
+++ b/docs/source/how_to/index.rst
@@ -37,7 +37,6 @@ Task-oriented recipes that solve a specific problem. Each guide is standalone
    :maxdepth: 1
    :caption: CLI & Infrastructure
 
-   pages/cli_batch_processing
    pages/rembi_metadata
    pages/slurm_pipelines
    pages/polars_cpu_build

--- a/docs/source/how_to/pages/gpu_detection_setup.md
+++ b/docs/source/how_to/pages/gpu_detection_setup.md
@@ -431,10 +431,9 @@ python -m phenotypic --pipeline sam2_pipeline.json --input /plates/ -o /output/ 
     --gpu-slurm slurm_partition=gpu --gpu-shards 2
 ```
 
-The resource nesting is three levels: `--gpu-shards` (whole GPUs, across nodes)
-→ `--gpu-workers-per-gpu` (replicas packed per GPU for small models) →
-`--gpu-batch-size` (images per forward pass; batchable models, `auto` in
-Spec 2). `--gpu-slurm` inherits/deltas over `--slurm`, so shared keys
+The resource nesting is two levels: `--gpu-shards` (whole GPUs, across nodes)
+→ `--gpu-workers-per-gpu` (replicas packed per GPU for small models).
+`--gpu-slurm` inherits/deltas over `--slurm`, so shared keys
 (account, qos, time) carry over and only the GPU partition/account need
 restating; one GPU is requested automatically.
 

--- a/docs/source/how_to/pages/gui_hub.md
+++ b/docs/source/how_to/pages/gui_hub.md
@@ -126,8 +126,8 @@ the images that would be processed without writing any output. The log tail
 shows the result.
 
 **Run (Local)** spawns `python -m phenotypic ...` as a subprocess of the GUI
-process. See [CLI Batch Processing](cli_batch_processing.md) for the full list
-of CLI flags that the form exposes. Only one local run can be active at a time;
+process. See [CLI Batch Processing](../../tutorials/pages/cli_batch_processing.md) for
+the full list of CLI flags that the form exposes. Only one local run can be active at a time;
 the Run button is disabled while a local subprocess is live. SLURM submissions
 have no equivalent cap.
 

--- a/docs/source/tutorials/cli.rst
+++ b/docs/source/tutorials/cli.rst
@@ -1,0 +1,17 @@
+Command-Line Tutorials
+======================
+
+The ``python -m phenotypic`` CLI runs an ``ImagePipeline`` over a directory of
+plate images without writing any Python. Start with the execution modes — they
+decide what a run produces and which flags it accepts — then work through the
+batch-processing recipe.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Learning Path
+
+   pages/cli_modes
+   pages/cli_batch_processing
+
+Every flag accepted by the CLI, plus the separate tuning CLI, is catalogued in
+the :doc:`CLI Reference </api_reference/cli_reference>`.

--- a/docs/source/tutorials/gui/06_view_results.md
+++ b/docs/source/tutorials/gui/06_view_results.md
@@ -82,5 +82,7 @@ a promise about RSS.
   store, and admonition in the hub.
 - [SLURM Pipelines](../../how_to/pages/slurm_pipelines.md) — chunk sizing, resume
   semantics, recompile flags.
-- [CLI Batch Processing](../../how_to/pages/cli_batch_processing.md) — every CLI flag the
+- [CLI Batch Processing](../pages/cli_batch_processing.md) — every CLI flag the
   Run console form exposes (and a few more).
+- [CLI Execution Modes](../pages/cli_modes.md) — what `full`, `measure`,
+  `recompile`, and `process` each produce.

--- a/docs/source/tutorials/index.rst
+++ b/docs/source/tutorials/index.rst
@@ -2,12 +2,12 @@ Tutorials
 =========
 
 Whether you're installing PhenoTypic for the first time, working through the
-notebook learning path, or taking a screenshot tour of the GUI hub, the
-tutorials are organized into three tracks. Pick the one that matches how you
-plan to use PhenoTypic.
+notebook learning path, batch-processing a directory of plates from the shell,
+or taking a screenshot tour of the GUI hub, the tutorials are organized into
+four tracks. Pick the one that matches how you plan to use PhenoTypic.
 
 
-.. grid:: 1 2 3 3
+.. grid:: 1 2 2 2
    :gutter: 4
    :padding: 2 2 0 0
    :class-container: sd-text-center
@@ -46,6 +46,23 @@ plan to use PhenoTypic.
 
          Start the learning path
 
+   .. grid-item-card:: Command Line
+      :class-card: intro-card
+      :shadow: md
+
+      The four ``--mode`` execution modes, the parameters that matter, and how
+      to batch-process a directory of plates locally or on SLURM.
+
+      +++
+
+      .. button-ref:: cli
+         :ref-type: doc
+         :click-parent:
+         :color: secondary
+         :expand:
+
+         Run from the shell
+
    .. grid-item-card:: GUI
       :class-card: intro-card
       :shadow: md
@@ -70,4 +87,5 @@ plan to use PhenoTypic.
 
    getting_started
    python_api
+   cli
    gui/index

--- a/docs/source/tutorials/pages/cli_batch_processing.md
+++ b/docs/source/tutorials/pages/cli_batch_processing.md
@@ -3,6 +3,10 @@
 Process an entire directory of plate images using the PhenoTypic command-line
 interface.
 
+This is the condensed recipe for the default `full` mode. For what the other
+three modes (`measure`, `recompile`, `process`) produce and which flags each
+one accepts, see [CLI Execution Modes](cli_modes.md).
+
 ## Basic Usage
 
 ```bash
@@ -17,9 +21,12 @@ python -m phenotypic --mode full --pipeline pipeline.json --input /path/to/plate
 
 ## Grid Plates
 
+`--image-type` already defaults to `GridImage`; pass `--nrows` / `--ncols` to
+override the pipeline's grid preset (which itself falls back to 8 × 12).
+
 ```bash
 python -m phenotypic --mode full --pipeline pipeline.json --input /plates/ --output /output/ \
-    --image-type GridImage --nrows 8 --ncols 12 --ext .png
+    --image-type GridImage --nrows 8 --ncols 12
 ```
 
 ## Parallelism
@@ -36,7 +43,8 @@ Omit `--njobs` to use all available CPU cores.
 python -m phenotypic --mode full --pipeline pipeline.json --input /plates/ --output /output/ --resume
 ```
 
-Add `--retry-failures` to reprocess only failed images.
+Add `--retry-failures` (which requires `--resume`) to also re-process images
+that previously failed, instead of skipping them.
 
 ## Testing
 
@@ -44,6 +52,10 @@ Add `--retry-failures` to reprocess only failed images.
 # Dry run: validate pipeline and list images without processing
 python -m phenotypic --mode full --pipeline pipeline.json --input /plates/ --output /output/ --dry-run
 
-# Process 5 random images as a test
-python -m phenotypic --mode full --pipeline pipeline.json --input /plates/ --output /output/ --sample 5
+# Process 5 random images per dataset as a test
+python -m phenotypic --mode full --pipeline pipeline.json --input /plates/ --output /output/ \
+    --sample 5 --random-seed 42
 ```
+
+`--sample` draws N images from *each* dataset (each first-level subdirectory of
+`--input`). Pass `--random-seed` to draw the same subset every time.

--- a/docs/source/tutorials/pages/cli_modes.md
+++ b/docs/source/tutorials/pages/cli_modes.md
@@ -1,0 +1,362 @@
+# CLI Execution Modes
+
+The PhenoTypic CLI has one entry point and one switch that decides what a run
+actually does:
+
+```bash
+python -m phenotypic --mode {full,measure,recompile,process} ...
+```
+
+A colony-phenotyping run is expensive in the detection step and cheap in
+everything downstream. Segmenting a plate costs seconds to minutes per image;
+re-reading a segmentation to compute `Size_Area` costs milliseconds. The four
+modes exist so that when you change your mind about a *measurement*, a
+*dashboard*, or a *threshold*, you only pay for the part that actually changed.
+
+| Mode | Re-runs detection? | Needs `--input` | Needs `--pipeline` | Produces |
+|------|--------------------|-----------------|--------------------|----------|
+| `full` (default) | Yes | Yes | Yes | Everything: HDFs, measurements, deliverables, QC, dashboard |
+| `measure` | No | No | Yes | New measurements + deliverables from existing HDFs |
+| `recompile` | No | No | No | Refreshed aggregate deliverables only |
+| `process` | Yes | Yes | Yes | One exported image layer per input, mirroring the input tree |
+
+`--output` is required in every mode.
+
+## Setting up
+
+Every command below is runnable. Create a pipeline and a small dataset first:
+
+```python
+from pathlib import Path
+
+import tifffile
+
+from phenotypic import ImagePipeline
+from phenotypic.data import load_synth_yeast_plate
+from phenotypic.detect import OtsuDetector
+from phenotypic.measure import MeasureSize
+
+plates = Path("plates/set_a")
+plates.mkdir(parents=True, exist_ok=True)
+
+plate = load_synth_yeast_plate()
+for i in range(2):
+    tifffile.imwrite(plates / f"plate_{i:02d}.tiff", plate.rgb[:])
+
+pipeline = ImagePipeline(ops=[OtsuDetector()], meas=[MeasureSize()])
+Path("pipe.json").write_text(pipeline.to_json())
+```
+
+The synthetic plate is not a grid layout, so pass `--image-type Image` to the
+commands that follow. The CLI defaults to `GridImage` (8 × 12), which is the
+right choice for real arrayed plates but would impose a grid on this image.
+
+## `full` — the complete run
+
+`full` applies the pipeline to every image, measures the detected objects, and
+writes every deliverable. It is the default, so `--mode full` can be omitted.
+
+```bash
+python -m phenotypic --mode full \
+    --pipeline pipe.json \
+    --input ./plates \
+    --output ./out \
+    --image-type Image
+```
+
+Before committing to a long run, preview the plan. `--dry-run` resolves the
+datasets, validates the pipeline, and prints the estimated output size without
+processing anything:
+
+```bash
+python -m phenotypic --pipeline pipe.json --input ./plates --output ./out \
+    --image-type Image --dry-run
+```
+
+A finished `full` run leaves three things under `--output`:
+
+```text
+out/
+├── deliverables/            # what you read and share
+│   ├── master_measurements.{csv,parquet}   # clean, pre-post archive
+│   ├── measurements.{csv,parquet}          # post-applied mirror (the GUI reads this)
+│   ├── measurements_by_feature/            # one file per measurer
+│   ├── overlays/<dataset>/                 # detection overlay PNGs
+│   ├── dashboard.html, analysis.html, processing_report.html
+│   └── README.md                           # generated column documentation
+├── results/<dataset>/
+│   ├── hdf/                # one .h5 per image — the reusable segmentation
+│   └── measurements/       # one parquet per image
+└── .phenotypic/            # machine state: progress manifest, event log, pipeline copy
+```
+
+The `hdf/` directory is what makes the other modes cheap: it holds each image's
+object map, so `measure` never has to detect again.
+
+### Scoping a run while you iterate
+
+Trying a new detector on a thousand plates to discover it splits every colony is
+a bad way to spend an afternoon. Process a random subset first:
+
+```bash
+python -m phenotypic --pipeline pipe.json --input ./plates --output ./out \
+    --image-type Image --sample 1 --random-seed 42
+```
+
+`--sample N` takes N random images **per dataset** (each first-level
+subdirectory of `--input` is one dataset). Pair it with `--random-seed` so the
+same subset is chosen on the next invocation — otherwise you are comparing two
+pipelines on two different images.
+
+### Surviving interruptions
+
+`--resume` skips images that already have output, so an interrupted run picks up
+where it stopped. If everything is already done, the CLI says so and exits:
+
+```bash
+python -m phenotypic --pipeline pipe.json --input ./plates --output ./out \
+    --image-type Image --resume
+# ✓ All images already processed!
+```
+
+Four flags control what happens to prior state, and the CLI enforces the
+combinations:
+
+- `--resume` — skip completed images. Failed images stay failed.
+- `--retry-failures` — also re-process the failures. **Requires `--resume`.**
+- `--restart` — clear the state file and start over. **Mutually exclusive with `--resume`.**
+- `--overwrite` — delete the output directory contents first. **Mutually exclusive with `--resume`.**
+
+Use `--resume --retry-failures` after fixing whatever broke — a corrupt input
+file, an out-of-memory detector — to reprocess only the images that failed.
+
+## `measure` — new numbers, same segmentation
+
+You ran a detector over 500 plates, then realized you also want texture
+measurements. `measure` re-runs the measurement stage against the HDFs already
+sitting in `results/<dataset>/hdf/`, using a pipeline you supply:
+
+```bash
+python -m phenotypic --mode measure --pipeline pipe.json --output ./out
+```
+
+There is no `--input`: the images are discovered from the output root. Passing
+one is an error.
+
+Because `measure` re-reads a finished segmentation rather than producing one, it
+refuses any flag that implies a fresh detection pass or that mutates run state.
+Each of these is rejected with a pointed message:
+
+```console
+$ python -m phenotypic --mode measure --pipeline pipe.json --output ./out --resume
+Error: --mode measure cannot be combined with --resume; --mode measure is a
+one-shot re-measurement run that does not touch processing state.
+```
+
+The same applies to `--restart`, `--retry-failures`, `--overwrite`, `--sample`,
+and `--dry-run`. `measure` is all-or-nothing over every HDF it finds.
+
+```{note}
+Swap the *measurers* freely, but keep the detector consistent with the one that
+wrote the HDFs. `measure` reads the stored object map; changing `OtsuDetector`
+to `LiDetector` in the pipeline you pass will not re-segment anything.
+```
+
+## `recompile` — rebuild the deliverables
+
+`recompile` takes neither `--input` nor `--pipeline`; both are reloaded from the
+output root. It re-aggregates the per-image parquets into
+`master_measurements.csv`, regenerates any missing overlay PNGs from their HDFs,
+re-runs the analysis plugins, rebuilds the progress manifest, and regenerates
+the dashboard.
+
+```bash
+python -m phenotypic --mode recompile --output ./out
+```
+
+Reach for it when the *numbers* are right but the *presentation* is not:
+
+- You deleted or corrupted `dashboard.html`.
+- A SLURM array finished its images but died before the aggregation step.
+- You want to attach a plate-layout metadata CSV to a finished run:
+
+```bash
+python -m phenotypic --mode recompile --output ./out --metadata plate_layout.csv
+```
+
+`--metadata` inner-joins the CSV onto `master_measurements.csv` on shared
+columns.
+
+The output directory must already exist, and passing `--pipeline` is an error —
+`recompile` deliberately uses the pipeline the run was executed with, not
+whatever is on disk now.
+
+```{warning}
+`--study` is **silently ignored** in `recompile` mode — the REMBI study fields
+are folded into `deliverables/rembi.yaml` during `full` and `measure` runs only.
+To attach a `study.yaml` to a finished run, use `--mode measure --study
+study.yaml`, which rebuilds `rembi.yaml` without re-detecting.
+```
+
+## `process` — export a layer, skip the analysis
+
+`process` is an **apply-only export**. It runs `pipeline.apply()` and writes one
+image layer per input, mirroring the input tree under `--output`. No
+measurement, no deliverables, no QC, no dashboard.
+
+```bash
+python -m phenotypic --mode process --pipeline pipe.json \
+    --input ./plates --output ./proc --image-type Image --layer objmap
+```
+
+```text
+proc/
+├── set_a/
+│   ├── plate_00.png        # mirrors plates/set_a/plate_00.tiff
+│   └── plate_01.png
+└── .phenotypic/
+```
+
+`--layer` is required in `process` mode and rejected in every other mode. Each
+layer is written at its native dtype through the accessor's `imsave`, with
+PhenoTypic metadata embedded:
+
+| `--layer` | File | Dtype |
+|-----------|------|-------|
+| `rgb` | `.tiff` | integer, at the source bit depth |
+| `gray` | `.tiff` | float, full precision |
+| `detect_mat` | `.tiff` | float, full precision |
+| `objmap` | `.png` | 16-bit raw labels |
+
+This is the mode for feeding another tool. Export `detect_mat` to inspect what
+your enhancement chain actually hands the detector; export `objmap` to import
+segmentations into CellProfiler, Fiji, or a training set. Note that `objmap`
+holds **raw label values**, not a rendered image — opening it in a viewer shows
+a near-black frame, because label 3 is the pixel value 3.
+
+Flags that only make sense for measurement output are ignored with a warning
+rather than an error:
+
+```console
+$ python -m phenotypic --mode process ... --layer gray --no-qc
+Warning: --no-qc is ignored in --mode process (no measurement/aggregation output).
+```
+
+The same applies to `--metadata` and `--no-dataset-column`.
+
+## Parameters worth knowing
+
+### Loading the images
+
+`--image-type` defaults to `GridImage`, which imposes an arrayed layout. Use
+`--nrows` / `--ncols` to override the pipeline's grid preset (the fallback is
+8 × 12); pass `--image-type Image` for non-arrayed plates.
+
+`--detect-mode` selects the channel the detector thresholds. It defaults to
+`gray`, but colony contrast often lives elsewhere — `LabA` separates
+red-pigmented colonies from agar far better than luminance does. The full set is
+`gray`, `red`, `green`, `blue`, `MinRGB`, `HsvS`, `HsvV`, `InvS`, `LabL`,
+`LabA`, `LabB`.
+
+```{warning}
+`--ext` no longer selects the output format. Forward runs write a single `.h5`
+per image; the flag now only affects overlay PNG rendering and is deprecated.
+```
+
+### Scaling out
+
+`--njobs` sets local parallelism and defaults to `-1` (all cores). Images are
+large and operations copy — on a memory-constrained machine, capping `--njobs`
+is often faster than swapping.
+
+`--slurm` submits to a cluster instead. It takes repeated `KEY=VALUE` pairs:
+
+```bash
+python -m phenotypic --pipeline pipe.json --input ./plates --output ./out \
+    --slurm slurm_partition=compute \
+    --slurm slurm_account=myproj \
+    --slurm mem_gb=16 \
+    --slurm time=120
+```
+
+Use the `slurm_` prefix for standard SBATCH directives, or the convenience keys
+`mem_gb` and `time`. **`time` is in minutes, as an integer** — `time=120`, not
+`time=02:00:00`. The CLI returns as soon as the jobs are submitted; add `--wait`
+to block and monitor them. `--force-local` overrides SLURM detection, which is
+what you want when testing on a login node.
+
+`--checkpoint-interval N` inserts checkpoint tasks every N images in a SLURM
+array so a walltime kill loses at most N images of progress.
+
+### GPU detectors
+
+A pipeline containing a `GpuDetector` automatically splits into three stages —
+CPU preprocess, resident-model GPU detect, CPU measure — reusing the per-image
+HDF. You do not opt in; you only tune it:
+
+- `--gpu-slurm KEY=VALUE` — SBATCH profile for the GPU stage. It **inherits and
+  deltas over `--slurm`**, so put the GPU partition and account here and leave
+  the CPU profile in `--slurm`. `slurm_gpus_per_node=1` is added automatically.
+- `--gpu-shards N` — parallel whole-GPU tasks (SLURM only; ignored locally).
+  Set it to your concurrent-GPU count.
+- `--gpu-workers-per-gpu W` — model replicas packed onto one physical GPU, to
+  fill a large card with a small model.
+- `--gpu-batch-size N` — images per forward pass, for detectors that batch.
+
+```bash
+python -m phenotypic --pipeline gpu_pipe.json --input ./plates --output ./out \
+    --slurm slurm_partition=cpu --slurm mem_gb=32 \
+    --gpu-slurm slurm_partition=gpu --gpu-slurm slurm_account=myproj \
+    --gpu-shards 4
+```
+
+```{note}
+`--gpu-batch-size auto` is accepted, but the VRAM probe behind it is not
+implemented yet — it currently behaves as a placeholder. Pass an explicit
+integer.
+```
+
+### Shaping the output
+
+- `--overlay-alpha` (default `0.3`) — opacity of the label overlay in the
+  saved overlay PNGs.
+- `--no-dataset-column` — drop the `MetadataExperiment_Dataset` column, which is
+  included by default and is what makes multi-dataset analysis possible.
+- `--no-qc` — skip the QC compute step. QC otherwise runs whenever the pipeline
+  has a non-empty `qc` section, and re-running it resets GUI review progress.
+- `--skip-validation` — bypass pipeline validation. Only worth it for pipelines
+  you have already run.
+
+## A typical iteration loop
+
+```bash
+# 1. Preview the plan.
+python -m phenotypic -p pipe.json -i ./plates -o ./out --dry-run
+
+# 2. Tune the detector against a fixed random subset.
+python -m phenotypic -p pipe.json -i ./plates -o ./trial --sample 5 --random-seed 42
+
+# 3. Commit to the full dataset on the cluster.
+python -m phenotypic -p pipe.json -i ./plates -o ./out \
+    --slurm slurm_partition=compute --slurm mem_gb=16 --slurm time=240
+
+# 4. Something died overnight — resume, retrying the failures.
+python -m phenotypic -p pipe.json -i ./plates -o ./out --resume --retry-failures
+
+# 5. Add a texture measurer. No re-detection.
+python -m phenotypic -m measure -p pipe_with_texture.json -o ./out
+
+# 6. Attach the plate layout and rebuild the dashboard.
+python -m phenotypic -m recompile -o ./out --metadata plate_layout.csv
+```
+
+Steps 5 and 6 are the payoff: neither one re-segments a single colony.
+
+## Where to go next
+
+- [CLI Batch Processing](cli_batch_processing.md) — the condensed recipe.
+- [SLURM Pipelines](../../how_to/pages/slurm_pipelines.md) — cluster execution
+  in depth.
+- [GPU Detection Setup](../../how_to/pages/gpu_detection_setup.md) — staging
+  model weights on offline compute nodes.
+- [CLI Reference](../../api_reference/cli_reference.rst) — every flag.

--- a/docs/source/tutorials/pages/cli_modes.md
+++ b/docs/source/tutorials/pages/cli_modes.md
@@ -301,7 +301,6 @@ HDF. You do not opt in; you only tune it:
   Set it to your concurrent-GPU count.
 - `--gpu-workers-per-gpu W` — model replicas packed onto one physical GPU, to
   fill a large card with a small model.
-- `--gpu-batch-size N` — images per forward pass, for detectors that batch.
 
 ```bash
 python -m phenotypic --pipeline gpu_pipe.json --input ./plates --output ./out \
@@ -310,11 +309,10 @@ python -m phenotypic --pipeline gpu_pipe.json --input ./plates --output ./out \
     --gpu-shards 4
 ```
 
-```{note}
-`--gpu-batch-size auto` is accepted, but the VRAM probe behind it is not
-implemented yet — it currently behaves as a placeholder. Pass an explicit
-integer.
-```
+GPU fill is therefore two levels: `--gpu-shards` distributes whole GPUs across
+nodes, and `--gpu-workers-per-gpu` packs replicas onto each one. There is no
+per-forward batching knob — the segmentation models PhenoTypic targets do not
+broadly support batched inference.
 
 ### Shaping the output
 

--- a/src/phenotypic/_cli/_cli_types.py
+++ b/src/phenotypic/_cli/_cli_types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Set
 from datetime import datetime
 
 from phenotypic.sdk_.typing_ import ExecutionMode, ImageTypeName, ProcessOnlyLayer
@@ -138,9 +138,6 @@ class ExecutionConfig:
     process_only_layer: Optional[ProcessOnlyLayer] = None
 
     # --- Staged GPU detection (Spec 1 §7/§10) ---------------------------------
-    # Images per GPU forward pass (Stage 2). Int, or "auto" (VRAM-probe; the
-    # probe is effective only for batchable detectors and lands in Spec 2).
-    gpu_batch_size: Union[int, str] = 1
     # Model replicas packed per physical GPU (Stage 2 fill for small models).
     gpu_workers_per_gpu: int = 1
     # Parallel Stage-2 GPU tasks (one whole GPU each; SLURM-only, ignored local).

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -132,7 +132,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from typing import Any, List, Optional, Sequence, Union, cast
+from typing import Any, List, Optional, Sequence, cast
 
 import click
 import yaml
@@ -240,16 +240,6 @@ def _parse_slurm_args(slurm_args: Sequence[str]) -> dict:
     kept for backward compatibility within this module.
     """
     return parse_slurm_args(slurm_args)
-
-
-def _parse_gpu_batch_size(ctx, param, value):
-    """--gpu-batch-size: integer images-per-forward, or the literal ``auto``."""
-    if value == "auto":
-        return "auto"
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        raise click.BadParameter("--gpu-batch-size must be an integer or 'auto'")
 
 
 def _validate_resume_input_images(state, current_datasets) -> tuple[bool, Optional[str]]:
@@ -670,15 +660,6 @@ def _print_process_only_dry_run_plan(
     "standard SBATCH directives, or use convenience params like mem_gb and time.",
 )
 @click.option(
-    "--gpu-batch-size",
-    "gpu_batch_size",
-    default="1",
-    show_default=True,
-    callback=_parse_gpu_batch_size,
-    help="Images per GPU forward pass (Stage 2). Integer, or 'auto' (VRAM-probe). "
-    "Effective only for batchable detectors; the 'auto' probe lands in Spec 2.",
-)
-@click.option(
     "--gpu-workers-per-gpu",
     "gpu_workers_per_gpu",
     type=int,
@@ -833,7 +814,6 @@ def phenotypic_cli(
     detect_mode: str,
     n_jobs: int,
     slurm_args: Sequence[str],
-    gpu_batch_size: Union[int, str],
     gpu_workers_per_gpu: int,
     gpu_shards: int,
     gpu_slurm_args: Sequence[str],
@@ -1149,7 +1129,6 @@ def phenotypic_cli(
             checkpoint_interval=checkpoint_interval,
             measure_only=measure_only,
             process_only_layer=process_only_layer,  # type: ignore[arg-type]
-            gpu_batch_size=gpu_batch_size,
             gpu_workers_per_gpu=gpu_workers_per_gpu,
             gpu_shards=gpu_shards,
             gpu_slurm_args=_parse_slurm_args(gpu_slurm_args),

--- a/tests/integration/cli/test_gpu_cli_flags.py
+++ b/tests/integration/cli/test_gpu_cli_flags.py
@@ -1,10 +1,8 @@
 """The staged-GPU CLI flags are exposed and parse (Spec 1 §10, Plan 3 Task 3)."""
 
-import click
-import pytest
 from click.testing import CliRunner
 
-from phenotypic.phenotypicCLI import _parse_gpu_batch_size, phenotypic_cli
+from phenotypic.phenotypicCLI import phenotypic_cli
 
 
 def test_gpu_flags_listed_in_help():
@@ -12,7 +10,6 @@ def test_gpu_flags_listed_in_help():
     result = runner.invoke(phenotypic_cli, ["--help"])
     assert result.exit_code == 0
     for opt in (
-        "--gpu-batch-size",
         "--gpu-workers-per-gpu",
         "--gpu-shards",
         "--gpu-slurm",
@@ -20,11 +17,19 @@ def test_gpu_flags_listed_in_help():
         assert opt in result.output
 
 
-def test_gpu_batch_size_callback_accepts_int_and_auto():
-    assert _parse_gpu_batch_size(None, None, "auto") == "auto"
-    assert _parse_gpu_batch_size(None, None, "4") == 4
+def test_gpu_batch_size_flag_is_removed():
+    """--gpu-batch-size was never wired into Stage 2; it must not be accepted.
 
+    Batching is not widely supported by the segmentation models PhenoTypic
+    targets, so the flag was removed rather than left as a silent no-op. Click
+    must reject it outright instead of ignoring it.
+    """
+    runner = CliRunner()
+    result = runner.invoke(phenotypic_cli, ["--help"])
+    assert "--gpu-batch-size" not in result.output
 
-def test_gpu_batch_size_callback_rejects_garbage():
-    with pytest.raises(click.BadParameter):
-        _parse_gpu_batch_size(None, None, "banana")
+    result = runner.invoke(
+        phenotypic_cli, ["-o", "out", "--gpu-batch-size", "4"]
+    )
+    assert result.exit_code != 0
+    assert "no such option" in result.output.lower()

--- a/tests/unit/test_docs_staged_cli.py
+++ b/tests/unit/test_docs_staged_cli.py
@@ -25,9 +25,9 @@ def test_claude_md_documents_gpu_flags():
         "--gpu-slurm",
         "--gpu-shards",
         "--gpu-workers-per-gpu",
-        "--gpu-batch-size",
     ):
         assert flag in txt
+    assert "--gpu-batch-size" not in txt
 
 
 def test_how_to_documents_slurm_staging():


### PR DESCRIPTION
## What

Adds a fourth **Tutorials** track — *Command Line* — covering the four `--mode` values (`full`, `measure`, `recompile`, `process`): what each produces, which flags each requires and rejects, and the parameters worth knowing (sampling, resume semantics, SLURM, staged-GPU tuning).

`how_to/pages/cli_batch_processing.md` moves into the new track (it was the only CLI page in How-To Guides, and it never covered modes), and its two inbound links are repointed.

```
tutorials/
  index.rst                       (4 cards now)
  getting_started.rst
  python_api.rst
  cli.rst                         <- NEW track
    pages/cli_modes.md            <- NEW
    pages/cli_batch_processing.md <- MOVED from how_to/pages/
  gui/index.md
```

## Removes the dead `--gpu-batch-size` flag

The flag was parsed into `ExecutionConfig.gpu_batch_size` and **never read back by anything** — Stage 2 never consumed it, so passing it had no effect. The `auto` VRAM-probe it advertised was a Spec-2 placeholder that was never implemented. Since batched inference is not broadly supported by the segmentation models PhenoTypic targets, the knob is removed rather than wired up.

Click now rejects it outright instead of silently ignoring it:

```
$ python -m phenotypic -o out --gpu-batch-size 4
Error: No such option: --gpu-batch-size
```

GPU fill remains two levels: `--gpu-shards` (whole GPUs) → `--gpu-workers-per-gpu` (replicas per GPU). Removed: the option, its `_parse_gpu_batch_size` callback, the `ExecutionConfig` field, and the now-unused `Union` imports in both modules. Historical design docs under `docs/superpowers/` are left as written.

## Two docs-vs-code discrepancies found while validating

Every command, mode rejection, and output layout in the new page was executed against the CLI on a synthetic two-image dataset rather than paraphrased from the existing docs. That surfaced two places where the docs disagreed with `phenotypicCLI.py`:

- **`--image-type` defaults to `GridImage`, not `Image`.** `cli_reference.rst` claimed `Image`. This matters: the default silently imposes an 8×12 grid on a non-arrayed plate.
- **`--study` is silently ignored by `--mode recompile`.** It is parsed after the recompile branch calls `sys.exit(0)`. Confirmed with a marker value that never reached `rembi.yaml` under `recompile`, and that *does* land under `measure`. Documented as a warning admonition pointing users at `--mode measure --study` instead.

## Also fixes `api_reference/cli_reference.rst`

It documented **two flags that do not exist**:

| Documented | Actual |
|---|---|
| `--include-dataset-column` | `--no-dataset-column` (column is on by default) |
| `--metadata-csv` | `--metadata` |

…and omitted `--study`, `--no-qc`, and the `--gpu-*` staging flags. Also corrects the `--njobs` default (`-1`), the `--ext` deprecation, the `--detect-mode` choices, `--checkpoint-interval` semantics, `--sample` being per-dataset, and the full set of flags `measure` rejects.

## Verification

- All four modes run end to end: `full` → `measure` → `recompile`, plus `process --layer objmap` producing the mirrored tree.
- All four mode rejections confirmed by execution (`--layer` outside `process`; `--pipeline` with `recompile`; `--resume` with `measure`; `process` without `--layer`), as well as the ignored-flag warnings in `process` mode and `--sample 1` really processing one image.
- `tests/integration/cli` + `tests/unit`: **4844 passed**. The 14 failures and 3 errors are pre-existing — they reproduce identically on unmodified `main` (missing napari/Qt extras and the measurements-ref docs env), and none touch the CLI.
- The new absence-assertion test was checked for vacuity: an option that *does* exist (`--gpu-shards`) does not produce "No such option", so the assertion discriminates.
- `ruff check` clean on all changed files; `mypy` introduces no new errors (the one `yaml` import-untyped error is a pre-existing missing stub package).
- `sphinx-build` succeeds with no warnings on any new, moved, or edited page; all cross-references resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDfsPdLP5dNcHivUMCxZQU