### PR TITLE
Label rendered object overlays

### DIFF
--- a/src/phenotypic/_core/_image_parts/_image_handler.py
+++ b/src/phenotypic/_core/_image_parts/_image_handler.py
@@ -718,6 +718,7 @@ class ImageHandler(ImageDataManager):
             figsize: Tuple[int, int] | None = None,
             *,
             ax: plt.Axes | None = None,
+            show_overlay_notice: bool = True,
             **kwargs,
     ) -> tuple[plt.Figure, plt.Axes]:
         """Display the image using matplotlib.
@@ -730,6 +731,8 @@ class ImageHandler(ImageDataManager):
                 auto-calculated from array aspect ratio.
             ax: Existing Matplotlib axes to plot into. If None, a new
                 figure and axes are created.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             **kwargs: Additional keyword arguments passed to the
                 accessor's ``show()`` method.
 
@@ -737,12 +740,22 @@ class ImageHandler(ImageDataManager):
             A ``(matplotlib.figure.Figure, matplotlib.axes.Axes)`` tuple.
         """
         if not self.rgb.isempty():
-            return self.rgb.show(figsize=figsize, ax=ax, **kwargs)
+            return self.rgb.show(
+                    figsize=figsize, ax=ax,
+                    show_overlay_notice=show_overlay_notice, **kwargs,
+            )
         else:
-            return self.gray.show(figsize=figsize, ax=ax, **kwargs)
+            return self.gray.show(
+                    figsize=figsize, ax=ax,
+                    show_overlay_notice=show_overlay_notice, **kwargs,
+            )
 
     def dash(
-            self, figsize: Tuple[int, int] | None = None, **kwargs
+            self,
+            figsize: Tuple[int, int] | None = None,
+            *,
+            show_overlay_notice: bool = True,
+            **kwargs,
     ) -> go.Figure:
         """Display the image using Plotly.
 
@@ -752,6 +765,8 @@ class ImageHandler(ImageDataManager):
         Args:
             figsize: Figure size in inches (width, height). If None,
                 auto-calculated from array aspect ratio.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             **kwargs: Additional keyword arguments passed to the
                 accessor's ``dash()`` method.
 
@@ -762,9 +777,15 @@ class ImageHandler(ImageDataManager):
             ImportError: If plotly is not installed.
         """
         if not self.rgb.isempty():
-            return self.rgb.dash(figsize=figsize, **kwargs)
+            return self.rgb.dash(
+                    figsize=figsize,
+                    show_overlay_notice=show_overlay_notice, **kwargs,
+            )
         else:
