### PR TITLE
Fix Windows nightly CI regressions

### DIFF
--- a/tests/unit/cli/test_cli_progress_dashboard.py
+++ b/tests/unit/cli/test_cli_progress_dashboard.py
@@ -644,9 +644,9 @@ class TestSentinelScript:
         # Uses the same Python path as array job scripts, not bare "python"
         assert "-m phenotypic._cli._cli_sentinel" in content
         log_path = logs_dir(tmp_dir) / "slurm" / "sentinel_%j.log"
-        assert f"#SBATCH --output={log_path}" in content
-        assert f"#SBATCH --error={log_path}" in content
-        assert str(progress_dir / "sentinel_%j.log") not in content
+        assert f"#SBATCH --output={log_path.as_posix()}" in content
+        assert f"#SBATCH --error={log_path.as_posix()}" in content
+        assert (progress_dir / "sentinel_%j.log").as_posix() not in content
 
     def test_time_derived_from_max_runtime(self, tmp_dir):
         script = generate_sentinel_script(

--- a/tests/unit/cli/test_slurm_process_only_scripts.py
+++ b/tests/unit/cli/test_slurm_process_only_scripts.py
@@ -34,7 +34,7 @@ def test_array_script_threads_process_only_and_omits_aggregation(
     dataset = datasets[0]
     assert all(path.is_relative_to(slurm_scripts_dir(out)) for path in script_paths)
     expected_log = logs_dir(out) / "slurm" / dataset.name / f"{dataset.name}_%A_%a.log"
-    assert str(expected_log) in blob
+    assert expected_log.as_posix() in blob
 
     # The per-image command is line-broken with ``\`` continuations, so the
     # flag and its value land on separate lines — assert each token is threaded

--- a/tests/unit/detect/nn/test_dino_support.py
+++ b/tests/unit/detect/nn/test_dino_support.py
@@ -5,8 +5,13 @@ register-token grid-reshape fix and the prototype-pool + cosine-match core that
 ``Insid3Detector`` and ``FssDinoDetector`` build on.
 """
 
+import importlib.util
+
 import numpy as np
 import pytest
+
+
+_TORCH_AVAILABLE = importlib.util.find_spec("torch") is not None
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +228,7 @@ class TestPatchGeometry:
         }
 
 
+@pytest.mark.skipif(not _TORCH_AVAILABLE, reason="Requires torch")
 class TestProcessorPolicy:
     """The extract_* fns must never let the checkpoint's classification preset
     (224 center-crop) decide the input size."""

--- a/tests/unit/enhance/test_monogenic_kernels.py
+++ b/tests/unit/enhance/test_monogenic_kernels.py
@@ -767,7 +767,9 @@ class TestOrientationIsFoldedIntoTheHalfOpenHalfPlane:
 
 
 class TestFeatureTypeUsesTheReferenceRadicand:
-    def test_it_is_sqrt_of_the_sum_of_squares_not_np_hypot(self):
+    def test_it_is_sqrt_of_the_sum_of_squares_not_np_hypot(
+            self, monkeypatch: pytest.MonkeyPatch
+    ):
         """All three references write ``sqrt(h1**2 + h2**2)``. ``hypot`` appears in none.
 
         ``grep -rn hypot`` over Kovesi's Julia, Kovesi's MATLAB and ``phasepack`` returns
@@ -781,19 +783,22 @@ class TestFeatureTypeUsesTheReferenceRadicand:
         agreement of ``6.7e-13``, which is 6.7 orders of slack.
 
         Pinned here by reconstructing ``feature_type`` from the primitives and requiring
-        bit-equality with the ``sqrt`` form and inequality with the ``hypot`` form.
+        bit-equality with the ``sqrt`` form. ``np.hypot`` is patched to raise, so the exact
+        source mutant fails even on platforms where the two forms round identically.
         """
         rng = np.random.default_rng(11)
         img = rng.normal(size=(64, 64))
-        result = monogenic_phase_congruency(img)
 
         sum_even, sum_h1, sum_h2 = _sum_monogenic_channels(img)
         faithful = np.arctan2(sum_even, np.sqrt(sum_h1 ** 2 + sum_h2 ** 2))
-        hypot_form = np.arctan2(sum_even, np.hypot(sum_h1, sum_h2))
+
+        def reject_hypot(*args, **kwargs):
+            raise AssertionError("np.hypot must not replace the reference radicand")
+
+        monkeypatch.setattr(np, "hypot", reject_hypot)
+        result = monogenic_phase_congruency(img)
 
         assert np.array_equal(result.feature_type, faithful)
-        # And the two really are distinguishable, so the assertion above is not vacuous.
-        assert not np.array_equal(faithful, hypot_form)
 
 
 class TestAcosClampIsInert:


### PR DESCRIPTION
## Summary

Fix the six recurring failures in the Windows Python 3.12 nightly test job without changing production behavior.

## Root causes and changes

- Compare generated SLURM log paths using POSIX serialization, matching the bash renderer instead of Windows-native backslashes.
- Skip the three processor-policy tests when `torch` is unavailable, matching the existing Windows dependency policy and repository test convention.
- Replace the platform-sensitive `sqrt` versus `hypot` numerical inequality with a deterministic mutation guard that fails if `np.hypot` is called while retaining bit-exact comparison with the `sqrt` result.

## Validation

- `uv run ruff check --fix` on the four changed test files
- Six formerly failing test nodes: 6 passed
- Four affected test modules with nightly pytest options: 179 passed
- In-memory `sqrt` to `hypot` mutation check: mutant killed
- Independent code review: no actionable findings

No production code, dependency declarations, public APIs, fixtures, or documentation changed.
