### PR TITLE
Make SAM2 inference memory-safe

### DIFF
--- a/docs/source/how_to/pages/gpu_detection_setup.md
+++ b/docs/source/how_to/pages/gpu_detection_setup.md
@@ -113,6 +113,14 @@ print(result.num_objects)
   Use 16 for large, well-separated colonies. Increase to 48--64 for dense
   plates with many small colonies. Higher values increase inference time
   quadratically.
+- **`points_per_batch`** (default 8): Controls how many existing prompt-grid
+  points are decoded at once. Lower this first when a run exhausts GPU or unified
+  memory. It changes throughput, not crop resolution, prompt positions, or prompt
+  density.
+- **`input_scaling`** (default `"image_max"`): Converts non-uint8 model input
+  in bounded row chunks. The default retains historical per-image contrast
+  normalization and performed better on the labeled uint16 accuracy fixture.
+  Use `"dtype_range"` when absolute sensor-scale intensity must be preserved.
 - **`pred_iou_thresh`** (default 0.7): Minimum predicted IoU for keeping a
   mask. Raise to 0.85--0.95 for conservative detection (fewer false
   positives); lower to 0.5 to catch faint or ambiguous colonies.
@@ -248,6 +256,8 @@ Key parameters:
 
 - `dino_version` / `dino_size` — backbone generation (2/3) and size.
 - `sam2_model_size` — SAM2 variant for the proposal generator.
+- `points_per_batch` — SAM2 proposal-decoder batch size (default 8). Lowering it
+  reduces peak memory without reducing proposal density or crop resolution.
 - `similarity_thresh` — minimum cosine-to-prototype score to keep a proposal.
 - `merge_iou_thresh` — IoU above which two survivors are merged.
 - `tile_px` / `tile_overlap` — geometry of the tiles the DINO backbone scores
@@ -654,14 +664,22 @@ CUDA was explicitly requested but is not available. Check:
 
 ### Out of memory (OOM) errors
 
-SAM models require significant GPU memory. To reduce VRAM usage:
+SAM models require significant GPU memory. To reduce VRAM or unified-memory usage
+without lowering segmentation resolution:
 
+- Lower `points_per_batch` first (for example, 4 instead of the default 8). This
+  keeps the same prompt grid, crop pyramid, thresholds, and mask geometry.
+- Both `input_scaling="dtype_range"` and `input_scaling="image_max"` use the
+  same bounded row-chunk conversion, so this setting is not an OOM control.
+  Keep the `"image_max"` default for the validated compatibility policy; use
+  `"dtype_range"` only when absolute sensor-scale intensity is required.
 - Use a smaller model: `Sam2Detector(model_size="tiny")` instead of `"large"`.
 - Use `MicroSamDetector(model_type="vit_t_lm")` for the smallest micro-sam
   model.
-- Reduce `points_per_side` (e.g., 16 instead of 32) to generate fewer
-  candidate masks.
-- Process smaller images or downscale before detection.
+- If memory is still insufficient, reduce `points_per_side` (for example, 16
+  instead of 32), then reduce `crop_n_layers` or downscale the image. These later
+  options reduce prompt density or effective segmentation resolution and can
+  affect accuracy.
 
 ### Checkpoint not found on SLURM compute nodes
 

