### PR TITLE
Support plotting image views on existing axes

### DIFF
--- a/src/phenotypic/_core/_image_parts/_image_handler.py
+++ b/src/phenotypic/_core/_image_parts/_image_handler.py
@@ -714,7 +714,11 @@ class ImageHandler(ImageDataManager):
         self._accessors.objmap.reset()
 
     def show(
-            self, figsize: Tuple[int, int] | None = None, **kwargs
+            self,
+            figsize: Tuple[int, int] | None = None,
+            *,
+            ax: plt.Axes | None = None,
+            **kwargs,
     ) -> tuple[plt.Figure, plt.Axes]:
         """Display the image using matplotlib.
 
@@ -724,6 +728,8 @@ class ImageHandler(ImageDataManager):
         Args:
             figsize: Figure size in inches (width, height). If None,
                 auto-calculated from array aspect ratio.
+            ax: Existing Matplotlib axes to plot into. If None, a new
+                figure and axes are created.
             **kwargs: Additional keyword arguments passed to the
                 accessor's ``show()`` method.
 
@@ -731,9 +737,9 @@ class ImageHandler(ImageDataManager):
             A ``(matplotlib.figure.Figure, matplotlib.axes.Axes)`` tuple.
         """
         if not self.rgb.isempty():
-            return self.rgb.show(figsize=figsize, **kwargs)
+            return self.rgb.show(figsize=figsize, ax=ax, **kwargs)
         else:
-            return self.gray.show(figsize=figsize, **kwargs)
+            return self.gray.show(figsize=figsize, ax=ax, **kwargs)
 
     def dash(
             self, figsize: Tuple[int, int] | None = None, **kwargs

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_mpl_handler.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_mpl_handler.py
@@ -393,6 +393,7 @@ class AccessorMplHandler(AccessorIOHandler):
         figsize: tuple[int, int] | None = None,
         title: str | bool | None = None,
         *,
+        ax: plt.Axes | None = None,
         overlay_settings: dict | None = None,
     ) -> tuple[plt.Figure, plt.Axes]:
         """Plot an array with object map overlay using matplotlib.
@@ -405,6 +406,8 @@ class AccessorMplHandler(AccessorIOHandler):
                 auto-calculated from array aspect ratio.
             title: Title of the plot. If None, defaults to the parent
                 image name.
+            ax: Existing Matplotlib axes to plot into. If None, a new
+                figure and axes are created.
             overlay_settings: Parameters passed to
                 ``skimage.color.label2rgb`` for overlay customization.
 
@@ -412,7 +415,9 @@ class AccessorMplHandler(AccessorIOHandler):
             A ``(plt.Figure, plt.Axes)`` tuple.
         """
         overlay_arr = self._compose_overlay(arr, objmap, overlay_settings)
-        return self._mpl_plot(arr=overlay_arr, figsize=figsize, title=title)
+        return self._mpl_plot(
+            arr=overlay_arr, figsize=figsize, title=title, ax=ax
+        )
 
     # ------------------------------------------------------------------
     # Matplotlib overlay decoration

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_multichannel_accessor.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_multichannel_accessor.py
@@ -122,6 +122,7 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: bool = False,
             overlay: bool = True,
             *,
+            ax: plt.Axes | None = None,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -140,6 +141,8 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: If True, only foreground is displayed.
             overlay: If True, overlay the object map on the image.
                 Falls back to plain image when no objects are detected.