-            return self.gray.dash(figsize=figsize, **kwargs)
+            return self.gray.dash(
+                    figsize=figsize,
+                    show_overlay_notice=show_overlay_notice, **kwargs,
+            )
 
     def rotate(
             self,

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_dash_handler.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_dash_handler.py
@@ -380,6 +380,7 @@ class AccessorDashHandler(AccessorMplHandler):
             *,
             has_objects: bool,
             object_label: int | None = None,
+            show_overlay_notice: bool = True,
             show_labels: bool = False,
             show_grid: bool = True,
             label_settings: dict | None = None,
@@ -390,6 +391,7 @@ class AccessorDashHandler(AccessorMplHandler):
             fig: Plotly figure to decorate.
             has_objects: Whether the image has detected objects.
             object_label: Specific object label being highlighted.
+            show_overlay_notice: Whether to display the overlay notice.
             show_labels: Whether to add centroid labels.
             show_grid: Whether to add gridlines and section boxes
                 (GridImage only).
@@ -397,6 +399,8 @@ class AccessorDashHandler(AccessorMplHandler):
         """
         if label_settings is None:
             label_settings = {}
+        if show_overlay_notice:
+            self._add_plotly_overlay_notice(fig)
         if show_labels:
             self._add_plotly_obj_labels(
                     fig=fig,
@@ -421,3 +425,21 @@ class AccessorDashHandler(AccessorMplHandler):
                         fig=fig, min_rr=min_rr, max_rr=max_rr,
                         min_cc=min_cc, max_cc=max_cc,
                 )
+
+    @staticmethod
+    def _add_plotly_overlay_notice(fig: go.Figure) -> None:
+        """Add a compact notice that the displayed image includes an overlay."""
+        fig.add_annotation(
+            x=0.01,
+            y=0.99,
+            xref="x domain",
+            yref="y domain",
+            xanchor="left",
+            yanchor="top",
+            text="Overlay",
+            showarrow=False,
+            font={"color": "white", "size": 12},
+            bgcolor="rgba(26, 26, 26, 1)",
+            bordercolor="rgba(0, 0, 0, 0)",
+            borderpad=3,
+        )

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_mpl_handler.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_image_accessor_base_parents/_accessor_mpl_handler.py
@@ -429,6 +429,7 @@ class AccessorMplHandler(AccessorIOHandler):
         *,
         has_objects: bool,
         object_label: int | None = None,
+        show_overlay_notice: bool = True,
         show_labels: bool = False,
         show_grid: bool = True,
         label_settings: dict | None = None,
@@ -439,6 +440,7 @@ class AccessorMplHandler(AccessorIOHandler):
             ax: Matplotlib axes to decorate.
             has_objects: Whether the image has detected objects.
             object_label: Specific object label being highlighted.
+            show_overlay_notice: Whether to display the overlay notice.
             show_labels: Whether to add centroid labels.
             show_grid: Whether to add gridlines and section boxes
                 (GridImage only).
@@ -446,6 +448,8 @@ class AccessorMplHandler(AccessorIOHandler):
         """
         if label_settings is None:
             label_settings = {}
+        if show_overlay_notice:
+            self._add_mpl_overlay_notice(ax)
         if show_labels:
             self._plot_obj_labels(
                 ax=ax,
@@ -458,6 +462,27 @@ class AccessorMplHandler(AccessorIOHandler):
             self._add_gridlines(ax)
             if has_objects:
                 self._add_section_boxes(ax)
+
+    @staticmethod
+    def _add_mpl_overlay_notice(ax: plt.Axes) -> None:
+        """Add a compact notice that the displayed image includes an overlay."""
+        ax.text(
+            0.01,
+            0.99,
+            "Overlay",
+            transform=ax.transAxes,
+            ha="left",
+            va="top",
+            color="white",
+            fontsize=10,
+            zorder=100,
+            bbox={
+                "boxstyle": "round,pad=0.2",
+                "facecolor": "#1a1a1a",
+                "edgecolor": "none",
+                "alpha": 1.0,
+            },
+        )
 
     # ------------------------------------------------------------------
     # Grid visualisation (matplotlib)

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_multichannel_accessor.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_multichannel_accessor.py
@@ -123,6 +123,7 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             overlay: bool = True,
             *,
             ax: plt.Axes | None = None,
+            show_overlay_notice: bool = True,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -143,6 +144,8 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
                 Falls back to plain image when no objects are detected.
             ax: Existing Matplotlib axes to plot into. If None, a new
                 figure and axes are created.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -176,6 +179,9 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             )
             self._decorate_mpl_overlay(
                     ax, has_objects=has_objects, object_label=object_label,
+                    show_overlay_notice=(
+                        show_overlay_notice and bool(objmap.any())
+                    ),
                     show_labels=show_labels, show_grid=show_grid,
                     label_settings=label_settings,
             )
@@ -198,6 +204,7 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: bool = False,
             overlay: bool = True,
             *,
+            show_overlay_notice: bool = True,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -217,6 +224,8 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: If True, only foreground is displayed.
             overlay: If True, overlay the object map on the image.
                 Falls back to plain image when no objects are detected.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -264,6 +273,9 @@ class MultiChannelAccessor(ImageAccessorBase, ABC):
             )
             self._decorate_plotly_overlay(
                     fig, has_objects=has_objects, object_label=object_label,
+                    show_overlay_notice=(
+                        show_overlay_notice and bool(objmap.any())
+                    ),
                     show_labels=show_labels, show_grid=show_grid,
                     label_settings=label_settings,
             )

--- a/src/phenotypic/_core/_image_parts/accessor_abstracts/_single_channel_accessor.py
+++ b/src/phenotypic/_core/_image_parts/accessor_abstracts/_single_channel_accessor.py
@@ -42,6 +42,7 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             overlay: bool = True,
             *,
             ax: plt.Axes | None = None,