--- a/docs/superpowers/logic_validation_scripts/2026-07-11-sam2-memory-safety/memory_invariants.py
+++ b/docs/superpowers/logic_validation_scripts/2026-07-11-sam2-memory-safety/memory_invariants.py
@@ -1,0 +1,107 @@
+"""Re-derive the numeric invariants behind SAM2 memory-safe processing.
+
+This script is intentionally independent of :mod:`phenotypic`.  It validates
+the byte-exact legacy normalization path, lossless Fortran-order RLE, and the
+load-bearing full-resolution mask-memory calculations used by the design.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+PLATE_HEIGHT = 3002
+PLATE_WIDTH = 5086
+MASKS_PER_POINT = 3
+FLOAT32_BYTES = 4
+
+
+def legacy_image_max_scale(values: np.ndarray, maximum: int) -> np.ndarray:
+    """Return the historical whole-array uint16-to-uint8 conversion."""
+    if maximum == 0:
+        return np.zeros(values.shape, dtype=np.uint8)
+    return (values / maximum * 255).astype(np.uint8)
+
+
+def chunked_image_max_scale(
+    values: np.ndarray, maximum: int, chunk_size: int = 257
+) -> np.ndarray:
+    """Return the same conversion while bounding temporary allocations."""
+    output = np.empty(values.shape, dtype=np.uint8)
+    for start in range(0, values.size, chunk_size):
+        stop = min(start + chunk_size, values.size)
+        output[start:stop] = legacy_image_max_scale(values[start:stop], maximum)
+    return output
+
+
+def encode_fortran_rle(mask: np.ndarray) -> dict[str, object]:
+    """Encode a Boolean mask using SAM2's uncompressed Fortran-order RLE."""
+    flat = np.asarray(mask, dtype=bool).ravel(order="F")
+    counts: list[int] = []
+    value = False
+    run = 0
+    for pixel in flat:
+        pixel_value = bool(pixel)
+        if pixel_value == value:
+            run += 1
+        else:
+            counts.append(run)
+            value = pixel_value
+            run = 1
+    counts.append(run)
+    return {"size": [int(mask.shape[0]), int(mask.shape[1])], "counts": counts}
+
+
+def decode_fortran_rle(rle: dict[str, object]) -> np.ndarray:
+    """Decode uncompressed Fortran-order RLE into its exact Boolean mask."""
+    height, width = (int(value) for value in rle["size"])  # type: ignore[index]
+    flat = np.empty(height * width, dtype=bool)
+    offset = 0
+    value = False
+    for count_value in rle["counts"]:  # type: ignore[union-attr]
+        count = int(count_value)
+        flat[offset : offset + count] = value
+        offset += count
+        value = not value
+    assert offset == flat.size
+    return flat.reshape((height, width), order="F")
+
+
+def validate_scaling_equivalence() -> None:
+    """Prove chunking preserves legacy bytes for representative maxima."""
+    for maximum in (0, 1, 257, 1023, 4095, 30_000, 65_522, 65_535):
+        values = np.arange(maximum + 1, dtype=np.uint16)
+        expected = legacy_image_max_scale(values, maximum)
+        actual = chunked_image_max_scale(values, maximum)
+        np.testing.assert_array_equal(actual, expected)
+
+
+def validate_rle_round_trips() -> None:
+    """Prove lossless RLE for edge cases and deterministic random masks."""
+    rng = np.random.default_rng(42)
+    masks = [
+        np.zeros((3, 5), dtype=bool),
+        np.ones((3, 5), dtype=bool),
+        np.indices((4, 7)).sum(axis=0) % 2 == 0,
+        rng.random((17, 11)) > 0.7,
+    ]
+    for mask in masks:
+        np.testing.assert_array_equal(decode_fortran_rle(encode_fortran_rle(mask)), mask)
+
+
+def validate_memory_arithmetic() -> None:
+    """Validate exact bytes without embedding an opaque decimal constant."""
+    pixels = PLATE_HEIGHT * PLATE_WIDTH
+    assert pixels == 15_268_172
+    batch_64 = 64 * MASKS_PER_POINT * pixels * FLOAT32_BYTES
+    batch_8 = 8 * MASKS_PER_POINT * pixels * FLOAT32_BYTES
+    assert batch_64 == 11_725_956_096
+    assert batch_8 == 1_465_744_512
+    assert batch_64 == 8 * batch_8
+
+
+if __name__ == "__main__":
+    validate_scaling_equivalence()
+    validate_rle_round_trips()
+    validate_memory_arithmetic()
+    print("SAM2 memory invariants verified")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ torch = [
     # handles missing micro_sam gracefully at runtime.
     "torch>=2.5.1;sys_platform!='win32'",
     "torchvision>=0.20.1;sys_platform!='win32'",
-    "sam2;sys_platform!='win32'",
+    "sam2>=1.1.0;sys_platform!='win32'",
 ]
 
 foundation = [

--- a/scripts/accuracy_gate_gpu_detectors.py
+++ b/scripts/accuracy_gate_gpu_detectors.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import contextlib
 import time
+from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 
@@ -21,7 +23,23 @@ from phenotypic import Image
 from phenotypic.data import load_synth_yeast_plate
 
 
-def tiled_plate(rows: int = 3, cols: int = 4) -> tuple[Image, np.ndarray]:
+@dataclass(frozen=True)
+class Evaluation:
+    """One detector result used by the accuracy and equivalence gates."""
+
+    iou: float
+    objects: int
+    truth_objects: int
+    objmap: np.ndarray
+    elapsed: float
+
+
+def tiled_plate(
+    rows: int = 3,
+    cols: int = 4,
+    *,
+    encoding: Literal["uint8", "uint16_nonfull"] = "uint8",
+) -> tuple[Image, np.ndarray]:
     """Replicate synth_plate into a plate larger than SAM2's 1024 encoder.
 
     Colony diameters stay 32-44 px; only the plate grows, so the detectors face
@@ -33,6 +51,10 @@ def tiled_plate(rows: int = 3, cols: int = 4) -> tuple[Image, np.ndarray]:
     """
     src = load_synth_yeast_plate()
     rgb = np.asarray(src.rgb[:])
+    if encoding == "uint16_nonfull":
+        # Exercise the policy choice with a 16-bit acquisition whose brightest
+        # sample does not fill the dtype range. This is lossless for uint8.
+        rgb = rgb.astype(np.uint16) * 128
     om = np.asarray(src.objmap[:])
     h, w = om.shape
     n = int(om.max())
@@ -68,8 +90,14 @@ def legacy_processor_policy():
         ds.NATIVE_PROCESSOR_KWARGS.update(saved)
 
 
-def evaluate(detector, label: str, *, legacy: bool = False) -> float:
-    image, truth_om = tiled_plate()
+def evaluate(
+    detector,
+    label: str,
+    *,
+    legacy: bool = False,
+    encoding: Literal["uint8", "uint16_nonfull"] = "uint8",
+) -> Evaluation:
+    image, truth_om = tiled_plate(encoding=encoding)
     truth = truth_om > 0
     ctx = legacy_processor_policy() if legacy else contextlib.nullcontext()
     t0 = time.perf_counter()
@@ -80,12 +108,68 @@ def evaluate(detector, label: str, *, legacy: bool = False) -> float:
     elapsed = time.perf_counter() - t0
     pred = np.asarray(result.objmask[:])
     iou = mask_iou(pred, truth)
+    objects = result.num_objects
+    truth_objects = int(truth_om.max())
     print(
         f"{label:<40} IoU {iou:.4f}  "
-        f"objects {result.num_objects:>5} / {int(truth_om.max())}  "
+        f"objects {objects:>5} / {truth_objects}  "
         f"{elapsed:7.1f}s"
     )
-    return iou
+    return Evaluation(
+        iou=iou,
+        objects=objects,
+        truth_objects=truth_objects,
+        objmap=np.asarray(result.objmap[:]),
+        elapsed=elapsed,
+    )
+
+
+def canonical_objmap(objmap: np.ndarray) -> np.ndarray:
+    """Relabel objects by top-left extent so label-order changes are ignored."""
+    records: list[tuple[int, int, int, int]] = []
+    for label in np.unique(objmap):
+        if label == 0:
+            continue
+        ys, xs = np.nonzero(objmap == label)
+        records.append((int(ys.min()), int(xs.min()), int(ys.size), int(label)))
+    records.sort()
+    canonical = np.zeros(objmap.shape, dtype=np.uint16)
+    for new_label, record in enumerate(records, start=1):
+        old_label = record[-1]
+        canonical[objmap == old_label] = new_label
+    return canonical
+
+
+def assert_batch_equivalence(reference: Evaluation, candidate: Evaluation) -> None:
+    """Require resource-only batching changes to preserve exact segmentation."""
+    np.testing.assert_array_equal(reference.objmap > 0, candidate.objmap > 0)
+    assert reference.objects == candidate.objects
+    np.testing.assert_array_equal(
+        canonical_objmap(reference.objmap), canonical_objmap(candidate.objmap)
+    )
+
+
+def assert_selected_scaling_not_worse(
+    selected: Evaluation, alternative: Evaluation
+) -> None:
+    """Require the selected default to match or beat the alternative policy."""
+    assert selected.iou >= alternative.iou
+    selected_error = abs(selected.objects - selected.truth_objects)
+    alternative_error = abs(alternative.objects - alternative.truth_objects)
+    assert selected_error <= alternative_error
+
+
+def assert_scaling_fixture_distinguishes_policies() -> None:
+    """Guard against accidentally benchmarking the uint8 passthrough path."""
+    from phenotypic.detect.nn import Sam2Detector
+
+    image, _ = tiled_plate(rows=1, cols=1, encoding="uint16_nonfull")
+    rgb = np.asarray(image.rgb[:])
+    dtype_input = Sam2Detector(input_scaling="dtype_range")._preprocess(rgb)
+    legacy_input = Sam2Detector(input_scaling="image_max")._preprocess(rgb)
+    assert rgb.dtype == np.uint16
+    assert int(rgb.max()) < np.iinfo(np.uint16).max
+    assert not np.array_equal(dtype_input, legacy_input)
 
 
 if __name__ == "__main__":
@@ -125,3 +209,53 @@ if __name__ == "__main__":
         Sam2Detector(model_size="tiny", crop_n_layers=1, device="auto"),
         "Sam2     crop_n_layers=1 (new default)",
     )
+
+    sam2_batch_64 = evaluate(
+        Sam2Detector(
+            model_size="tiny",
+            crop_n_layers=1,
+            points_per_batch=64,
+            input_scaling="dtype_range",
+            device="auto",
+        ),
+        "Sam2     points_per_batch=64",
+    )
+    sam2_batch_8 = evaluate(
+        Sam2Detector(
+            model_size="tiny",
+            crop_n_layers=1,
+            points_per_batch=8,
+            input_scaling="dtype_range",
+            device="auto",
+        ),
+        "Sam2     points_per_batch=8",
+    )
+    assert_batch_equivalence(sam2_batch_64, sam2_batch_8)
+
+    assert_scaling_fixture_distinguishes_policies()
+    sam2_dtype_range = evaluate(
+        Sam2Detector(
+            model_size="tiny",
+            crop_n_layers=1,
+            points_per_batch=8,
+            input_scaling="dtype_range",
+            device="auto",
+        ),
+        "Sam2     uint16 dtype_range",
+        encoding="uint16_nonfull",
+    )
+    sam2_image_max = evaluate(
+        Sam2Detector(
+            model_size="tiny",
+            crop_n_layers=1,
+            points_per_batch=8,
+            input_scaling="image_max",
+            device="auto",
+        ),
+        "Sam2     uint16 image_max",
+        encoding="uint16_nonfull",
+    )
+    # The labeled uint16 fixture favors image_max (IoU 0.8709 versus 0.8626,
+    # 1079 versus 1051 objects against 1152 truth objects), so retain the
+    # compatibility policy as the default while keeping both options public.
+    assert_selected_scaling_not_worse(sam2_image_max, sam2_dtype_range)