+            ax: Existing Matplotlib axes to plot into. If None, a new
+                figure and axes are created.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -168,6 +171,7 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             objmap = self._get_filtered_objmap(object_label)
             fig, ax = self._plot_overlay(
                     arr=plot_arr, objmap=objmap, figsize=figsize, title=title,
+                    ax=ax,
                     overlay_settings=overlay_settings,
             )
             self._decorate_mpl_overlay(
@@ -179,11 +183,11 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
 
         if channel is None:
             return self._mpl_plot(
-                    arr=arr, figsize=figsize, title=title,
+                    arr=arr, figsize=figsize, title=title, ax=ax,
             )
         return self._mpl_plot(
                 arr=arr[:, :, channel], figsize=figsize, title=title,
-                cmap="gray",
+                cmap="gray", ax=ax,
         )
 
     def dash(

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_single_channel_accessor.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_single_channel_accessor.py
@@ -41,6 +41,7 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: bool = False,
             overlay: bool = True,
             *,
+            ax: plt.Axes | None = None,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -57,6 +58,8 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: If True, display only foreground elements.
             overlay: If True, overlay the object map on the image.
                 Falls back to plain image when no objects are detected.
+            ax: Existing Matplotlib axes to plot into. If None, a new
+                figure and axes are created.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -77,6 +80,7 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             objmap = self._get_filtered_objmap(object_label)
             fig, ax = self._plot_overlay(
                     arr=arr, objmap=objmap, figsize=figsize, title=title,
+                    ax=ax,
                     overlay_settings=overlay_settings,
             )
             self._decorate_mpl_overlay(
@@ -87,7 +91,7 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             return fig, ax
 
         return self._mpl_plot(
-                arr=arr, figsize=figsize, title=title, cmap=cmap or "gray",
+                arr=arr, figsize=figsize, title=title, cmap=cmap or "gray", ax=ax,
         )
 
     def dash(

--- a/tests/unit/core/test_plotly_show.py
+++ b/tests/unit/core/test_plotly_show.py
@@ -49,6 +49,14 @@ class TestRGBShow:
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
 
+    @pytest.mark.parametrize("overlay", [False, True])
+    def test_rgb_show_reuses_existing_axes(self, grid_image, overlay):
+        fig, ax = plt.subplots()
+        returned_fig, returned_ax = grid_image.rgb.show(ax=ax, overlay=overlay)
+        assert returned_fig is fig
+        assert returned_ax is ax
+        plt.close(fig)
+
 
 class TestGrayShow:
     """Tests for image.gray.show() returning matplotlib tuple."""
@@ -69,6 +77,14 @@ class TestGrayShow:
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
 
+    @pytest.mark.parametrize("overlay", [False, True])
+    def test_gray_show_reuses_existing_axes(self, grid_image, overlay):
+        fig, ax = plt.subplots()
+        returned_fig, returned_ax = grid_image.gray.show(ax=ax, overlay=overlay)
+        assert returned_fig is fig
+        assert returned_ax is ax
+        plt.close(fig)
+
 
 class TestDetectMatShow:
     """Tests for image.detect_mat.show() returning matplotlib tuple."""
@@ -77,6 +93,16 @@ class TestDetectMatShow:
         fig, ax = grid_image.detect_mat.show()
         assert isinstance(fig, plt.Figure)
         assert isinstance(ax, plt.Axes)
+        plt.close(fig)
+
+    @pytest.mark.parametrize("overlay", [False, True])
+    def test_detect_mat_show_reuses_existing_axes(self, grid_image, overlay):
+        fig, ax = plt.subplots()
+        returned_fig, returned_ax = grid_image.detect_mat.show(
+            ax=ax, overlay=overlay
+        )
+        assert returned_fig is fig
+        assert returned_ax is ax
         plt.close(fig)
 
 
@@ -225,6 +251,14 @@ class TestImageShow:
         fig, ax = grid_image.show()
         assert isinstance(fig, plt.Figure)
         assert isinstance(ax, plt.Axes)
+        plt.close(fig)
+
+    @pytest.mark.parametrize("overlay", [False, True])
+    def test_grid_image_show_reuses_existing_axes(self, grid_image, overlay):
+        fig, ax = plt.subplots()
+        returned_fig, returned_ax = grid_image.show(ax=ax, overlay=overlay)
+        assert returned_fig is fig
+        assert returned_ax is ax
         plt.close(fig)
 
     def test_image_show_with_title(self, grid_image):


### PR DESCRIPTION
## Summary

- add a keyword-only `ax` parameter to `Image.show()` and the shared single- and multichannel accessor implementations
- reuse caller-provided Matplotlib axes for plain, channel-selected, and object-overlay rendering
- cover `GridImage.show()`, RGB, grayscale, and detection-matrix views with regression tests

## Why

The low-level Matplotlib renderer already supported an existing axes, but most public `show()` methods did not forward it. This made subplot composition inconsistent with `objmap.show()` and `objmask.show()`.

## User impact

Users can now render `Image`, `GridImage`, RGB, grayscale, and detection-matrix views directly into an existing Matplotlib subplot via `show(ax=ax)`, including when overlays are enabled.

## Validation

- `uv run pytest tests/unit/core/test_plotly_show.py -q` (46 passed)
- `uv run ruff check` on all changed Python files (passed)
- `git diff --check` (passed)
- independent code review (no findings)