+            show_overlay_notice: bool = True,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -60,6 +61,8 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
                 Falls back to plain image when no objects are detected.
             ax: Existing Matplotlib axes to plot into. If None, a new
                 figure and axes are created.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -85,6 +88,9 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             )
             self._decorate_mpl_overlay(
                     ax, has_objects=has_objects, object_label=object_label,
+                    show_overlay_notice=(
+                        show_overlay_notice and bool(objmap.any())
+                    ),
                     show_labels=show_labels, show_grid=show_grid,
                     label_settings=label_settings,
             )
@@ -102,6 +108,7 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: bool = False,
             overlay: bool = True,
             *,
+            show_overlay_notice: bool = True,
             object_label: int | None = None,
             show_labels: bool = False,
             show_grid: bool = True,
@@ -119,6 +126,8 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             foreground_only: If True, display only foreground elements.
             overlay: If True, overlay the object map on the image.
                 Falls back to plain image when no objects are detected.
+            show_overlay_notice: If True, display an ``Overlay`` notice when
+                an object overlay is rendered.
             object_label: Specific object label to highlight. If None,
                 shows all detected objects. Only used when overlay is True.
             show_labels: If True, displays numeric labels at object centroids.
@@ -158,6 +167,9 @@ class SingleChannelAccessor(ImageAccessorBase, ABC):
             )
             self._decorate_plotly_overlay(
                     fig, has_objects=has_objects, object_label=object_label,
+                    show_overlay_notice=(
+                        show_overlay_notice and bool(objmap.any())
+                    ),
                     show_labels=show_labels, show_grid=show_grid,
                     label_settings=label_settings,
             )

--- a/tests/unit/core/test_plotly_show.py
+++ b/tests/unit/core/test_plotly_show.py
@@ -19,6 +19,20 @@ def grid_image():
     return load_synth_yeast_plate()
 
 