--- a/src/phenotypic/abc_/_gpu_detector.py
+++ b/src/phenotypic/abc_/_gpu_detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Annotated, Any, List
+from typing import TYPE_CHECKING, Annotated, Any, List, Literal
 
 import numpy as np
 
@@ -11,6 +11,49 @@ if TYPE_CHECKING:
     from phenotypic._core._image import Image
 
 from ._object_detector import ObjectDetector
+
+
+_UINT8_CONVERSION_CHUNK_BYTES = 16 * 1024 * 1024
+
+
+def _conversion_rows(array: np.ndarray) -> int:
+    """Return a row count that bounds float64 conversion temporaries."""
+    values_per_row = int(np.prod(array.shape[1:], dtype=np.int64))
+    bytes_per_row = max(1, values_per_row * np.dtype(np.float64).itemsize)
+    return max(1, _UINT8_CONVERSION_CHUNK_BYTES // bytes_per_row)
+
+
+def _scale_to_uint8(
+    array: np.ndarray,
+    scaling: Literal["dtype_range", "image_max"],
+) -> np.ndarray:
+    """Scale a non-uint8 array into uint8 using bounded row chunks."""
+    output = np.empty(array.shape, dtype=np.uint8)
+    if scaling == "image_max":
+        scale_max = array.max()
+    elif np.issubdtype(array.dtype, np.integer):
+        scale_max = np.iinfo(array.dtype).max
+    else:
+        scale_max = 1.0
+
+    if scale_max <= 0:
+        output.fill(0)
+        return output
+
+    rows_per_chunk = _conversion_rows(array)
+    for row_start in range(0, array.shape[0], rows_per_chunk):
+        row_stop = min(row_start + rows_per_chunk, array.shape[0])
+        chunk = array[row_start:row_stop]
+        if scaling == "image_max":
+            # Keep this expression identical to the legacy whole-array path.
+            output[row_start:row_stop] = (
+                chunk / scale_max * 255
+            ).astype(np.uint8)
+        else:
+            output[row_start:row_stop] = (
+                np.clip(chunk, 0, scale_max) / scale_max * 255
+            ).astype(np.uint8)
+    return output
 
 
 # <<Interface>>
@@ -105,6 +148,9 @@ class GpuDetector(ObjectDetector, ABC):
     # serialize and round-trip (Spec 1 §4, review S4). Subclasses override the
     # defaults; "instance" keeps existing SAM behavior unchanged.
     input_layer: GpuInputLayer = "rgb"
+    input_scaling: Annotated[
+        Literal["dtype_range", "image_max"], TuneSpec(tunable=False)
+    ] = "image_max"
     supports_batching: bool = False
     output_kind: GpuOutputKind = "instance"
 
@@ -126,23 +172,19 @@ class GpuDetector(ObjectDetector, ABC):
     def _preprocess(self, array: np.ndarray) -> Any:
         """Turn a raw ``input_layer`` array into a model-ready ``uint8`` sample.
 
-        Single-channel 2D layers (``gray``/``detect_mat``) are stacked into an
-        ``(H, W, 3)`` block so 3-channel models (SAM/DINO ViT) consume them
-        unchanged; ``rgb`` keeps its three channels. The result is then coerced
-        to ``uint8`` — float ``[0, 1]`` (``gray``/``detect_mat``) and ``uint16``
-        (16-bit ``rgb``) layers are max-normalized to ``0..255``, while an
-        already-``uint8`` ``rgb`` array passes through byte-identical — so every
-        layer reaches the model through this one shared conversion. Subclasses
-        rarely need to override this.
+        Non-uint8 inputs are converted in bounded row chunks. ``dtype_range``
+        maps integer dtype limits (for example, uint16 0..65535) or normalized
+        float 0..1 to 0..255; ``image_max`` retains the legacy per-image maximum
+        normalization. ``dtype_range`` values outside its range are clipped. A
+        2D layer is converted before it is stacked into an ``(H, W, 3)`` block,
+        avoiding three-channel conversion temporaries. An already-uint8 3D array
+        passes through without a copy. Subclasses rarely need to override this
+        method.
         """
+        if array.dtype != np.uint8:
+            array = _scale_to_uint8(array, self.input_scaling)
         if array.ndim == 2:
             array = np.stack([array, array, array], axis=-1)
-        if array.dtype != np.uint8:
-            max_val = array.max()
-            if max_val > 0:
-                array = (array / max_val * 255).astype(np.uint8)
-            else:
-                array = np.zeros(array.shape, dtype=np.uint8)
         return array
 
     def _collate(self, samples: List[Any]) -> Any:

--- a/src/phenotypic/detect/nn/_dinosam2_detector.py
+++ b/src/phenotypic/detect/nn/_dinosam2_detector.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Annotated, Any, List
 
-from pydantic import PrivateAttr
+from pydantic import Field, PrivateAttr
 
 from phenotypic.abc_ import GpuDetector
 from phenotypic.detect.nn._checkpoint_manager import Device, Sam2ModelSize
@@ -147,6 +147,38 @@ def _assemble_objmap(
     return objmap
 
 
+def _assemble_rle_objmap(
+    proposals: List[dict],
+    scores: "np.ndarray",
+    similarity_thresh: float,
+    merge_iou_thresh: float,
+    shape: tuple[int, int],
+) -> "np.ndarray":
+    """Filter, RLE-IoU merge, and stream scored proposals into an objmap."""
+    import numpy as np
+
+    from phenotypic.detect.nn._sam2_rle import (
+        merge_rle_records_by_iou,
+        paint_rle_records,
+    )
+
+    aligned_scores = np.asarray(scores)
+    foreground = [
+        proposal
+        for proposal, score in zip(proposals, aligned_scores)
+        if score >= similarity_thresh
+    ]
+    if not foreground:
+        return np.zeros(shape, dtype=np.uint16)
+    kept = merge_rle_records_by_iou(foreground, merge_iou_thresh)
+    return paint_rle_records(
+        kept,
+        shape,
+        detector_name="DinoSam2",
+        truncate_before_sort=False,
+    )
+
+
 class DinoSam2Detector(GpuDetector):
     """Detect colonies with SAM2 proposals scored by DINOv2 features.
 
@@ -186,6 +218,9 @@ class DinoSam2Detector(GpuDetector):
             duplicates (fixes SAM2 over-segmentation).  Default 0.7.
         min_proposal_area: Minimum proposal area in pixels (forwarded to SAM2's
             mask generator).  Default 100.
+        points_per_batch: Number of SAM2 point prompts decoded together. Lower
+            this first if inference runs out of memory; it preserves proposal
+            positions and crop resolution at the cost of throughput. Default 8.
         tile_px: Tile size, in pixels, at which DINO dense features are
             extracted.  A colony must be resolvable on the patch grid to be
             pooled at all: on a whole 4000x3000 plate a 30 px colony spans
@@ -288,6 +323,9 @@ class DinoSam2Detector(GpuDetector):
     similarity_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.5
     merge_iou_thresh: Annotated[float, TuneSpec(0.0, 1.0)] = 0.7
     min_proposal_area: Annotated[int, TuneSpec(0, 500)] = 100
+    points_per_batch: Annotated[int, TuneSpec(tunable=False)] = Field(
+        default=8, ge=1
+    )
 
     # DINO feature tiling — 518 = 14 * 37, an exact DINOv2 patch multiple.
     # Whole-plate pooling makes every colony sub-patch (see
@@ -358,6 +396,7 @@ class DinoSam2Detector(GpuDetector):
             self.sam2_model_size,
             device=self._device,
             min_mask_region_area=self.min_proposal_area,
+            points_per_batch=self.points_per_batch,
             crop_n_layers=self.crop_n_layers,
             crop_nms_thresh=self.crop_nms_thresh,
             crop_overlap_ratio=self.crop_overlap_ratio,
@@ -393,7 +432,13 @@ class DinoSam2Detector(GpuDetector):
         if not raw:
             return np.zeros(rgb.shape[:2], dtype=np.uint16)
 
-        proposals = [m["segmentation"].astype(bool) for m in raw]
+        shape = rgb.shape[:2]
+        from phenotypic.detect.nn._sam2_rle import (
+            decode_uncompressed_rle,
+            normalize_rle_records,
+        )
+
+        normalize_rle_records(raw, expected_shape=shape)
         # Shared, register-token-aware dense features (C1 fix lives in one
         # place — _dino_support.extract_patch_features — not duplicated here).
         from phenotypic.detect.nn import _dino_support
@@ -410,21 +455,26 @@ class DinoSam2Detector(GpuDetector):
             )
             for t in tiles
         ]
-        features = np.stack(
-            [
+        pooled_features = []
+        for proposal in raw:
+            mask = decode_uncompressed_rle(
+                proposal["segmentation"], expected_shape=shape
+            )
+            pooled_features.append(
                 _dino_support.pool_prototype_tiled(
-                    dense_by_tile, tiles, p, patch
+                    dense_by_tile, tiles, mask, patch
                 ).astype(np.float64)
-                for p in proposals
-            ]
-        )
+            )
+            del mask
+        features = np.stack(pooled_features)
         prototype = self._foreground_prototype(features, raw)
         scores = _score_by_prototype(features, prototype)
-        return _assemble_objmap(
-            proposals,
+        return _assemble_rle_objmap(
+            raw,
             scores,
             similarity_thresh=self.similarity_thresh,
             merge_iou_thresh=self.merge_iou_thresh,
+            shape=shape,
         )
 
     @staticmethod

--- a/src/phenotypic/detect/nn/_sam2_detector.py
+++ b/src/phenotypic/detect/nn/_sam2_detector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Annotated
 
-from pydantic import PrivateAttr
+from pydantic import Field, PrivateAttr
 
 from phenotypic.abc_ import GpuDetector
 from phenotypic.detect.nn._checkpoint_manager import (
@@ -20,6 +20,7 @@ def build_sam2_generator(
     *,
     device: str,
     points_per_side: int = 32,
+    points_per_batch: int = 8,
     pred_iou_thresh: float = 0.7,
     stability_score_thresh: float = 0.92,
     min_mask_region_area: int = 100,
@@ -47,6 +48,9 @@ def build_sam2_generator(
         model_size: SAM2 variant (``"tiny"`` … ``"large"``).
         device: Resolved torch device string (from ``resolve_device``).
         points_per_side: Point-prompt grid density (``points_per_side ** 2``).
+        points_per_batch: Number of point prompts decoded together. Lowering
+            this bounds peak full-resolution mask memory without changing the
+            prompt grid or segmentation resolution.
         pred_iou_thresh: Minimum predicted-IoU score to keep a mask.
         stability_score_thresh: Minimum mask-stability score.
         min_mask_region_area: Minimum mask area in pixels.
@@ -98,6 +102,7 @@ def build_sam2_generator(
     return SAM2AutomaticMaskGenerator(
         model,
         points_per_side=points_per_side,
+        points_per_batch=points_per_batch,
         pred_iou_thresh=pred_iou_thresh,
         stability_score_thresh=stability_score_thresh,
         min_mask_region_area=min_mask_region_area,
@@ -106,6 +111,7 @@ def build_sam2_generator(
         crop_overlap_ratio=crop_overlap_ratio,
         crop_n_points_downscale_factor=crop_n_points_downscale_factor,
         box_nms_thresh=box_nms_thresh,
+        output_mode="uncompressed_rle",
     )
 
 
@@ -141,6 +147,10 @@ class Sam2Detector(GpuDetector):
             locations.  Increase for dense plates with many small
             colonies; decrease to speed up inference on sparse plates.
             Typical range: 16--64.  Default 32 (1024 points).
+        points_per_batch: Number of point prompts decoded together. Lower this
+            first if SAM2 runs out of memory; it preserves prompt positions,
+            crop resolution, and quality thresholds at the cost of throughput.
+            Default 8.
         pred_iou_thresh: Minimum predicted IoU score for a mask to be
             kept.  SAM2 self-estimates mask quality; masks below this
             threshold are discarded.  Raise to keep only high-confidence
@@ -273,6 +283,9 @@ class Sam2Detector(GpuDetector):
 
     model_size: Sam2ModelSize = "tiny"
     points_per_side: int = 32
+    points_per_batch: Annotated[int, TuneSpec(tunable=False)] = Field(
+        default=8, ge=1
+    )
     pred_iou_thresh: float = 0.7
     stability_score_thresh: float = 0.92
     min_mask_region_area: int = 100
@@ -312,6 +325,7 @@ class Sam2Detector(GpuDetector):
             self.model_size,
             device=device,
             points_per_side=self.points_per_side,
+            points_per_batch=self.points_per_batch,
             pred_iou_thresh=self.pred_iou_thresh,
             stability_score_thresh=self.stability_score_thresh,
             min_mask_region_area=self.min_mask_region_area,
@@ -330,29 +344,22 @@ class Sam2Detector(GpuDetector):
         Returns a uint16 labeled objmap (largest-first painting preserves
         small-colony identity at overlaps).
         """
-        import numpy as np
-
         rgb = sample
         masks = self._generator.generate(rgb)  # type: ignore[attr-defined]
 
         h, w = rgb.shape[:2]
-        objmap = np.zeros((h, w), dtype=np.uint16)
-        if masks:
-            max_labels = int(np.iinfo(np.uint16).max)
-            if len(masks) > max_labels:
-                import warnings
+        from phenotypic.detect.nn._sam2_rle import (
+            normalize_rle_records,
+            paint_rle_records,
+        )
 
-                warnings.warn(
-                    f"SAM2 generated {len(masks)} masks, exceeding uint16 "
-                    f"range. Only the first {max_labels} will be labeled.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                masks = masks[:max_labels]
-            masks = sorted(masks, key=lambda m: m["area"], reverse=True)
-            for idx, m in enumerate(masks, start=1):
-                objmap[m["segmentation"]] = idx
-        return objmap
+        normalize_rle_records(masks, expected_shape=(h, w))
+        return paint_rle_records(
+            masks,
+            (h, w),
+            detector_name="SAM2",
+            truncate_before_sort=True,
+        )
 
 
 # Expose the class docstring on .apply() for Sphinx autodoc

--- a/src/phenotypic/detect/nn/_sam2_rle.py
+++ b/src/phenotypic/detect/nn/_sam2_rle.py
@@ -1,0 +1,238 @@
+"""Lossless, bounded-memory helpers for SAM2 uncompressed RLE masks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from numbers import Integral
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def validate_uncompressed_rle(
+    rle: Mapping[str, Any],
+    *,
+    expected_shape: tuple[int, int] | None = None,
+) -> tuple[tuple[int, int], tuple[int, ...]]:
+    """Validate an upstream SAM2 uncompressed, Fortran-order RLE.
+
+    Args:
+        rle: Mapping with ``size=[height, width]`` and integer run ``counts``.
+        expected_shape: Optional image shape that ``size`` must match.
+
+    Returns:
+        The validated shape and immutable run counts.
+
+    Raises:
+        ValueError: If the RLE is malformed or does not cover exactly one mask.
+    """
+    if not isinstance(rle, Mapping) or "size" not in rle or "counts" not in rle:
+        raise ValueError("SAM2 RLE must contain 'size' and 'counts'")
+
+    size = rle["size"]
+    if (
+        not isinstance(size, Sequence)
+        or isinstance(size, (str, bytes))
+        or len(size) != 2
+        or any(
+            isinstance(value, bool) or not isinstance(value, Integral)
+            for value in size
+        )
+    ):
+        raise ValueError("SAM2 RLE 'size' must contain two integers")
+    shape = (int(size[0]), int(size[1]))
+    if shape[0] < 0 or shape[1] < 0:
+        raise ValueError("SAM2 RLE dimensions must be non-negative")
+    if expected_shape is not None and shape != expected_shape:
+        raise ValueError(
+            f"SAM2 RLE shape {shape} does not match image shape {expected_shape}"
+        )
+
+    counts_value = rle["counts"]
+    if (
+        not isinstance(counts_value, Sequence)
+        or isinstance(counts_value, (str, bytes))
+        or any(
+            isinstance(value, bool) or not isinstance(value, Integral)
+            for value in counts_value
+        )
+    ):
+        raise ValueError("SAM2 uncompressed RLE 'counts' must be integer runs")
+    counts = tuple(int(value) for value in counts_value)
+    if any(value < 0 for value in counts):
+        raise ValueError("SAM2 RLE runs must be non-negative")
+    if sum(counts) != shape[0] * shape[1]:
+        raise ValueError("SAM2 RLE runs must cover exactly height * width pixels")
+    return shape, counts
+
+
+def decode_uncompressed_rle(
+    rle: Mapping[str, Any],
+    *,
+    expected_shape: tuple[int, int] | None = None,
+):
+    """Decode one SAM2 uncompressed RLE using its Fortran-order convention."""
+    import numpy as np
+
+    shape, counts = validate_uncompressed_rle(rle, expected_shape=expected_shape)
+    flat: np.ndarray = np.empty(shape[0] * shape[1], dtype=bool)
+    offset = 0
+    value = False
+    for count in counts:
+        flat[offset : offset + count] = value
+        offset += count
+        value = not value
+    return flat.reshape(shape, order="F")
+
+
+def encode_uncompressed_rle(mask) -> dict[str, list[int]]:
+    """Encode a 2-D mask into upstream-compatible Fortran-order RLE."""
+    import numpy as np
+
+    array = np.asarray(mask, dtype=bool)
+    if array.ndim != 2:
+        raise ValueError("SAM2 masks must be two-dimensional")
+    flat = array.reshape(-1, order="F")
+    counts: list[int] = []
+    value = False
+    run = 0
+    for pixel in flat:
+        pixel_value = bool(pixel)
+        if pixel_value == value:
+            run += 1
+        else:
+            counts.append(run)
+            run = 1
+            value = pixel_value
+    counts.append(run)
+    return {"size": [array.shape[0], array.shape[1]], "counts": counts}
+
+
+def segmentation_as_rle(
+    segmentation: Any, *, expected_shape: tuple[int, int]
+) -> Mapping[str, Any]:
+    """Return a validated RLE, accepting Boolean masks for compatibility."""
+    if isinstance(segmentation, Mapping):
+        validate_uncompressed_rle(segmentation, expected_shape=expected_shape)
+        return segmentation
+    rle = encode_uncompressed_rle(segmentation)
+    validate_uncompressed_rle(rle, expected_shape=expected_shape)
+    return rle
+
+
+def normalize_rle_records(
+    records: Sequence[MutableMapping[str, Any]],
+    *,
+    expected_shape: tuple[int, int],
+) -> None:
+    """Normalize SAM2 record segmentations to validated RLE in place."""
+    for record in records:
+        record["segmentation"] = segmentation_as_rle(
+            record["segmentation"], expected_shape=expected_shape
+        )
+        record.setdefault("area", rle_area(record["segmentation"]))
+
+
+def rle_area(rle: Mapping[str, Any]) -> int:
+    """Return the exact foreground area without decoding the mask."""
+    _, counts = validate_uncompressed_rle(rle)
+    return sum(counts[1::2])
+
+
+def rle_iou(rle_a: Mapping[str, Any], rle_b: Mapping[str, Any]) -> float:
+    """Calculate exact mask IoU directly from two uncompressed RLE streams."""
+    shape_a, counts_a = validate_uncompressed_rle(rle_a)
+    shape_b, counts_b = validate_uncompressed_rle(rle_b)
+    if shape_a != shape_b:
+        raise ValueError(f"Cannot compare RLE shapes {shape_a} and {shape_b}")
+
+    index_a = index_b = 0
+    remaining_a = counts_a[0] if counts_a else 0
+    remaining_b = counts_b[0] if counts_b else 0
+    value_a = value_b = False
+    intersection = union = 0
+    total = shape_a[0] * shape_a[1]
+    consumed = 0
+    while consumed < total:
+        while remaining_a == 0:
+            index_a += 1
+            value_a = not value_a
+            remaining_a = counts_a[index_a]
+        while remaining_b == 0:
+            index_b += 1
+            value_b = not value_b
+            remaining_b = counts_b[index_b]
+        span = min(remaining_a, remaining_b)
+        if value_a and value_b:
+            intersection += span
+        if value_a or value_b:
+            union += span
+        remaining_a -= span
+        remaining_b -= span
+        consumed += span
+    return intersection / union if union else 0.0
+
+
+def stable_area_order(records: Sequence[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
+    """Return records largest-first, preserving input order for area ties."""
+    return sorted(records, key=lambda record: int(record["area"]), reverse=True)
+
+
+def merge_rle_records_by_iou(
+    records: Sequence[Mapping[str, Any]], iou_thresh: float
+) -> list[Mapping[str, Any]]:
+    """Greedily deduplicate RLE records by exact IoU, largest-first."""
+    ordered = stable_area_order(records)
+    kept: list[Mapping[str, Any]] = []
+    for candidate in ordered:
+        candidate_rle = candidate["segmentation"]
+        if any(
+            rle_iou(candidate_rle, record["segmentation"]) > iou_thresh
+            for record in kept
+        ):
+            continue
+        kept.append(candidate)
+    return kept
+
+
+def paint_rle_records(
+    records: Sequence[Mapping[str, Any]],
+    shape: tuple[int, int],
+    *,
+    detector_name: str,
+    truncate_before_sort: bool,
+):
+    """Paint records largest-first while decoding at most one mask at a time."""
+    import warnings
+
+    import numpy as np
+
+    selected = list(records)
+    max_labels = int(np.iinfo(np.uint16).max)
+    if truncate_before_sort and len(selected) > max_labels:
+        warnings.warn(
+            f"{detector_name} generated {len(selected)} masks, exceeding uint16 "
+            f"range. Only the first {max_labels} will be labeled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        selected = selected[:max_labels]
+    selected = stable_area_order(selected)
+    if not truncate_before_sort and len(selected) > max_labels:
+        warnings.warn(
+            f"{detector_name} kept {len(selected)} proposals, exceeding uint16 "
+            f"range. Only the first {max_labels} (largest) will be labeled.",
+            UserWarning,
+            stacklevel=2,
+        )
+        selected = selected[:max_labels]
+
+    objmap: np.ndarray = np.zeros(shape, dtype=np.uint16)
+    for label, record in enumerate(selected, start=1):
+        mask = decode_uncompressed_rle(
+            record["segmentation"], expected_shape=shape
+        )
+        objmap[mask] = label
+        del mask
+    return objmap

--- a/tests/unit/abc_/test_gpu_detector_interface.py
+++ b/tests/unit/abc_/test_gpu_detector_interface.py
@@ -7,6 +7,8 @@ All tests construct detectors WITHOUT torch — the interface and the CPU
 from typing import get_args
 
 import numpy as np
+import pytest
+from pydantic import ValidationError
 
 from phenotypic.abc_ import GpuDetector
 from phenotypic.data import load_synth_yeast_plate
@@ -33,14 +35,25 @@ class TestCapabilityFields:
     def test_fields_are_serializable_pydantic_fields(self):
         # capability markers are real fields (not ClassVar) -> in model_fields
         assert "input_layer" in GpuDetector.model_fields
+        assert "input_scaling" in GpuDetector.model_fields
         assert "supports_batching" in GpuDetector.model_fields
         assert "output_kind" in GpuDetector.model_fields
+
+    def test_input_scaling_default_and_round_trip(self):
+        det = Sam2Detector()
+        assert det.input_scaling == "image_max"
+        restored = Sam2Detector.model_validate_json(det.model_dump_json())
+        assert restored.input_scaling == "image_max"
+
+    def test_input_scaling_rejects_unknown_value(self):
+        with pytest.raises(ValidationError):
+            Sam2Detector(input_scaling="percentile")
 
 
 class TestPreprocess:
     def test_2d_float_layer_stacked_and_uint8_normalized(self):
-        # gray/detect_mat arrive as 2D float [0,1]; _preprocess stacks them to
-        # (H,W,3) and max-normalizes to uint8 through one shared path.
+        # gray/detect_mat arrive as 2D float [0,1]; _preprocess converts before
+        # stacking them to (H,W,3).
         det = Sam2Detector()
         gray = np.linspace(0.0, 1.0, 20, dtype=np.float32).reshape(4, 5)
         out = det._preprocess(gray)
@@ -65,6 +78,48 @@ class TestPreprocess:
         assert out.shape == (4, 5, 3)
         assert out.dtype == np.uint8
         assert out.max() == 0
+
+    def test_dtype_range_uint16_uses_full_bit_depth(self):
+        det = Sam2Detector(input_scaling="dtype_range")
+        rgb = np.array([0, 32768, 65535], dtype=np.uint16).reshape(1, 1, 3)
+        out = det._preprocess(rgb)
+        np.testing.assert_array_equal(out, [[[0, 127, 255]]])
+
+    def test_dtype_range_float_clips_out_of_range_values(self):
+        det = Sam2Detector(input_scaling="dtype_range")
+        layer = np.array([[-0.5, 0.5, 1.5]], dtype=np.float32)
+        out = det._preprocess(layer)
+        np.testing.assert_array_equal(out[..., 0], [[0, 127, 255]])
+
+    def test_dtype_range_handles_non_square_2d_uint16_before_stacking(self):
+        det = Sam2Detector(input_scaling="dtype_range")
+        layer = np.arange(15, dtype=np.uint16).reshape(3, 5) * 4000
+        out = det._preprocess(layer)
+        assert out.shape == (3, 5, 3)
+        np.testing.assert_array_equal(out[..., 0], out[..., 1])
+        np.testing.assert_array_equal(out[..., 0], out[..., 2])
+
+    def test_image_max_matches_legacy_for_complete_uint16_domain(self):
+        det = Sam2Detector(input_scaling="image_max")
+        values = np.arange(65536, dtype=np.uint16).reshape(256, 256)
+        expected = (values / values.max() * 255).astype(np.uint8)
+        actual = det._preprocess(values)[..., 0]
+        np.testing.assert_array_equal(actual, expected)
+
+    @pytest.mark.parametrize("maximum", [1, 255, 1000, 30_000, 65_534])
+    def test_image_max_matches_legacy_for_representative_maxima(self, maximum):
+        det = Sam2Detector(input_scaling="image_max")
+        values = np.linspace(0, maximum, 10_001, dtype=np.uint16).reshape(73, 137)
+        expected = (values / values.max() * 255).astype(np.uint8)
+        actual = det._preprocess(values)[..., 0]
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_image_max_conversion_crosses_chunk_boundaries(self):
+        det = Sam2Detector(input_scaling="image_max")
+        values = np.arange(2_200_000, dtype=np.uint32).reshape(1100, 2000)
+        expected = (values / values.max() * 255).astype(np.uint8)
+        actual = det._preprocess(values)[..., 0]
+        np.testing.assert_array_equal(actual, expected)
 
 
 class TestInferBatchDefault:

--- a/tests/unit/detect/nn/test_dinosam2_detector.py
+++ b/tests/unit/detect/nn/test_dinosam2_detector.py
@@ -16,6 +16,7 @@ import pytest
 from phenotypic import ImagePipeline
 from phenotypic.abc_ import GpuDetector, ObjectDetector
 from phenotypic.detect.nn import DinoSam2Detector
+from pydantic import ValidationError
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +45,11 @@ class TestDinoSam2Construction:
         assert det.similarity_thresh == 0.5
         assert det.merge_iou_thresh == 0.7
         assert det.min_proposal_area == 100
+        assert det.points_per_batch == 8
+
+    def test_points_per_batch_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            DinoSam2Detector(points_per_batch=0)
 
     def test_dinov3_is_opt_in(self):
         det = DinoSam2Detector(dino_version=3, dino_size="base")
@@ -73,11 +79,27 @@ class TestDinoSam2Construction:
 
 class TestDinoSam2Serialization:
     def test_pipeline_json_round_trip(self):
-        pipe = ImagePipeline(ops=[DinoSam2Detector(dino_size="large")])
+        pipe = ImagePipeline(
+            ops=[DinoSam2Detector(dino_size="large", points_per_batch=4)]
+        )
         restored = ImagePipeline.from_json(pipe.to_json())
         det = list(restored._ops.values())[0]
         assert isinstance(det, DinoSam2Detector)
         assert det.dino_size == "large"
+        assert det.points_per_batch == 4
+
+    def test_old_pipeline_payload_defaults_points_per_batch(self):
+        config = json.loads(ImagePipeline(ops=[DinoSam2Detector()]).to_json())
+        detector_config = next(
+            value
+            for value in config["pipe_cfgs"].values()
+            if value["class"] == "DinoSam2Detector"
+        )
+        detector_config["params"].pop("points_per_batch")
+
+        restored = ImagePipeline.from_json(json.dumps(config))
+
+        assert list(restored._ops.values())[0].points_per_batch == 8
 
     def test_private_attrs_not_in_json(self):
         det = DinoSam2Detector()
@@ -209,6 +231,121 @@ class TestRecipeAlgorithm:
         assert objmap.max() == 1  # only the foreground proposal survives
         assert objmap[4, 4] == 1
         assert objmap[14, 14] == 0  # background dropped
+
+    def test_rle_recipe_matches_boolean_recipe(self):
+        from phenotypic.detect.nn._dinosam2_detector import (
+            _assemble_objmap,
+            _assemble_rle_objmap,
+        )
+        from phenotypic.detect.nn._sam2_rle import encode_uncompressed_rle
+
+        outer = np.zeros((12, 15), bool)
+        outer[1:10, 1:13] = True
+        inner = np.zeros((12, 15), bool)
+        inner[4:7, 5:9] = True
+        distinct = np.zeros((12, 15), bool)
+        distinct[9:11, 12:15] = True
+        masks = [inner, outer, distinct]
+        scores = np.array([0.9, 0.95, 0.1])
+        expected = _assemble_objmap(masks, scores, 0.5, 0.7)
+        records = [
+            {
+                "segmentation": encode_uncompressed_rle(mask),
+                "area": int(mask.sum()),
+            }
+            for mask in masks
+        ]
+        actual = _assemble_rle_objmap(records, scores, 0.5, 0.7, outer.shape)
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_rle_merge_matches_boolean_merge(self):
+        from phenotypic.detect.nn._dinosam2_detector import _merge_by_iou
+        from phenotypic.detect.nn._sam2_rle import (
+            encode_uncompressed_rle,
+            merge_rle_records_by_iou,
+        )
+
+        rng = np.random.default_rng(11)
+        masks = [rng.random((10, 14)) > 0.75 for _ in range(8)]
+        bool_kept = _merge_by_iou(masks, 0.2)
+        records = [
+            {
+                "segmentation": encode_uncompressed_rle(mask),
+                "area": int(mask.sum()),
+                "identity": id(mask),
+            }
+            for mask in masks
+        ]
+        rle_kept = merge_rle_records_by_iou(records, 0.2)
+        assert [record["identity"] for record in rle_kept] == [
+            id(mask) for mask in bool_kept
+        ]
+
+    def test_rle_path_preserves_pooling_scores_order_and_final_map(self):
+        from phenotypic.detect.nn import _dino_support
+        from phenotypic.detect.nn._dinosam2_detector import (
+            _assemble_objmap,
+            _assemble_rle_objmap,
+            _score_by_prototype,
+        )
+        from phenotypic.detect.nn._sam2_rle import (
+            decode_uncompressed_rle,
+            encode_uncompressed_rle,
+        )
+        from phenotypic.detect.nn._tiling import _Tile
+
+        shape = (12, 15)
+        outer = np.zeros(shape, bool)
+        outer[1:10, 1:13] = True
+        inner = np.zeros(shape, bool)
+        inner[4:7, 5:9] = True
+        distinct = np.zeros(shape, bool)
+        distinct[9:11, 12:15] = True
+        masks = [inner, outer, distinct]
+        predicted_ious = [0.9, 0.95, 0.2]
+        yy, xx = np.indices(shape)
+        dense = np.stack((yy + 1, xx + 1, yy + xx + 1), axis=-1).astype(
+            np.float32
+        )
+        tiles = [_Tile(0, 0, *shape)]
+
+        bool_features = np.stack(
+            [
+                _dino_support.pool_prototype_tiled([dense], tiles, mask, 1)
+                for mask in masks
+            ]
+        )
+        records = [
+            {
+                "segmentation": encode_uncompressed_rle(mask),
+                "area": int(mask.sum()),
+                "predicted_iou": predicted_iou,
+            }
+            for mask, predicted_iou in zip(masks, predicted_ious)
+        ]
+        rle_features = np.stack(
+            [
+                _dino_support.pool_prototype_tiled(
+                    [dense],
+                    tiles,
+                    decode_uncompressed_rle(record["segmentation"]),
+                    1,
+                )
+                for record in records
+            ]
+        )
+        np.testing.assert_array_equal(rle_features, bool_features)
+
+        detector = DinoSam2Detector()
+        bool_prototype = detector._foreground_prototype(bool_features, records)
+        rle_prototype = detector._foreground_prototype(rle_features, records)
+        bool_scores = _score_by_prototype(bool_features, bool_prototype)
+        rle_scores = _score_by_prototype(rle_features, rle_prototype)
+        np.testing.assert_array_equal(rle_scores, bool_scores)
+
+        expected = _assemble_objmap(masks, bool_scores, 0.0, 0.7)
+        actual = _assemble_rle_objmap(records, rle_scores, 0.0, 0.7, shape)
+        np.testing.assert_array_equal(actual, expected)
 
 
 # ---------------------------------------------------------------------------
@@ -345,6 +482,7 @@ class TestDinoSam2Tiling:
         assert seen["crop_overlap_ratio"] == 0.25
         assert seen["crop_n_points_downscale_factor"] == 2
         assert seen["min_mask_region_area"] == 100
+        assert seen["points_per_batch"] == 8
 
     def test_infer_one_extracts_features_per_tile_not_per_plate(self, monkeypatch):
         """_infer_one must never hand the whole plate to the ViT: on a

--- a/tests/unit/detect/nn/test_sam2_detector.py
+++ b/tests/unit/detect/nn/test_sam2_detector.py
@@ -6,8 +6,12 @@ full ``phenotypic[torch]`` extra is available.
 """
 
 import json
+import sys
+import types
 
+import numpy as np
 import pytest
+from pydantic import ValidationError
 
 from phenotypic import ImagePipeline
 from phenotypic.abc_ import GpuDetector, ObjectDetector
@@ -26,6 +30,7 @@ class TestSam2DetectorConstruction:
         det = Sam2Detector()
         assert det.model_size == "tiny"
         assert det.points_per_side == 32
+        assert det.points_per_batch == 8
         assert det.pred_iou_thresh == 0.7
         assert det.stability_score_thresh == 0.92
         assert det.min_mask_region_area == 100
@@ -78,6 +83,10 @@ class TestSam2DetectorConstruction:
         det = Sam2Detector()
         assert det._generator is None
 
+    def test_points_per_batch_must_be_positive(self):
+        with pytest.raises(ValidationError):
+            Sam2Detector(points_per_batch=0)
+
     def test_all_model_sizes_accepted(self):
         for size in ("tiny", "small", "base_plus", "large"):
             det = Sam2Detector(model_size=size)
@@ -119,6 +128,7 @@ class TestSam2DetectorSerialization:
         original = Sam2Detector(
             model_size="small",
             points_per_side=48,
+            points_per_batch=4,
             pred_iou_thresh=0.8,
             stability_score_thresh=0.95,
             min_mask_region_area=200,
@@ -134,6 +144,7 @@ class TestSam2DetectorSerialization:
         assert isinstance(restored, Sam2Detector)
         assert restored.model_size == "small"
         assert restored.points_per_side == 48
+        assert restored.points_per_batch == 4
         assert restored.pred_iou_thresh == 0.8
         assert restored.stability_score_thresh == 0.95
         assert restored.min_mask_region_area == 200
@@ -161,6 +172,20 @@ class TestSam2DetectorSerialization:
         restored_det = list(restored._ops.values())[0]
         assert isinstance(restored_det, Sam2Detector)
         assert restored_det.model_size == "tiny"
+        assert restored_det.points_per_batch == 8
+
+    def test_old_pipeline_payload_defaults_points_per_batch(self):
+        config = json.loads(ImagePipeline(ops=[Sam2Detector()]).to_json())
+        sam2_config = next(
+            value
+            for value in config["pipe_cfgs"].values()
+            if value["class"] == "Sam2Detector"
+        )
+        sam2_config["params"].pop("points_per_batch")
+
+        restored = ImagePipeline.from_json(json.dumps(config))
+
+        assert list(restored._ops.values())[0].points_per_batch == 8
 
     def test_json_structure(self):
         """Verify the serialised JSON has the expected structure."""
@@ -268,6 +293,146 @@ class TestSam2CropPyramid:
         sig = inspect.signature(build_sam2_generator)
         assert "box_nms_thresh" in sig.parameters
         assert sig.parameters["box_nms_thresh"].default == 0.7
+
+
+class TestSam2RleStreaming:
+    def test_builder_forwards_batch_size_and_internal_rle_mode(
+        self, monkeypatch
+    ):
+        from phenotypic.detect.nn._sam2_detector import build_sam2_generator
+
+        seen: dict = {}
+
+        class FakeGenerator:
+            def __init__(self, model, **kwargs):
+                seen.update(kwargs)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "sam2.automatic_mask_generator",
+            types.SimpleNamespace(SAM2AutomaticMaskGenerator=FakeGenerator),
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "sam2.build_sam",
+            types.SimpleNamespace(build_sam2=lambda *a, **k: object()),
+        )
+        build_sam2_generator(
+            "tiny",
+            device="cpu",
+            points_per_batch=3,
+            checkpoint="/fake/checkpoint.pt",
+            config="fake.yaml",
+        )
+        assert seen["points_per_batch"] == 3
+        assert seen["output_mode"] == "uncompressed_rle"
+
+    @pytest.mark.parametrize(
+        "mask",
+        [
+            np.zeros((3, 5), dtype=bool),
+            np.ones((3, 5), dtype=bool),
+            np.indices((4, 7)).sum(axis=0) % 2 == 0,
+        ],
+    )
+    def test_fortran_rle_round_trip(self, mask):
+        from phenotypic.detect.nn._sam2_rle import (
+            decode_uncompressed_rle,
+            encode_uncompressed_rle,
+        )
+
+        rle = encode_uncompressed_rle(mask)
+        np.testing.assert_array_equal(decode_uncompressed_rle(rle), mask)
+
+    def test_rle_iou_matches_boolean_iou_randomized(self):
+        from phenotypic.detect.nn._sam2_rle import (
+            encode_uncompressed_rle,
+            rle_iou,
+        )
+
+        rng = np.random.default_rng(7)
+        for _ in range(30):
+            a = rng.random((9, 13)) > 0.7
+            b = rng.random((9, 13)) > 0.7
+            union = int((a | b).sum())
+            expected = int((a & b).sum()) / union if union else 0.0
+            assert rle_iou(
+                encode_uncompressed_rle(a), encode_uncompressed_rle(b)
+            ) == expected
+
+    def test_streamed_objmap_matches_binary_mask_ordering(self):
+        from phenotypic.detect.nn._sam2_rle import (
+            encode_uncompressed_rle,
+            paint_rle_records,
+        )
+
+        large = np.zeros((8, 11), bool)
+        large[1:7, 1:10] = True
+        small = np.zeros((8, 11), bool)
+        small[3:5, 4:7] = True
+        equal = np.zeros((8, 11), bool)
+        equal[:2, :3] = True
+        binary = [
+            {"segmentation": small, "area": int(small.sum())},
+            {"segmentation": equal, "area": int(equal.sum())},
+            {"segmentation": large, "area": int(large.sum())},
+        ]
+        expected = np.zeros(large.shape, dtype=np.uint16)
+        for label, record in enumerate(
+            sorted(binary, key=lambda item: item["area"], reverse=True), start=1
+        ):
+            expected[record["segmentation"]] = label
+        rle_records = [
+            {
+                "segmentation": encode_uncompressed_rle(record["segmentation"]),
+                "area": record["area"],
+            }
+            for record in binary
+        ]
+        actual = paint_rle_records(
+            rle_records,
+            large.shape,
+            detector_name="SAM2",
+            truncate_before_sort=True,
+        )
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_uint16_cap_occurs_before_area_sort(self, monkeypatch):
+        from types import SimpleNamespace
+
+        from phenotypic.detect.nn._sam2_rle import (
+            encode_uncompressed_rle,
+            paint_rle_records,
+        )
+
+        masks = []
+        for column in range(3):
+            mask = np.zeros((1, 3), dtype=bool)
+            mask[0, column] = True
+            masks.append(mask)
+        records = [
+            {"segmentation": encode_uncompressed_rle(masks[0]), "area": 1},
+            {"segmentation": encode_uncompressed_rle(masks[1]), "area": 1},
+            # A later, larger record must be discarded before sorting.
+            {"segmentation": encode_uncompressed_rle(masks[2]), "area": 100},
+        ]
+        monkeypatch.setattr(np, "iinfo", lambda _dtype: SimpleNamespace(max=2))
+
+        with pytest.warns(UserWarning, match="exceeding uint16"):
+            actual = paint_rle_records(
+                records,
+                (1, 3),
+                detector_name="SAM2",
+                truncate_before_sort=True,
+            )
+
+        np.testing.assert_array_equal(actual, np.array([[1, 2, 0]], np.uint16))
+
+    def test_malformed_rle_is_rejected(self):
+        from phenotypic.detect.nn._sam2_rle import validate_uncompressed_rle
+
+        with pytest.raises(ValueError, match="cover exactly"):
+            validate_uncompressed_rle({"size": [2, 3], "counts": [2, 3]})
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -3986,7 +3986,7 @@ requires-dist = [
     { name = "rawpy", marker = "sys_platform != 'win32'" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "ruptures", specifier = ">=1.1.9" },
-    { name = "sam2", marker = "sys_platform != 'win32' and extra == 'torch'" },
+    { name = "sam2", marker = "sys_platform != 'win32' and extra == 'torch'", specifier = ">=1.1.0" },
     { name = "scikit-image" },
     { name = "scikit-learn" },
     { name = "scipy" },


### PR DESCRIPTION
## Summary

- bound uint16/float GPU preprocessing allocations with row-chunked conversion
- add serialized, non-tunable `points_per_batch=8` controls to SAM2 and DinoSAM2
- stream lossless uncompressed Fortran-order RLE through proposal assembly, exact IoU, DINO pooling, and object-map painting
- require `sam2>=1.1.0` and document memory-safe tuning guidance
- add independent numeric memory-invariant and accuracy gates

## Why

The Maresca notebook processes a 6016 x 4012 uint16 RGB plate and previously exhausted laptop memory when high-resolution SAM2 crop-pyramid detection was enabled. The main causes were large conversion temporaries, large prompt decoder batches, and retaining full-frame Boolean masks for every proposal.

This change preserves the 32 x 32 prompt grid, `crop_n_layers=1`, overlap, thresholds, and resolution-preferring NMS while bounding those allocations.

## Accuracy and compatibility

The labeled non-full-range uint16 fixture found that `image_max` remains the better default:

- `image_max`: foreground IoU 0.8709, 1079 objects
- `dtype_range`: foreground IoU 0.8626, 1051 objects
- truth: 1152 objects

Both policies remain available and use the same bounded converter.

The 64-point and 8-point prompt batches produced exact foreground masks, object counts, and canonically relabeled object maps. The 8-point run took 66.3 seconds versus 74.0 seconds for 64 points on the fixture.

## Memory profile

The cropped Maresca plate (5086 x 3002 uint16 RGB) completed with:

- `crop_n_layers=1`
- `points_per_side=32`
- `points_per_batch=8`
- 118.3 seconds SAM2 runtime
- 3.38 GB maximum process RSS
- no OOM

The private SAM2 predictor adapter is therefore not included.

## Validation

- 82 related tests passed, 5 weight-backed functional tests deselected
- 11 focused RLE tests passed
- touched-file Ruff passed
- changed-source Mypy passed
- numeric memory invariants passed
- independent implementation review, simplification pass, and final re-review completed cleanly

The full repository suite was intentionally not required because it is very heavy. A partial run reached 1828 passes before being stopped.