+def _mpl_overlay_notices(ax):
+    """Return Matplotlib text artists used for the overlay notice."""
+    return [text for text in ax.texts if text.get_text() == "Overlay"]
+
+
+def _plotly_overlay_notices(fig):
+    """Return Plotly annotations used for the overlay notice."""
+    return [
+        annotation
+        for annotation in (fig.layout.annotations or ())
+        if annotation.text == "Overlay"
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Accessor show() tests — always matplotlib
 # ---------------------------------------------------------------------------
@@ -239,6 +253,96 @@ class TestDashWithOverlay:
         assert fig.layout.yaxis.side == "right"
 
 
+class TestOverlayNotice:
+    """Tests for the default opt-out notice on rendered object overlays."""
+
+    @pytest.mark.parametrize("accessor_name", ["rgb", "gray", "detect_mat"])
+    def test_accessor_show_adds_notice(self, grid_image, accessor_name):
+        accessor = getattr(grid_image, accessor_name)
+        fig, ax = accessor.show(overlay=True, show_grid=False)
+        notices = _mpl_overlay_notices(ax)
+        assert len(notices) == 1
+        assert notices[0].get_position() == (0.01, 0.99)
+        assert notices[0].get_color() == "white"
+        assert notices[0].get_bbox_patch().get_alpha() == 1.0
+        plt.close(fig)
+
+    @pytest.mark.parametrize("accessor_name", ["rgb", "gray", "detect_mat"])
+    def test_accessor_dash_adds_notice(self, grid_image, accessor_name):
+        accessor = getattr(grid_image, accessor_name)
+        fig = accessor.dash(overlay=True, show_grid=False)
+        notices = _plotly_overlay_notices(fig)
+        assert len(notices) == 1
+        assert notices[0].x == 0.01
+        assert notices[0].y == 0.99
+        assert notices[0].font.color == "white"
+        assert notices[0].bgcolor == "rgba(26, 26, 26, 1)"
+
+    def test_show_notice_can_be_disabled(self, grid_image):
+        fig, ax = grid_image.rgb.show(
+            overlay=True, show_overlay_notice=False,
+        )
+        assert _mpl_overlay_notices(ax) == []
+        assert len(ax.images) == 1
+        plt.close(fig)
+
+    def test_dash_notice_can_be_disabled(self, grid_image):
+        fig = grid_image.rgb.dash(
+            overlay=True, show_overlay_notice=False,
+        )
+        assert _plotly_overlay_notices(fig) == []
+        assert len(fig.data) == 1
+
+    def test_notice_not_shown_without_overlay(self, grid_image):
+        fig, ax = grid_image.rgb.show(overlay=False)
+        assert _mpl_overlay_notices(ax) == []
+        plt.close(fig)
+
+        dash_fig = grid_image.rgb.dash(overlay=False)
+        assert _plotly_overlay_notices(dash_fig) == []
+
+    def test_notice_not_shown_for_missing_object_label(self, grid_image):
+        missing_label = max(grid_image.objects.labels) + 1
+        fig, ax = grid_image.rgb.show(
+            overlay=True, object_label=missing_label,
+        )
+        assert _mpl_overlay_notices(ax) == []
+        plt.close(fig)
+
+        dash_fig = grid_image.rgb.dash(
+            overlay=True, object_label=missing_label,
+        )
+        assert _plotly_overlay_notices(dash_fig) == []
+
+    def test_grid_image_forwards_notice_option(self, grid_image):
+        fig, ax = grid_image.show(
+            overlay=True, show_overlay_notice=False,
+        )
+        assert _mpl_overlay_notices(ax) == []
+        plt.close(fig)
+
+        dash_fig = grid_image.dash(
+            overlay=True, show_overlay_notice=False,
+        )
+        assert _plotly_overlay_notices(dash_fig) == []
+
+    def test_notice_coexists_with_labels_and_grid(self, grid_image):
+        fig, ax = grid_image.show(
+            overlay=True, show_overlay_notice=True,
+            show_labels=True, show_grid=True,
+        )
+        assert len(_mpl_overlay_notices(ax)) == 1
+        assert len(ax.texts) > 1
+        plt.close(fig)
+
+        dash_fig = grid_image.dash(
+            overlay=True, show_overlay_notice=True,
+            show_labels=True, show_grid=True,
+        )
+        assert len(_plotly_overlay_notices(dash_fig)) == 1
+        assert len(dash_fig.layout.annotations) > 1
+
+
 # ---------------------------------------------------------------------------
 # Image.show(overlay=True) / Image.dash(overlay=True) — auto-pick accessor
 # ---------------------------------------------------------------------------
@@ -325,17 +429,21 @@ class TestOverlayNoObjects:
     def test_show_overlay_no_objects(self, empty_image):
         fig, ax = empty_image.show(overlay=True)
         assert isinstance(fig, plt.Figure)
+        assert _mpl_overlay_notices(ax) == []
         plt.close(fig)
 
     def test_dash_overlay_no_objects(self, empty_image):
         fig = empty_image.dash(overlay=True)
         assert isinstance(fig, go.Figure)
+        assert _plotly_overlay_notices(fig) == []
 
     def test_accessor_show_overlay_no_objects(self, empty_image):
         fig, ax = empty_image.rgb.show(overlay=True)
         assert isinstance(fig, plt.Figure)
+        assert _mpl_overlay_notices(ax) == []
         plt.close(fig)
 
     def test_accessor_dash_overlay_no_objects(self, empty_image):
         fig = empty_image.rgb.dash(overlay=True)
         assert isinstance(fig, go.Figure)
+        assert _plotly_overlay_notices(fig) == []


### PR DESCRIPTION
## Summary

- add `show_overlay_notice: bool = True` to `Image.show()` / `Image.dash()` and the shared single- and multichannel accessor APIs
- render a compact, high-contrast `Overlay` notice in Matplotlib and Plotly whenever object colors are actually blended
- allow users to suppress the notice with `show_overlay_notice=False`
- preserve the existing-axes support already merged into `main` through PR #191

## Why

Object overlays blend label colors into the displayed image. Because overlays default to enabled once objects exist, users could mistake diagnostic overlay colors for the source image's RGB values. The new notice makes that rendering state visible without changing overlay behavior.

## User impact

Overlay plots now show `Overlay` in the top-left by default. The notice is omitted when overlays are disabled, no objects exist, a filtered object label has no pixels, or the caller opts out.

## Validation

- `uv run pytest tests/unit/core/test_plotly_show.py -q` (58 passed)
- `uv run ruff check` on all changed Python files (passed)
- `git diff --check` (passed)
- independent code review, including follow-up verification after fixing a missing-object-label edge case (no findings)
