### PR TITLE
Fix staged GPU deliverables and SLURM finalization

### DIFF
--- a/docs/superpowers/specs/2026-06-11-centered-auto-grid-finder-design.md
+++ b/docs/superpowers/specs/2026-06-11-centered-auto-grid-finder-design.md
@@ -215,7 +215,11 @@ self-consistent but high-residual fit (~450× higher in the challenger's
 experiment), so the correct registration wins cleanly. This multi-start is what
 defeats the one-cell-shift trap: there is no reliable in-place "escape" once ICP
 locks onto a shifted lattice, so we instead *start* from every plausible placement
-and let the residual choose.
+and let the residual choose. Before residual selection, discard any refined
+placement whose clipped row or column edges are non-finite or not strictly
+increasing. This feasibility check removes whole-pitch registrations that would
+collapse an outer cell at the frame boundary. Among residual ties within the
+sub-pixel tolerance, explicitly prefer the fitted center nearest the image center.
 
 Each refinement iterates (`max_iter`, default ~5):
 
@@ -251,8 +255,13 @@ exceeds `residual_fraction · p`, escalate to the fallback ladder §6 (warn).
 
 Cell centers → edges as the **midlines between adjacent centers**, with outer
 edges extrapolated by `± p/2`, producing `R+1` row edges and `C+1` col edges,
-clipped to image bounds. `_operate` then calls `_get_grid_info(...)` for faithful,
-many-to-one assignment (no collision handling).
+clipped to image bounds. One outer edge may clip while leaving a valid partial
+edge cell. Two or more edges clipping to the same boundary is invalid because it
+creates a zero-width cell. The finder enforces finite, bounded, strictly increasing
+edges before `_operate` calls `_get_grid_info(...)` for faithful, many-to-one
+assignment (no collision handling). Column feasibility uses the assignment layer's
+effective upper bound `W - 1`, so its final clipping step cannot collapse a
+sub-pixel partial cell that looked valid against `W`.
 
 ---
 
@@ -269,6 +278,7 @@ Evaluated top-down; first matching rule applies. Every fallback emits a
 | `p_min ≥ p_max` | Contradiction (object span exceeds what the frame can hold at the expected count → likely a detection outlier or wrong `R/C`). Clamp: drop to image-fit pitch `p = p_max`, center at image center, warn loudly. |
 | degenerate comb-response (`R_peak < absolute_floor`) | No periodicity detectable; fall back to uniform centered grid at the span-derived `p_min` (object floor), warn. |
 | ICP failed (best multi-start residual `> residual_fraction·p`, **or** every candidate tripped the singularity guard) | Use the comb-response `p` (if it cleared the floor) with center = image center as a uniform grid; else uniform centered grid at `p_min`. Warn. |
+| Every refined registration has invalid edge geometry | Reject the registrations and use the bounded comb-response `p` with center = image center. Warn with the `invalid-geometry` reason. |
 
 The floor is **2 colonies** for any *inferred* pitch; `N ∈ {0,1}` only guarantees a
 non-crashing centered default.
@@ -370,6 +380,9 @@ recovered `p, cx, cy` within tolerance across:
 - clustered-corner occupancy (octave stress);
 - **off-center plate** (true center offset > one pitch from image center):
   multi-start recovers the correct registration (regression for challenger #5);
+- **boundary-collapse registration**: a lower-residual whole-pitch placement that
+  clips two edges to one boundary is rejected in favor of the feasible placement;
+- **single clipped outer edge**: remains valid and does not trigger recentering;
 - **one-cell-shifted seed**: assert multi-start selects the correct placement, not
   the shifted local minimum (regression for challenger #2);
 - 2-colony floor (assert bounded, non-crashing, within `[p_min,p_max]`);

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -1205,11 +1205,14 @@ def aggregate_measurements(
 
     if scratch_dir is not None and master_df is not None:
         staged_to_original = {
-            str(scratch_dir / _scratch_dest_name(original)): str(original)
+            str(scratch_dir / _scratch_dest_name(original)).replace(
+                "\\", "/"
+            ): str(original)
             for original in path_to_dataset
         }
         master_df = master_df.with_columns(
             pl.col(SOURCE_PATH_COLUMN)
+            .str.replace_all(r"\\", "/")
             .replace_strict(
                 staged_to_original,
                 default=pl.col(SOURCE_PATH_COLUMN),

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -40,7 +40,7 @@ from ._measurement_sources import (
     discover_measurement_sources,
     measurement_sources_by_path,
 )
-from ._cli_parquet_agg import aggregate_parquet_files
+from ._cli_parquet_agg import SOURCE_PATH_COLUMN, aggregate_parquet_files
 from phenotypic.schema import EXPERIMENT_METADATA, METADATA, METADATA_MATCH
 from phenotypic.util import split_measurements
 from phenotypic.sdk_ import (
@@ -1202,6 +1202,20 @@ def aggregate_measurements(
         include_dataset_column=include_dataset_column,
         keep_filename=True,
     )
+
+    if scratch_dir is not None and master_df is not None:
+        staged_to_original = {
+            str(scratch_dir / _scratch_dest_name(original)): str(original)
+            for original in path_to_dataset
+        }
+        master_df = master_df.with_columns(
+            pl.col(SOURCE_PATH_COLUMN)
+            .replace_strict(
+                staged_to_original,
+                default=pl.col(SOURCE_PATH_COLUMN),
+            )
+            .alias(SOURCE_PATH_COLUMN)
+        )
 
     if scratch_dir is not None:
         _cleanup_scratch(scratch_dir)

--- a/src/phenotypic/_cli/_cli_staged_orchestration.py
+++ b/src/phenotypic/_cli/_cli_staged_orchestration.py
@@ -498,7 +498,7 @@ def _job_from_scheduler_comment(comment: str) -> str | None:
 def _mirror_job_to_metadata(
     output_dir: Path, *, token: str, role: str, job_id: str
 ) -> None:
-    """Expose dynamically submitted jobs through existing metadata consumers."""
+    """Expose dynamic jobs without polluting the numeric chunk registry."""
     path = job_metadata_path(output_dir)
     if not path.is_file():
         return
@@ -511,7 +511,7 @@ def _mirror_job_to_metadata(
         all_jobs = payload.setdefault(JobMetadataKey.SLURM_JOB_IDS, {})
         if isinstance(all_jobs, dict):
             all_jobs[token] = job_id
-        if role in {"stage1", "stage2", "stage3"}:
+        if role in {"stage1", "stage2", "stage3"} and token.isdecimal():
             chunks = payload.setdefault(JobMetadataKey.CHUNK_JOB_IDS, {})
             if isinstance(chunks, dict):
                 chunks[token] = job_id

--- a/src/phenotypic/_cli/_cli_staged_slurm.py
+++ b/src/phenotypic/_cli/_cli_staged_slurm.py
@@ -109,6 +109,7 @@ def _stage_worker_body(
     markers_required: bool = True,
     n_shards: int | None = None,
     index_var: str = "$SLURM_ARRAY_TASK_ID",
+    overlay_alpha: float = 0.3,
 ) -> str:
     """The per-array-task command line that invokes the staged SLURM worker.
 
@@ -136,6 +137,8 @@ def _stage_worker_body(
         parts.append("--stage3-markers-required")
     if stage == 2:
         parts.append(f"--n-shards {n_shards}")
+    if stage == 3:
+        parts.append(f"--overlay-alpha {overlay_alpha}")
     return " \\\n    ".join(parts)
 
 
@@ -241,6 +244,7 @@ def generate_staged_scripts(
     epoch: str,
     resume: bool = False,
     markers_required: bool = True,
+    overlay_alpha: float = 0.3,
 ) -> Dict[str, Any]:
     """Write the per-stage SBATCH array scripts (no submission).
 
@@ -288,6 +292,7 @@ def generate_staged_scripts(
             resume,
             markers_required,
             index_var="$CURRENT_TASK_INDEX",
+            overlay_alpha=overlay_alpha,
         )
 
     stage1 = _write_image_stage_chunks(
@@ -500,6 +505,7 @@ class StagedSlurmStrategy(ExecutionStrategy):
             epoch=epoch,
             resume=getattr(cfg, "resume", False),
             markers_required=getattr(cfg, "staged_stage3_markers", True),
+            overlay_alpha=cfg.overlay_alpha,
         )
         _write_staged_job_metadata(
             datasets=datasets,

--- a/src/phenotypic/_cli/_cli_staged_slurm_worker.py
+++ b/src/phenotypic/_cli/_cli_staged_slurm_worker.py
@@ -40,6 +40,7 @@ from ._cli_staged_resume import (
 )
 from ._cli_staged_workers import (
     emit_missing_prereq,
+    ensure_staged_overlay,
     stage1_preprocess_core,
     stage2_detect_core,
     stage3_merge_measure_core,
@@ -229,6 +230,7 @@ def run_stage3_step(
     epoch: str | None = None,
     resume: bool = False,
     markers_required: bool = True,
+    overlay_alpha: float = 0.3,
 ) -> None:
     """Merge one sidecar, measure it, and publish final per-image outputs."""
     item = _entry(manifest[index])
@@ -236,9 +238,24 @@ def run_stage3_step(
         dataset_measurements_dir(output_dir, item.dataset)
         / f"{item.stem}.parquet"
     )
-    if stage3_completion_exists(output_dir, item.dataset, item.stem) or (
+    output_manager = OutputManager.from_config(
+        output_dir,
+        ext,
+        overlay_alpha=overlay_alpha,
+        save_overlays=True,
+    )
+    terminal = stage3_completion_exists(output_dir, item.dataset, item.stem) or (
         resume and not markers_required and parquet.is_file()
-    ):
+    )
+    if terminal:
+        ensure_staged_overlay(
+            output_dir,
+            item.dataset,
+            item.stem,
+            output_manager,
+            image_type,
+            active_check=_active_check(output_dir, epoch),
+        )
         return
     check = _active_check(output_dir, epoch)
     if check is not None:
@@ -254,9 +271,6 @@ def run_stage3_step(
         )
         raise SystemExit(1)
     plan = split_pipeline_at_gpu(ImagePipeline.from_json(pipeline_path))
-    output_manager = OutputManager.from_config(
-        output_dir, ext, save_overlays=False
-    )
     with stage_event(log, item.dataset, item.image_name, STAGE_MEASURE):
         stage3_merge_measure_core(
             plan,
@@ -294,6 +308,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--epoch", required=True)
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--stage3-markers-required", action="store_true")
+    parser.add_argument("--overlay-alpha", type=float, default=0.3)
     args = parser.parse_args(argv)
 
     _preload_custom_op_modules()
@@ -332,6 +347,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             args.index,
             args.ext,
             markers_required=args.stage3_markers_required,
+            overlay_alpha=args.overlay_alpha,
             **common,
         )
     return 0

--- a/src/phenotypic/_cli/_cli_staged_strategy.py
+++ b/src/phenotypic/_cli/_cli_staged_strategy.py
@@ -28,6 +28,7 @@ from ._cli_staged_resume import (
 from ._cli_staged_workers import (
     _image_class,
     emit_missing_prereq,
+    ensure_staged_overlay,
     stage1_preprocess_core,
     stage2_detect_core,
     stage3_merge_measure_core,
@@ -68,13 +69,23 @@ class StagedGpuStrategy(ExecutionStrategy):
                 return process_only_output_path(
                     output_dir, img, cfg.input_path, "objmap"
                 ).is_file()
-            if stage3_completion_exists(output_dir, ds_name, img.stem):
-                return True
-            return bool(
+            terminal = stage3_completion_exists(
+                output_dir, ds_name, img.stem
+            ) or bool(
                 cfg.resume
                 and not cfg.staged_stage3_markers
                 and _parquet_path(ds_name, img.stem).is_file()
             )
+            if terminal:
+                ensure_staged_overlay(
+                    output_dir,
+                    ds_name,
+                    img.stem,
+                    self.output_manager,
+                    cfg.image_type,
+                )
+                return True
+            return False
 
         # ---- Stage 1: CPU preprocess -> staged HDF (parallel, resumable) ----
         def _stage1(ds: Dataset, img: Path) -> None:

--- a/src/phenotypic/_cli/_cli_staged_workers.py
+++ b/src/phenotypic/_cli/_cli_staged_workers.py
@@ -182,6 +182,7 @@ def stage3_merge_measure_core(
     image_cls = _image_class(image_type)
     hdf = dataset_hdf_dir(output_dir, dataset_name) / f"{image_stem}.h5"
     image = image_cls.load_hdf5(hdf)
+    image.name = image_stem
 
     result = load_sidecar(output_dir, dataset_name, image_stem)
     plan.gpu_detector._write_object_output(image, result)

--- a/src/phenotypic/_cli/_cli_staged_workers.py
+++ b/src/phenotypic/_cli/_cli_staged_workers.py
@@ -143,6 +143,31 @@ def stage2_detect_core(
     write_sidecar(output_dir, dataset_name, image_stem, result)
 
 
+def ensure_staged_overlay(
+    output_dir: Path,
+    dataset_name: str,
+    image_stem: str,
+    output_manager: OutputManager,
+    image_type: ImageTypeName,
+    active_check: ActiveCheck | None = None,
+) -> Path | None:
+    """Publish a missing staged-run overlay from the completed image HDF."""
+    if not output_manager.save_overlays:
+        return None
+    overlay_path = output_manager.get_output_path(
+        dataset_name, "overlays", image_stem
+    )
+    if overlay_path.is_file():
+        return overlay_path
+
+    _check_active(active_check)
+    hdf = dataset_hdf_dir(output_dir, dataset_name) / f"{image_stem}.h5"
+    image = _image_class(image_type).load_hdf5(hdf)
+    overlay_path.parent.mkdir(parents=True, exist_ok=True)
+    _check_active(active_check)
+    return output_manager.save_overlay(image, dataset_name, image_stem)
+
+
 def stage3_merge_measure_core(
     plan: StagePlan,
     output_dir: Path,
@@ -177,6 +202,9 @@ def stage3_merge_measure_core(
         raise RuntimeError(
             f"Stage 3 HDF publication failed for {dataset_name}/{image_stem}"
         )
+    if output_manager.save_overlays:
+        _check_active(active_check)
+        output_manager.save_overlay(image, dataset_name, image_stem)
     from phenotypic.plotting import PlotCoordinator
 
     _check_active(active_check)

--- a/src/phenotypic/_cli/_dashboard/_manifest_builder.py
+++ b/src/phenotypic/_cli/_dashboard/_manifest_builder.py
@@ -228,12 +228,15 @@ def query_sacct_chunk_states(
     active: List[int] = []
     completed: List[int] = []
     pending: List[int] = []
+    numeric_chunk_job_ids = {
+        key: job_id for key, job_id in chunk_job_ids.items() if key.isdecimal()
+    }
 
     # Separate cached (terminal) jobs from those needing a fresh query.
     uncached_job_ids: Dict[str, str] = {}
     cached_results: Dict[str, Dict[str, str]] = {}
 
-    for chunk_idx_str, job_id in chunk_job_ids.items():
+    for chunk_idx_str, job_id in numeric_chunk_job_ids.items():
         if job_id in _terminal_job_cache:
             cached_results[job_id] = _terminal_job_cache[job_id]
         else:
@@ -262,7 +265,7 @@ def query_sacct_chunk_states(
         **cached_results,
     }
 
-    for chunk_idx_str, job_id in chunk_job_ids.items():
+    for chunk_idx_str, job_id in numeric_chunk_job_ids.items():
         chunk_idx = int(chunk_idx_str)
         task_states = all_results.get(job_id)
 
@@ -492,11 +495,16 @@ def build_manifest(
 
     # 3-4. SLURM-specific queries.
     is_slurm = execution_mode == "slurm"
+    numeric_slurm_job_ids = {
+        key: job_id
+        for key, job_id in (slurm_job_ids or {}).items()
+        if key.isdecimal()
+    }
     active_chunks: List[int] = []
     completed_chunks: List[int] = []
     pending_chunks: List[int] = []
 
-    if is_slurm and slurm_job_ids:
+    if is_slurm and numeric_slurm_job_ids:
         # Early exit: skip sacct entirely when event log already shows all
         # images have reached a terminal state (completed or failed).
         total_images_for_check = sum(datasets.values())
@@ -505,10 +513,10 @@ def build_manifest(
         )
         event_failed = sum(len(ds.failed) for ds in dataset_states.values())
         if (event_completed + event_failed) >= total_images_for_check:
-            completed_chunks = sorted(int(k) for k in slurm_job_ids)
+            completed_chunks = sorted(int(k) for k in numeric_slurm_job_ids)
         else:
             active_chunks, completed_chunks, pending_chunks = (
-                query_sacct_chunk_states(slurm_job_ids)
+                query_sacct_chunk_states(numeric_slurm_job_ids)
             )
 
         # Detect OOM / silent failures (needs image_task_mapping -- build
@@ -589,10 +597,10 @@ def build_manifest(
     if is_slurm:
         manifest[DashboardManifestKey.SLURM_INFO] = {
             DashboardManifestSlurmInfoKey.CHUNK_SCRIPTS: chunk_scripts or [],
-            DashboardManifestSlurmInfoKey.TOTAL_CHUNKS: len(slurm_job_ids)
-            if slurm_job_ids
+            DashboardManifestSlurmInfoKey.TOTAL_CHUNKS: len(numeric_slurm_job_ids)
+            if numeric_slurm_job_ids
             else 0,
-            DashboardManifestSlurmInfoKey.CHUNK_JOB_IDS: slurm_job_ids or {},
+            DashboardManifestSlurmInfoKey.CHUNK_JOB_IDS: numeric_slurm_job_ids,
             DashboardManifestSlurmInfoKey.ACTIVE_CHUNKS: active_chunks,
             DashboardManifestSlurmInfoKey.COMPLETED_CHUNKS: completed_chunks,
             DashboardManifestSlurmInfoKey.PENDING_CHUNKS: pending_chunks,

--- a/src/phenotypic/_cli/_measurement_sources.py
+++ b/src/phenotypic/_cli/_measurement_sources.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 from pathlib import Path
 from typing import Iterable
 
@@ -14,6 +15,14 @@ from phenotypic.sdk_ import (
     DIR_RESULTS,
 )
 
+logger = logging.getLogger(__name__)
+
+_UUID_PATTERN = (
+    r"(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+    r"[0-9a-f]{4}-[0-9a-f]{12}$"
+)
+_DATASET_AGGREGATED_STEM = Path(DATASET_AGGREGATED_PARQUET).stem
+
 
 @dataclass(frozen=True)
 class MeasurementSource:
@@ -21,6 +30,33 @@ class MeasurementSource:
 
     path: Path
     dataset: str
+
+
+def _aggregate_needs_image_name_recovery(path: Path) -> bool:
+    """Return whether an aggregate cannot supply valid per-image identities."""
+    image_name_col = str(METADATA.IMAGE_NAME)
+    try:
+        aggregate = pl.scan_parquet(path)
+        if image_name_col not in aggregate.collect_schema():
+            return True
+        uuid_found = (
+            aggregate.select(
+                pl.col(image_name_col)
+                .cast(pl.String, strict=False)
+                .str.contains(_UUID_PATTERN)
+                .any()
+            )
+            .collect()
+            .item()
+        )
+    except Exception:
+        logger.debug(
+            "Could not inspect aggregate image identities in %s",
+            path,
+            exc_info=True,
+        )
+        return False
+    return bool(uuid_found)
 
 
 def discover_measurement_sources(
@@ -36,7 +72,8 @@ def discover_measurement_sources(
 
     Returns:
         Ordered measurement sources. Per dataset, ``_dataset_aggregated.parquet``
-        is preferred over individual non-internal parquet files.
+        is preferred over individual non-internal parquet files unless its
+        image identities need recovery from those individual filenames.
     """
     results_dir = output_dir / DIR_RESULTS
     if not results_dir.is_dir():
@@ -54,15 +91,37 @@ def discover_measurement_sources(
         if not meas_dir.is_dir():
             continue
 
+        individual_paths = [
+            path
+            for path in sorted(meas_dir.glob("*.parquet"))
+            if not path.name.startswith("_")
+        ]
         aggregated = meas_dir / DATASET_AGGREGATED_PARQUET
+        aggregate_needs_recovery = (
+            aggregated.exists()
+            and _aggregate_needs_image_name_recovery(aggregated)
+        )
         if aggregated.exists():
-            sources.append(MeasurementSource(aggregated, dataset_name))
-            continue
+            if aggregate_needs_recovery and individual_paths:
+                logger.warning(
+                    "Aggregate %s has missing or UUID image identities; "
+                    "using individual measurement parquets for recovery",
+                    aggregated,
+                )
+            else:
+                if aggregate_needs_recovery:
+                    logger.warning(
+                        "Aggregate %s has missing or UUID image identities, "
+                        "but no individual measurement parquets remain for "
+                        "recovery",
+                        aggregated,
+                    )
+                sources.append(MeasurementSource(aggregated, dataset_name))
+                continue
 
         sources.extend(
             MeasurementSource(path, dataset_name)
-            for path in sorted(meas_dir.glob("*.parquet"))
-            if not path.name.startswith("_")
+            for path in individual_paths
         )
     return sources
 
@@ -75,23 +134,42 @@ def measurement_sources_by_path(
 
 
 def add_metadata_image_name_from_filename(frame: pl.DataFrame) -> pl.DataFrame:
-    """Derive ``Metadata_ImageName`` from ``filename`` and drop ``filename``.
+    """Derive or repair ``Metadata_ImageName`` from ``filename``.
 
     Args:
         frame: Aggregated measurement frame. ``filename`` is produced by
             ``aggregate_parquet_files(..., keep_filename=True)``.
 
     Returns:
-        Frame with no ``filename`` column. If ``Metadata_ImageName`` already
-        exists, it is preserved.
+        Frame with no ``filename`` column. Existing non-UUID image names are
+        preserved; UUID-shaped values from pre-fix staged HDF reloads are
+        replaced with an individual parquet's filename stem.
     """
     image_name_col = str(METADATA.IMAGE_NAME)
-    if image_name_col not in frame.columns and "filename" in frame.columns:
-        frame = frame.with_columns(
-            pl.col("filename")
-            .str.extract(r"([^/\\]+)\.[^.]+$", 1)
-            .alias(image_name_col)
+    if "filename" in frame.columns:
+        filename_stem = pl.col("filename").str.extract(
+            r"([^/\\]+)\.[^.]+$", 1
         )
+        is_individual_source = filename_stem != _DATASET_AGGREGATED_STEM
+        if image_name_col not in frame.columns:
+            frame = frame.with_columns(
+                pl.when(is_individual_source)
+                .then(filename_stem)
+                .otherwise(None)
+                .alias(image_name_col)
+            )
+        else:
+            frame = frame.with_columns(
+                pl.when(
+                    is_individual_source
+                    & pl.col(image_name_col)
+                    .cast(pl.String, strict=False)
+                    .str.contains(_UUID_PATTERN)
+                )
+                .then(filename_stem)
+                .otherwise(pl.col(image_name_col))
+                .alias(image_name_col)
+            )
     if "filename" in frame.columns:
         frame = frame.drop("filename")
     return frame

--- a/src/phenotypic/_core/_image_parts/_image_io_handler.py
+++ b/src/phenotypic/_core/_image_parts/_image_io_handler.py
@@ -927,7 +927,9 @@ class ImageIOHandler(ImageColorSpace):
                 attrs = meta[name].attrs
                 # setdefault-style merge: caller kwargs (e.g. bit_depth) have
                 # already populated matching protected-metadata keys via the
-                # Image constructor, so we must not clobber them here.
+                # Image constructor, so we must not clobber non-None values here.
+                # Constructor placeholders such as ImageName=None must be restored
+                # from the file or Image.name falls back to a fresh UUID.
                 # public/imported are effectively fresh dicts at construction,
                 # so the same logic is a no-op for them but keeps behaviour
                 # uniform across sections.
@@ -937,7 +939,7 @@ class ImageIOHandler(ImageColorSpace):
                     # constructor-populated "MetadataImage_ImageName" and is skipped
                     # rather than added as a stale duplicate.
                     mapped = _remap_legacy_metadata_key(key)
-                    if mapped in target:
+                    if mapped in target and target[mapped] is not None:
                         continue
                     target[mapped] = _decode_meta(attrs[key])
 

--- a/src/phenotypic/grid/_centered_auto_grid_finder.py
+++ b/src/phenotypic/grid/_centered_auto_grid_finder.py
@@ -51,7 +51,9 @@ class CenteredAutoGridFinder(GridFinder):
         nrows/ncols must match the physical plate; a mismatch produces a wrong
         grid silently (no internal guard). For multiple colonies per well use a
         downstream refiner (KeepNearestCenter / KeepSectionLargest /
-        MergeWithinSection); this finder assigns faithfully, many-to-one.
+        MergeWithinSection); this finder assigns faithfully, many-to-one. A fitted
+        grid may have one outer edge clipped to the image boundary, but placements
+        that would collapse an entire cell are rejected before assignment.
 
     Examples:
         Default 96-well fit on the bundled synthetic plate:
@@ -154,12 +156,49 @@ class CenteredAutoGridFinder(GridFinder):
                 cands.append(float(c))
         return sorted(cands, key=lambda c: abs(c - img_c))
 
-    def _icp_refine(self, x: np.ndarray, y: np.ndarray,
-                    cx: float, cy: float, p: float):
+    @staticmethod
+    def _bounded_solution(
+            solution: np.ndarray,
+            x: np.ndarray,
+            y: np.ndarray,
+            a: np.ndarray,
+            b: np.ndarray,
+            p_min: float,
+            p_max: float,
+    ) -> tuple[float, float, float] | None:
+        """Apply pitch bounds to a lattice solve and re-optimize its center."""
+        cx, cy, p = (float(value) for value in solution)
+        if not np.all(np.isfinite([cx, cy, p])):
+            return None
+
+        bounded_p = float(np.clip(p, p_min, p_max))
+        if bounded_p != p:
+            cx = float(np.mean(x - a * bounded_p))
+            cy = float(np.mean(y - b * bounded_p))
+        return cx, cy, bounded_p
+
+    def _icp_refine(
+            self,
+            x: np.ndarray,
+            y: np.ndarray,
+            cx: float,
+            cy: float,
+            p: float,
+            p_min: float,
+            p_max: float,
+    ) -> tuple[float, float, float, float] | None:
         """Closed-form assign->solve ICP from one seed. Returns (cx,cy,p,mean_residual)
-        or None if the design matrix is singular (cannot constrain pitch)."""
+        or None if the design matrix is singular (cannot constrain pitch).
+
+        The fitted pitch is constrained to ``[p_min, p_max]`` after every solve.
+        When a bound is active, the grid center is re-optimized for that fixed pitch.
+        """
+        if not (np.isfinite(p_min) and np.isfinite(p_max) and 0 < p_min <= p_max):
+            return None
+
         R, C, N = self.nrows, self.ncols, len(x)
         a = b = None
+        p = float(np.clip(p, p_min, p_max))
         for _ in range(self.max_iter):
             jx = np.clip(np.round((x - cx) / p + (C - 1) / 2.0), 0, C - 1)
             iy = np.clip(np.round((y - cy) / p + (R - 1) / 2.0), 0, R - 1)
@@ -171,7 +210,12 @@ class CenteredAutoGridFinder(GridFinder):
             if abs(np.linalg.det(A)) < self.DET_EPS:
                 return None
             rhs = np.array([x.sum(), y.sum(), (a * x + b * y).sum()])
-            cx, cy, p = np.linalg.solve(A, rhs)
+            bounded = self._bounded_solution(
+                np.linalg.solve(A, rhs), x, y, a, b, p_min, p_max
+            )
+            if bounded is None:
+                return None
+            cx, cy, p = bounded
             # one-pass robust trim then re-solve on inliers
             res = np.hypot(x - (cx + a * p), y - (cy + b * p))
             inl = res <= self.residual_fraction * p
@@ -181,41 +225,114 @@ class CenteredAutoGridFinder(GridFinder):
                                [0.0, ni, bi.sum()],
                                [ai.sum(), bi.sum(), (ai * ai + bi * bi).sum()]])
                 if abs(np.linalg.det(A2)) >= self.DET_EPS:
-                    cx, cy, p = np.linalg.solve(A2, np.array([xi.sum(), yi.sum(),
-                                                              (ai * xi + bi * yi).sum()]))
+                    bounded = self._bounded_solution(
+                        np.linalg.solve(
+                            A2,
+                            np.array([
+                                xi.sum(),
+                                yi.sum(),
+                                (ai * xi + bi * yi).sum(),
+                            ]),
+                        ),
+                        xi,
+                        yi,
+                        ai,
+                        bi,
+                        p_min,
+                        p_max,
+                    )
+                    if bounded is None:
+                        return None
+                    cx, cy, p = bounded
         if a is None or b is None:
             # max_iter <= 0: the loop never ran, so nothing was fitted.
             return None
         res = np.hypot(x - (cx + a * p), y - (cy + b * p))
         return float(cx), float(cy), float(p), float(res.mean())
 
-    def _multi_start_refine(self, x: np.ndarray, y: np.ndarray, p0: float,
-                            cx_cands: list[float], cy_cands: list[float]):
-        """Run ICP from every (cx,cy) candidate; keep the lowest-residual result.
+    def _multi_start_refine(
+            self,
+            x: np.ndarray,
+            y: np.ndarray,
+            p0: float,
+            p_min: float,
+            p_max: float,
+            cx_cands: list[float],
+            cy_cands: list[float],
+            H: int,
+            W: int,
+    ) -> tuple[tuple[float, float, float, float] | None, bool]:
+        """Run ICP from every candidate and keep the best feasible registration.
 
-        Candidates are supplied nearest-image-center first (the ordering prior). A
-        later candidate replaces the current best only if it is *meaningfully* lower
-        (by ``_RESIDUAL_TIE_TOL`` px), so a row/column-translation-invariant sparse
-        layout — where several integer placements all fit with ~0 residual and differ
-        only by floating-point noise — resolves to the placement nearest the image
-        center rather than to whichever tie computed a marginally smaller float.
+        Residual is the primary score. Fits tied within ``_RESIDUAL_TIE_TOL``
+        explicitly prefer the grid center nearest the image center. Candidates whose
+        clipped edges collapse a cell are discarded before scoring. The returned
+        boolean records whether ICP produced any result, including infeasible ones.
         """
-        best = None
+        best: tuple[float, float, float, float] | None = None
+        best_center_distance = np.inf
+        saw_refined_candidate = False
         for cx0 in cx_cands:
             for cy0 in cy_cands:
-                out = self._icp_refine(x, y, cx0, cy0, p0)
+                out = self._icp_refine(x, y, cx0, cy0, p0, p_min, p_max)
                 if out is None:
                     continue
-                if best is None or out[3] < best[3] - self._RESIDUAL_TIE_TOL:
+                saw_refined_candidate = True
+                cx, cy, p, residual = out
+                if not np.all(np.isfinite(out)) or not (p_min <= p <= p_max):
+                    continue
+                row_edges = self._axis_edges(cy, p, self.nrows, H)
+                col_edges = self._axis_edges(cx, p, self.ncols, W - 1)
+                if not (
+                    self._axis_edges_are_valid(row_edges, self.nrows, H)
+                    and self._axis_edges_are_valid(col_edges, self.ncols, W - 1)
+                ):
+                    continue
+
+                center_distance = float(
+                    np.hypot(cx - (W - 1) / 2.0, cy - H / 2.0)
+                )
+                residual_tied = (
+                    best is not None
+                    and abs(residual - best[3]) <= self._RESIDUAL_TIE_TOL
+                )
+                if (
+                    best is None
+                    or residual < best[3] - self._RESIDUAL_TIE_TOL
+                    or (residual_tied and center_distance < best_center_distance)
+                ):
                     best = out
-        return best
+                    best_center_distance = center_distance
+        return best, saw_refined_candidate
 
     # ---- centers -> edges ----
     def _axis_edges(self, center: float, p: float, n_cells: int, image_dim: int) -> np.ndarray:
-        """n+1 edges = cell-center midlines with outer edges at +/- p/2, clipped to [0, image_dim]."""
+        """Return clipped cell midlines without silently repairing collapsed cells.
+
+        A single outer edge may clip to the frame while the partition remains valid.
+        Callers use :meth:`_axis_edges_are_valid` to reject placements where two or
+        more clipped edges coincide.
+        """
         first_center = center - (n_cells - 1) / 2.0 * p
         edges = first_center - p / 2.0 + np.arange(n_cells + 1) * p
         return np.clip(edges, 0, image_dim)
+
+    @staticmethod
+    def _axis_edges_are_valid(
+            edges: np.ndarray,
+            n_cells: int,
+            image_dim: int,
+    ) -> bool:
+        """Return whether edges form a finite, bounded, strict cell partition."""
+        edges = np.asarray(edges)
+        return bool(
+            edges.ndim == 1
+            and len(edges) == n_cells + 1
+            and np.all(np.isfinite(edges))
+            and np.all(edges >= 0)
+            and np.all(edges <= image_dim)
+            and np.all(np.diff(edges) > 0)
+        )
 
     @staticmethod
     def _extract_centers(image: "Image"):
@@ -230,10 +347,64 @@ class CenteredAutoGridFinder(GridFinder):
                           CenteredAutoGridFinderFallbackWarning, stacklevel=2)
 
     def _centered_uniform(self, p: float, H: int, W: int):
-        """Centered uniform grid at pitch p (image-centered)."""
-        re = self._axis_edges(H / 2.0, p, self.nrows, H)
-        ce = self._axis_edges(W / 2.0, p, self.ncols, W)
-        return re, ce
+        """Return a strict image-centered grid, safely bounding degenerate pitches."""
+        centers_fit_max = min(
+            H / max(self.nrows - 1, 1),
+            (W - 1) / max(self.ncols - 1, 1),
+        )
+        full_cells_pitch = min(
+            H / max(self.nrows, 1),
+            (W - 1) / max(self.ncols, 1),
+        )
+        if np.isfinite(p) and p > 0:
+            safe_p = min(float(p), centers_fit_max)
+        else:
+            safe_p = full_cells_pitch
+
+        row_edges = self._axis_edges(H / 2.0, safe_p, self.nrows, H)
+        col_edges = self._axis_edges((W - 1) / 2.0, safe_p, self.ncols, W - 1)
+        if (
+            self._axis_edges_are_valid(row_edges, self.nrows, H)
+            and self._axis_edges_are_valid(col_edges, self.ncols, W - 1)
+        ):
+            return row_edges, col_edges
+
+        row_edges = self._axis_edges(H / 2.0, full_cells_pitch, self.nrows, H)
+        col_edges = self._axis_edges(
+            (W - 1) / 2.0, full_cells_pitch, self.ncols, W - 1
+        )
+        if (
+            self._axis_edges_are_valid(row_edges, self.nrows, H)
+            and self._axis_edges_are_valid(col_edges, self.ncols, W - 1)
+        ):
+            return row_edges, col_edges
+
+        # Pathological dimensions or floating-point resolution: preserve the edge
+        # contract independently on each axis rather than returning collapsed bins.
+        return (
+            self._uniform_edges(self.nrows, H),
+            self._uniform_edges(self.ncols, W - 1),
+        )
+
+    def _finalize_grid_edges(
+            self,
+            row_edges: np.ndarray,
+            col_edges: np.ndarray,
+            fallback_pitch: float,
+            H: int,
+            W: int,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Enforce the strict-edge postcondition before delegating to ``pd.cut``."""
+        if (
+            self._axis_edges_are_valid(row_edges, self.nrows, H)
+            and self._axis_edges_are_valid(col_edges, self.ncols, W - 1)
+        ):
+            return row_edges, col_edges
+        self._warn(
+            "[invalid-geometry] fitted edges do not form a strict partition; "
+            "centered uniform fallback."
+        )
+        return self._centered_uniform(fallback_pitch, H, W)
 
     def _fit_grid_from_centers(self, x: np.ndarray, y: np.ndarray, H: int, W: int):
         """Full pipeline on raw center arrays -> (row_edges, col_edges), with the
@@ -258,15 +429,35 @@ class CenteredAutoGridFinder(GridFinder):
         if N <= self.min_fit_objects:
             self._warn(f"[few-objects] N={N}: bounded-ambiguous fit (best-effort, not confident).")
 
-        cx_c = self._center_candidates(x, p0, self.ncols, W)
+        cx_c = self._center_candidates(x, p0, self.ncols, W - 1)
         cy_c = self._center_candidates(y, p0, self.nrows, H)
-        best = self._multi_start_refine(x, y, p0, cx_c, cy_c)
-        if best is None or best[3] > self.residual_fraction * best[2]:
+        best, saw_refined_candidate = self._multi_start_refine(
+            x, y, p0, p_min, p_max, cx_c, cy_c, H, W
+        )
+        if best is None:
+            if saw_refined_candidate:
+                self._warn(
+                    "[invalid-geometry] ICP registrations collapse one or more "
+                    "grid cells; centered uniform at comb pitch."
+                )
+            else:
+                self._warn(
+                    "[icp-failed] no registration could be refined; "
+                    "centered uniform at comb pitch."
+                )
+            return self._centered_uniform(p0, H, W)
+        if best[3] > self.residual_fraction * best[2]:
             self._warn("[icp-failed] no acceptable registration; centered uniform at comb pitch.")
             return self._centered_uniform(p0, H, W)
 
         cx, cy, p, _res = best
-        return self._axis_edges(cy, p, self.nrows, H), self._axis_edges(cx, p, self.ncols, W)
+        return self._finalize_grid_edges(
+            self._axis_edges(cy, p, self.nrows, H),
+            self._axis_edges(cx, p, self.ncols, W - 1),
+            p0,
+            H,
+            W,
+        )
 
     # ---- GridFinder overrides ----
     def get_row_edges(self, image: "Image") -> np.ndarray:

--- a/src/phenotypic/phenotypicCLI.py
+++ b/src/phenotypic/phenotypicCLI.py
@@ -1453,6 +1453,30 @@ def phenotypic_cli(
                 )
                 if not marker_contract:
                     migrate_legacy_stage3_markers(output_dir, resume_plan)
+                if (
+                    config.process_only_layer is None
+                    and config.save_overlays
+                ):
+                    from phenotypic._cli._cli_staged_workers import (
+                        ensure_staged_overlay,
+                    )
+
+                    resume_output_manager = OutputManager.from_config(
+                        base_dir=output_dir,
+                        ext=config.ext,
+                        include_dataset_column=config.include_dataset_column,
+                        overlay_alpha=config.overlay_alpha,
+                        save_overlays=True,
+                    )
+                    for resume_item in resume_plan.items:
+                        if resume_item.stage == "complete":
+                            ensure_staged_overlay(
+                                output_dir,
+                                resume_item.dataset,
+                                resume_item.image.stem,
+                                resume_output_manager,
+                                config.image_type,
+                            )
                 reconcile_stage3_publications(
                     output_dir,
                     config.full_dataset_inventory,

--- a/tests/integration/cli/test_staged_gpu_local.py
+++ b/tests/integration/cli/test_staged_gpu_local.py
@@ -2,6 +2,7 @@
 
 import phenotypic
 import numpy as np
+import polars as pl
 import pytest
 from click.testing import CliRunner
 from datetime import datetime
@@ -9,6 +10,7 @@ from datetime import datetime
 from phenotypic import ImagePipeline
 from phenotypic.data import load_synth_yeast_plate
 from phenotypic.measure import MeasureSize
+from phenotypic.schema import METADATA
 from phenotypic._cli._cli_output_manager import OutputManager
 from phenotypic._cli._cli_pipeline_split import split_pipeline_at_gpu
 from phenotypic._cli._cli_process_only import process_only_output_path
@@ -108,7 +110,12 @@ def test_three_stage_cores_end_to_end(tmp_path):
     stage1_preprocess_core(
         plan, image_path, "ds", "img", out, om, image_type="Image"
     )
-    assert (dataset_hdf_dir(out, "ds") / "img.h5").is_file()
+    staged_hdf = dataset_hdf_dir(out, "ds") / "img.h5"
+    assert staged_hdf.is_file()
+    pre_fix_image = phenotypic.Image.load_hdf5(staged_hdf)
+    pre_fix_image.name = str(pre_fix_image.uuid)
+    pre_fix_image.save2hdf5(staged_hdf)
+    assert phenotypic.Image.load_hdf5(staged_hdf).name != "img"
 
     # Stage 2: resident detector -> sidecar
     plan.gpu_detector._ensure_model_loaded()
@@ -117,7 +124,11 @@ def test_three_stage_cores_end_to_end(tmp_path):
 
     # Stage 3: merge + measure -> parquet, re-save HDF, delete sidecar
     stage3_merge_measure_core(plan, out, "ds", "img", om, image_type="Image")
-    assert (out / "results" / "ds" / "measurements" / "img.parquet").is_file()
+    measurements_path = out / "results" / "ds" / "measurements" / "img.parquet"
+    assert measurements_path.is_file()
+    measurements = pl.read_parquet(measurements_path)
+    assert measurements[str(METADATA.IMAGE_NAME)].unique().to_list() == ["img"]
+    assert phenotypic.Image.load_hdf5(staged_hdf).name == "img"
     assert not sidecar_exists(out, "ds", "img")  # mandatory cleanup
 
 

--- a/tests/integration/cli/test_staged_gpu_local.py
+++ b/tests/integration/cli/test_staged_gpu_local.py
@@ -23,6 +23,11 @@ from phenotypic._cli._cli_staged_resume import (
     build_staged_resume_plan,
     reconcile_stage3_publications,
     stage3_completion_exists,
+    stage3_completion_marker_path,
+)
+from phenotypic._cli._cli_state_management import (
+    load_processing_state,
+    save_processing_state,
 )
 from phenotypic._cli._cli_staged_workers import (
     stage1_preprocess_core,
@@ -34,7 +39,7 @@ from phenotypic._cli._cli_update_state import (
     aggregate_stage_state_from_events,
     parse_event_line,
 )
-from phenotypic.sdk_ import dataset_hdf_dir, event_log_path
+from phenotypic.sdk_ import dataset_hdf_dir, dataset_overlays_dir, event_log_path
 from tests._fakes.fake_gpu_detector import FakeGpuDetector
 from phenotypic.phenotypicCLI import phenotypic_cli
 
@@ -126,7 +131,7 @@ def test_staged_strategy_runs_all_stages(tmp_path):
     )
     pipe_path = out / "pipeline.json"
     pipe_path.write_text(pipe.to_json(), encoding="utf-8")
-    om = OutputManager.from_config(out, ".tiff", save_overlays=False)
+    om = OutputManager.from_config(out, ".tiff", save_overlays=True)
     om.create_structure([Dataset("ds", [image_path], tmp_path, out)])
 
     strat = StagedGpuStrategy(_config(out, pipe_path), om)
@@ -134,7 +139,38 @@ def test_staged_strategy_runs_all_stages(tmp_path):
 
     assert results.total_completed == 1
     assert (out / "results" / "ds" / "measurements" / "img.parquet").is_file()
+    assert (dataset_overlays_dir(out, "ds") / "img.png").is_file()
     assert not sidecar_exists(out, "ds", "img")
+
+
+def test_staged_strategy_resume_backfills_missing_overlay_without_gpu(tmp_path, monkeypatch):
+    image_path = _write_image(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+    pipe = ImagePipeline(
+        ops=[FakeGpuDetector(output_kind="instance", threshold=0.3)],
+        meas=[MeasureSize()],
+    )
+    pipe_path = out / "pipeline.json"
+    pipe_path.write_text(pipe.to_json(), encoding="utf-8")
+    om = OutputManager.from_config(out, ".tiff", save_overlays=True)
+    datasets = [Dataset("ds", [image_path], tmp_path, out)]
+    om.create_structure(datasets)
+    StagedGpuStrategy(_config(out, pipe_path), om).execute(datasets, out)
+    overlay = dataset_overlays_dir(out, "ds") / "img.png"
+    overlay.unlink()
+    monkeypatch.setattr(
+        FakeGpuDetector,
+        "_ensure_model_loaded",
+        lambda self: (_ for _ in ()).throw(AssertionError("model loaded")),
+    )
+
+    result = StagedGpuStrategy(
+        _config(out, pipe_path, resume=True), om
+    ).execute(datasets, out)
+
+    assert result.total_completed == 1
+    assert overlay.is_file()
 
 
 def test_staged_strategy_resumes_skipping_done_stages(tmp_path):
@@ -425,6 +461,70 @@ def test_cli_plain_resume_includes_recorded_stage2_failure(
     assert sorted(aggregated_images) == ["img.tiff", "img2.tiff"]
 
 
+@pytest.mark.parametrize("legacy_markerless", [False, True])
+def test_cli_resume_backfills_completed_overlay_before_early_exit(
+    tmp_path, monkeypatch, legacy_markerless
+):
+    images = tmp_path / "images"
+    images.mkdir()
+    image_path = _write_image(images)
+    out = tmp_path / "out"
+    pipe = ImagePipeline(
+        ops=[FakeGpuDetector(threshold=0.3)], meas=[MeasureSize()]
+    )
+    pipe_path = tmp_path / "pipeline.json"
+    pipe_path.write_text(pipe.to_json(), encoding="utf-8")
+    args = [
+        "--pipeline",
+        str(pipe_path),
+        "--input",
+        str(images),
+        "--output",
+        str(out),
+        "--image-type",
+        "Image",
+        "--force-local",
+        "--skip-validation",
+        "--njobs",
+        "1",
+        "--overlay-alpha",
+        "0.65",
+    ]
+    first = CliRunner().invoke(phenotypic_cli, args)
+    assert first.exit_code == 0, first.output
+    overlay = dataset_overlays_dir(out, images.name) / "img.png"
+    overlay.unlink()
+    if legacy_markerless:
+        stage3_completion_marker_path(
+            out, images.name, image_path.stem
+        ).unlink()
+        state = load_processing_state(out)
+        assert state is not None
+        state.config["staged_stage3_markers"] = False
+        save_processing_state(state, out)
+    monkeypatch.setattr(
+        FakeGpuDetector,
+        "_ensure_model_loaded",
+        lambda self: (_ for _ in ()).throw(AssertionError("model loaded")),
+    )
+    observed_alpha = []
+    original_save_overlay = OutputManager.save_overlay
+
+    def _save_overlay_with_alpha(manager, *args, **kwargs):
+        observed_alpha.append(manager.overlay_alpha)
+        return original_save_overlay(manager, *args, **kwargs)
+
+    monkeypatch.setattr(OutputManager, "save_overlay", _save_overlay_with_alpha)
+
+    resumed = CliRunner().invoke(phenotypic_cli, [*args, "--resume"])
+
+    assert resumed.exit_code == 0, resumed.output
+    assert "All images already processed" in resumed.output
+    assert overlay.is_file()
+    assert observed_alpha == [0.65]
+    assert stage3_completion_exists(out, images.name, image_path.stem)
+
+
 def test_cli_resumes_finalizer_only_when_image_stages_are_complete(
     tmp_path, monkeypatch
 ):
@@ -689,6 +789,63 @@ def _stage1_only(tmp_path):
         image_type="Image",
     )
     return out, pipe_path
+
+
+def test_slurm_stage3_worker_writes_and_backfills_overlay(tmp_path, monkeypatch):
+    import phenotypic._cli._cli_staged_slurm_worker as worker
+
+    out, pipe_path = _stage1_only(tmp_path)
+    dataset_overlays_dir(out, "ds").mkdir(parents=True)
+    manifest = [("ds", "img")]
+    observed_alpha = []
+    original_save_overlay = OutputManager.save_overlay
+
+    def _save_overlay_with_alpha(manager, *args, **kwargs):
+        observed_alpha.append(manager.overlay_alpha)
+        return original_save_overlay(manager, *args, **kwargs)
+
+    monkeypatch.setattr(OutputManager, "save_overlay", _save_overlay_with_alpha)
+    worker.run_stage2_shard(
+        pipeline_path=pipe_path,
+        output_dir=out,
+        image_type="Image",
+        manifest=manifest,
+        shard_index=0,
+        n_shards=1,
+    )
+
+    worker.run_stage3_step(
+        pipeline_path=pipe_path,
+        output_dir=out,
+        image_type="Image",
+        manifest=manifest,
+        index=0,
+        overlay_alpha=0.65,
+    )
+
+    overlay = dataset_overlays_dir(out, "ds") / "img.png"
+    assert overlay.is_file()
+    overlay.unlink()
+    monkeypatch.setattr(
+        worker,
+        "split_pipeline_at_gpu",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("pipeline reloaded")
+        ),
+    )
+
+    worker.run_stage3_step(
+        pipeline_path=pipe_path,
+        output_dir=out,
+        image_type="Image",
+        manifest=manifest,
+        index=0,
+        resume=True,
+        overlay_alpha=0.65,
+    )
+
+    assert overlay.is_file()
+    assert observed_alpha == [0.65, 0.65]
 
 
 def test_completed_shard_exits_before_loading_model(tmp_path, monkeypatch):

--- a/tests/unit/cli/test_cli_progress_dashboard.py
+++ b/tests/unit/cli/test_cli_progress_dashboard.py
@@ -421,6 +421,31 @@ class TestManifestBuilder:
         assert manifest["slurm_info"]["chunk_scripts"] == ["chunk0.sh"]
         assert manifest["slurm_info"]["chunk_job_ids"] == {"0": "12345"}
 
+    def test_slurm_manifest_ignores_named_staged_round_jobs(self, tmp_dir):
+        progress_dir = tmp_dir / "progress"
+        progress_dir.mkdir()
+        event_log = tmp_dir / "processing_events.log"
+        append_event(event_log, "plate1", "img001.tif", "started")
+        append_completion_event(
+            event_log, "plate1", "img001.tif", "completed"
+        )
+
+        build_manifest(
+            output_dir=tmp_dir,
+            progress_dir=progress_dir,
+            datasets={"plate1": 1},
+            execution_mode="slurm",
+            start_time=datetime.now().isoformat(timespec="milliseconds"),
+            slurm_job_ids={"0": "12345", "stage2-round-1": "23456"},
+            chunk_scripts=["chunk0.sh"],
+        )
+
+        manifest = json.loads((progress_dir / "manifest.json").read_text())
+        slurm_info = manifest["slurm_info"]
+        assert slurm_info["total_chunks"] == 1
+        assert slurm_info["chunk_job_ids"] == {"0": "12345"}
+        assert slurm_info["completed_chunks"] == [0]
+
 
 # ──────────────────────────────────────────────────────────────────────
 # sacct parsing
@@ -490,6 +515,25 @@ class TestSacctParsing:
         finally:
             mb._terminal_job_cache.clear()
             mb._terminal_job_cache.update(saved)
+
+    def test_sacct_chunk_states_ignores_named_staged_round_jobs(
+        self, monkeypatch
+    ):
+        import phenotypic._cli._dashboard._manifest_builder as mb
+
+        monkeypatch.setattr(mb, "_terminal_job_cache", {})
+        with patch(
+            "phenotypic._cli._dashboard._manifest_builder.query_sacct_batch",
+            return_value={"12345": {"12345_0": "COMPLETED"}},
+        ) as query_batch:
+            active, completed, pending = query_sacct_chunk_states(
+                {"0": "12345", "stage2-round-1": "23456"}
+            )
+
+        query_batch.assert_called_once_with(["12345"])
+        assert active == []
+        assert completed == [0]
+        assert pending == []
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/unit/cli/test_cli_v2.py
+++ b/tests/unit/cli/test_cli_v2.py
@@ -1865,6 +1865,28 @@ class TestAggregateMeasurements:
     ):
         """Scratch staging retains the original stem used by metadata joins."""
         import pandas as pd
+        import polars as pl
+
+        from phenotypic._cli import _cli_output_manager
+        from phenotypic._cli._cli_parquet_agg import SOURCE_PATH_COLUMN
+
+        aggregate_parquet_files = _cli_output_manager.aggregate_parquet_files
+
+        def _aggregate_with_windows_source_paths(*args, **kwargs):
+            frame = aggregate_parquet_files(*args, **kwargs)
+            if frame is None:
+                return None
+            return frame.with_columns(
+                pl.col(SOURCE_PATH_COLUMN).str.replace_all(
+                    "/", "\\", literal=True
+                )
+            )
+
+        monkeypatch.setattr(
+            _cli_output_manager,
+            "aggregate_parquet_files",
+            _aggregate_with_windows_source_paths,
+        )
 
         image_stem = "d000374_280_121_2026-04-11_16-55-18"
         self._create_measurement_csvs(temp_output_dir, {

--- a/tests/unit/cli/test_cli_v2.py
+++ b/tests/unit/cli/test_cli_v2.py
@@ -1860,6 +1860,50 @@ class TestAggregateMeasurements:
         assert set(master[DATASET_HEADER]) == {"plate_A", "plate_B"}
         assert master.loc[master[DATASET_HEADER] == "plate_A", "area"].iloc[0] == 10
 
+    def test_aggregate_repairs_staged_uuid_when_using_scratch(
+        self, temp_output_dir, tmp_path, monkeypatch
+    ):
+        """Scratch staging retains the original stem used by metadata joins."""
+        import pandas as pd
+
+        image_stem = "d000374_280_121_2026-04-11_16-55-18"
+        self._create_measurement_csvs(temp_output_dir, {
+            "plate": [
+                (
+                    image_stem,
+                    pd.DataFrame({
+                        IMAGE_NAME_HEADER: [
+                            "4815d217-4afc-40dd-ab6c-bbf1521f4109"
+                        ],
+                        "area": [10],
+                    }),
+                )
+            ],
+        })
+        metadata_path = temp_output_dir / "metadata.csv"
+        pd.DataFrame({
+            IMAGE_NAME_HEADER: [image_stem],
+            TREATMENT_LABEL: ["control"],
+        }).to_csv(metadata_path, index=False)
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        monkeypatch.setenv("SCRATCH", str(scratch))
+
+        result = aggregate_measurements(
+            output_dir=temp_output_dir,
+            dataset_names=["plate"],
+            include_dataset_column=True,
+            metadata_csv=metadata_path,
+        )
+
+        assert result is not None
+        master = pd.read_csv(result)
+        assert master[IMAGE_NAME_HEADER].tolist() == [image_stem]
+        mirror = pd.read_csv(measurements_csv_path(temp_output_dir))
+        assert mirror[IMAGE_NAME_HEADER].tolist() == [image_stem]
+        assert mirror["area"].tolist() == [10]
+        assert mirror[TREATMENT_HEADER].tolist() == ["control"]
+
     def test_aggregate_measurements_no_dataset_column(self, temp_output_dir):
         """include_dataset_column=False: no Metadata_Dataset column added."""
         import pandas as pd

--- a/tests/unit/cli/test_measurement_sources.py
+++ b/tests/unit/cli/test_measurement_sources.py
@@ -40,6 +40,28 @@ def test_discover_measurement_sources_prefers_dataset_aggregated_file(
     assert [(src.path, src.dataset) for src in sources] == [(agg, "plate_a")]
 
 
+def test_discover_measurement_sources_uses_individuals_for_uuid_aggregate(
+    tmp_path: Path,
+) -> None:
+    """UUID identities in an aggregate fall back to recoverable source names."""
+    meas_dir = tmp_path / "results" / "plate_a" / "measurements"
+    agg = meas_dir / DATASET_AGGREGATED_PARQUET
+    raw = meas_dir / "img.parquet"
+    meas_dir.mkdir(parents=True)
+    pl.DataFrame(
+        {
+            str(METADATA.IMAGE_NAME): [
+                "4815d217-4afc-40dd-ab6c-bbf1521f4109"
+            ]
+        }
+    ).write_parquet(agg)
+    _touch(raw)
+
+    sources = discover_measurement_sources(tmp_path, ["plate_a"])
+
+    assert [(src.path, src.dataset) for src in sources] == [(raw, "plate_a")]
+
+
 def test_discover_measurement_sources_skips_internal_files_and_sorts(
     tmp_path: Path,
 ) -> None:
@@ -109,3 +131,38 @@ def test_add_metadata_image_name_from_filename_preserves_existing_column() -> No
 
     assert "filename" not in out.columns
     assert out[str(METADATA.IMAGE_NAME)].to_list() == ["kept"]
+
+
+def test_add_metadata_image_name_from_filename_repairs_staged_uuid() -> None:
+    """Pre-fix staged UUID identities are replaced by the parquet stem."""
+    frame = pl.DataFrame(
+        {
+            "filename": [
+                "/tmp/plate/d000374_280_121_2026-04-11_16-55-18.parquet"
+            ],
+            str(METADATA.IMAGE_NAME): [
+                "4815d217-4afc-40dd-ab6c-bbf1521f4109"
+            ],
+        }
+    )
+
+    out = add_metadata_image_name_from_filename(frame)
+
+    assert out[str(METADATA.IMAGE_NAME)].to_list() == [
+        "d000374_280_121_2026-04-11_16-55-18"
+    ]
+
+
+def test_add_metadata_image_name_does_not_infer_from_aggregate_filename() -> None:
+    """An aggregate basename cannot identify any of its constituent images."""
+    uuid_name = "4815d217-4afc-40dd-ab6c-bbf1521f4109"
+    frame = pl.DataFrame(
+        {
+            "filename": [f"/tmp/plate/{DATASET_AGGREGATED_PARQUET}"],
+            str(METADATA.IMAGE_NAME): [uuid_name],
+        }
+    )
+
+    out = add_metadata_image_name_from_filename(frame)
+
+    assert out[str(METADATA.IMAGE_NAME)].to_list() == [uuid_name]

--- a/tests/unit/cli/test_staged_controller.py
+++ b/tests/unit/cli/test_staged_controller.py
@@ -12,6 +12,7 @@ import pytest
 from phenotypic._cli._cli_staged_controller import run_staged_controller
 from phenotypic._cli._cli_staged_orchestration import (
     StagedManifestEntry,
+    _mirror_job_to_metadata,
     append_job_ledger,
     append_stage2_terminal_failure,
     cancel_staged_jobs,
@@ -30,7 +31,13 @@ from phenotypic._cli._cli_staged_orchestration import (
     terminal_stage2_identities,
     write_staged_manifest,
 )
-from phenotypic.sdk_ import atomic_write_json, dataset_hdf_dir, dataset_measurements_dir
+from phenotypic.sdk_ import (
+    JobMetadataKey,
+    atomic_write_json,
+    dataset_hdf_dir,
+    dataset_measurements_dir,
+    job_metadata_path,
+)
 
 
 def _controller_fixture(tmp_path: Path, epoch: str = "epoch-1") -> Path:
@@ -289,6 +296,29 @@ def test_submission_intent_discovers_job_after_recording_crash(
     )
     assert job_id == "777"
     assert read_job_ledger(tmp_path)[-1]["status"] == "submitted"
+
+
+def test_named_stage_job_is_not_mirrored_as_numeric_chunk(tmp_path: Path) -> None:
+    metadata_path = job_metadata_path(tmp_path)
+    metadata_path.parent.mkdir(parents=True)
+    atomic_write_json(
+        metadata_path,
+        {
+            JobMetadataKey.SLURM_JOB_IDS: {},
+            JobMetadataKey.CHUNK_JOB_IDS: {"0": "100"},
+        },
+    )
+
+    _mirror_job_to_metadata(
+        tmp_path,
+        token="stage2-round-1",
+        role="stage2",
+        job_id="23456",
+    )
+
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata[JobMetadataKey.SLURM_JOB_IDS]["stage2-round-1"] == "23456"
+    assert metadata[JobMetadataKey.CHUNK_JOB_IDS] == {"0": "100"}
 
 
 def test_duplicate_transition_uses_ledger_without_sbatch(

--- a/tests/unit/cli/test_staged_slurm_scripts.py
+++ b/tests/unit/cli/test_staged_slurm_scripts.py
@@ -92,6 +92,7 @@ def test_generates_three_stage_scripts_with_correct_resources(tmp_path):
         gpu_slurm_args={"slurm_partition": "gpu"},
         n_shards=2,
         epoch="epoch-1",
+        overlay_alpha=0.65,
     )
     assert set(scripts) == {
         "stage1",
@@ -115,6 +116,8 @@ def test_generates_three_stage_scripts_with_correct_resources(tmp_path):
     # Stage 1/3 = array over images (0-2); Stage 2 = array over shards (0-1)
     assert "--array=0-2" in s1 and "--array=0-2" in s3
     assert "--array=0-1" in s2
+    assert "--overlay-alpha 0.65" in s3
+    assert "--overlay-alpha" not in s1 and "--overlay-alpha" not in s2
     # Stage 2 invokes the shard worker
     assert "_cli_staged_slurm_worker" in s2
     assert "_cli_checkpoint_handler" in finalizer
@@ -304,6 +307,7 @@ def test_strategy_reserves_two_max_submit_slots_for_controllers(
             "gpu_slurm_args": {},
             "gpu_shards": 1,
             "ext": None,
+            "overlay_alpha": 0.3,
             "include_dataset_column": False,
             "metadata_csv": None,
             "no_qc": False,

--- a/tests/unit/core/test_image_hdf_roundtrip.py
+++ b/tests/unit/core/test_image_hdf_roundtrip.py
@@ -59,6 +59,17 @@ def test_image_roundtrip_bit_depth_16(tmp_path):
     assert loaded.rgb[:].dtype == np.uint16
 
 
+def test_image_roundtrip_restores_name_from_constructor_placeholder(tmp_path):
+    """A v2 HDF reload replaces the constructor's empty image-name placeholder."""
+    img = Image(arr=_make_small_rgb(), name="plate_001")
+    path = tmp_path / "named.h5"
+
+    img.save2hdf5(path)
+    loaded = Image.load_hdf5(path)
+
+    assert loaded.name == "plate_001"
+
+
 def test_image_roundtrip_illuminant_gamma(tmp_path):
     """D50 + LINEAR round-trip preserves illuminant and gamma identity."""
     img = Image(

--- a/tests/unit/grid/test_centered_auto_grid_finder.py
+++ b/tests/unit/grid/test_centered_auto_grid_finder.py
@@ -1,9 +1,10 @@
 import numpy as np
+import pandas as pd
 import pytest
 
 from phenotypic.abc_ import GridFinder
 from phenotypic.grid import CenteredAutoGridFinder, CenteredAutoGridFinderFallbackWarning
-from phenotypic.schema import GRID
+from phenotypic.schema import BBOX, GRID
 
 
 def test_is_gridfinder_and_constructs_keyword_only():
@@ -101,7 +102,9 @@ def test_icp_recovers_params_from_good_seed():
     p_true, cx, cy = 404.0, 2545.0, 1575.0
     occ = [(1, 0), (1, 4), (2, 3), (3, 5), (5, 8), (6, 11), (3, 1), (5, 4), (2, 7), (6, 0)]
     x, y = _lattice_points(p_true, cx, cy, 8, 12, occ)
-    out = f._icp_refine(x, y, cx + 30, cy - 25, p_true + 6)  # seed within ~0.1 cell
+    out = f._icp_refine(
+        x, y, cx + 30, cy - 25, p_true + 6, p_min=300.0, p_max=450.0
+    )  # seed within ~0.1 cell
     assert out is not None
     rcx, rcy, rp, res = out
     assert rp == pytest.approx(p_true, abs=1.0)
@@ -117,7 +120,9 @@ def test_multistart_rejects_one_cell_shift():
     x, y = _lattice_points(p_true, cx, cy, 8, 12, occ)
     # A one-cell-shifted seed alone gets TRAPPED on a high-residual lattice: edge
     # colonies (col 0, col 11) clip when their index shifts, so the fit can't match.
-    shifted = f._icp_refine(x, y, cx + p_true, cy, p_true)
+    shifted = f._icp_refine(
+        x, y, cx + p_true, cy, p_true, p_min=300.0, p_max=450.0
+    )
     assert shifted is not None
     assert shifted[3] > 0.15 * p_true                      # the trap: large residual
     # Multi-start over all candidates escapes the trap by selecting the lowest-
@@ -125,8 +130,19 @@ def test_multistart_rejects_one_cell_shift():
     # decisive gap (res << shifted) disappears.
     cx_c = f._center_candidates(x, p_true, f.ncols, W)
     cy_c = f._center_candidates(y, p_true, f.nrows, H)
-    best = f._multi_start_refine(x, y, p_true, cx_c, cy_c)
+    best, saw_refined = f._multi_start_refine(
+        x,
+        y,
+        p_true,
+        300.0,
+        450.0,
+        cx_c,
+        cy_c,
+        H,
+        W,
+    )
     assert best is not None
+    assert saw_refined
     bcx, bcy, bp, res = best
     assert res < 0.05 * p_true                             # decisively beats the trap
     assert res < shifted[3] / 3
@@ -138,7 +154,9 @@ def test_icp_singular_returns_none_all_one_cell():
     # all points in a tiny cluster -> every assignment rounds to one cell -> det ~ 0
     x = np.array([2500.0, 2503.0, 2498.0])
     y = np.array([1570.0, 1572.0, 1569.0])
-    out = f._icp_refine(x, y, 2533.0, 1576.0, 404.0)
+    out = f._icp_refine(
+        x, y, 2533.0, 1576.0, 404.0, p_min=300.0, p_max=450.0
+    )
     assert out is None
 
 
@@ -148,6 +166,166 @@ def test_axis_edges_length_sorted_clipped():
     assert len(edges) == 9                  # n+1
     assert np.all(np.diff(edges) > 0)       # sorted ascending
     assert edges[0] >= 0 and edges[-1] <= 3152
+
+
+def test_axis_edge_validation_rejects_reported_and_mirrored_collapse():
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+
+    reported_rows = f._axis_edges(
+        center=1983.0, p=403.2, n_cells=8, image_dim=3002
+    )
+    assert reported_rows[-2] == reported_rows[-1] == 3002.0
+    assert not f._axis_edges_are_valid(reported_rows, 8, 3002)
+
+    mirrored_cols = f._axis_edges(
+        center=2800.0, p=350.0, n_cells=12, image_dim=4500
+    )
+    assert mirrored_cols[-2] == mirrored_cols[-1] == 4500.0
+    assert not f._axis_edges_are_valid(mirrored_cols, 12, 4500)
+
+    one_pitch_up = f._axis_edges(
+        center=1579.8, p=403.2, n_cells=8, image_dim=3002
+    )
+    assert f._axis_edges_are_valid(one_pitch_up, 8, 3002)
+
+
+def test_multistart_uses_downstream_effective_column_bound(monkeypatch):
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W, p = 3002, 1099, 99.0
+    feasible_cx = (W - 1) / 2.0
+    subpixel_last_cell_cx = 603.5
+
+    pre_assignment_edges = f._axis_edges(
+        subpixel_last_cell_cx, p, f.ncols, W
+    )
+    assert f._axis_edges_are_valid(pre_assignment_edges, f.ncols, W)
+    downstream_edges = np.clip(pre_assignment_edges, 0, W - 1)
+    assert not f._axis_edges_are_valid(downstream_edges, f.ncols, W - 1)
+
+    def fake_icp_refine(self, x, y, cx, cy, p0, p_min, p_max):
+        del self, x, y, p0, p_min, p_max
+        residual = 0.2 if cx == feasible_cx else 0.1
+        return float(cx), float(cy), p, residual
+
+    monkeypatch.setattr(
+        CenteredAutoGridFinder, "_icp_refine", fake_icp_refine
+    )
+    best, saw_refined = f._multi_start_refine(
+        np.array([feasible_cx]),
+        np.array([H / 2.0]),
+        p,
+        90.0,
+        110.0,
+        [feasible_cx, subpixel_last_cell_cx],
+        [H / 2.0],
+        H,
+        W,
+    )
+
+    assert saw_refined
+    assert best is not None
+    assert best[0] == feasible_cx
+    col_edges = f._axis_edges(best[0], best[2], f.ncols, W - 1)
+    table = pd.DataFrame({str(BBOX.CENTER_CC): [54.0, 153.0]})
+    assigned = f._add_col_number_info(table, col_edges, (H, W))
+    assert assigned[str(GRID.COL_NUM)].notna().all()
+
+
+def test_multistart_rejects_collapsed_fit_and_maps_rows_b_through_g(monkeypatch):
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W, p = 3002, 5066, 403.2
+    feasible_cy = 1579.8
+    collapsed_cy = 1983.0
+
+    def fake_icp_refine(
+        self, x, y, cx, cy, p0, p_min, p_max
+    ):  # pragma: no cover - signature documents the private seam
+        del self, x, y, p0, p_min, p_max
+        residual = 0.2 if cy == feasible_cy else 0.1
+        return float(cx), float(cy), p, residual
+
+    monkeypatch.setattr(
+        CenteredAutoGridFinder, "_icp_refine", fake_icp_refine
+    )
+    best, saw_refined = f._multi_start_refine(
+        np.array([W / 2.0]),
+        np.array([571.8]),
+        p,
+        350.0,
+        430.0,
+        [W / 2.0],
+        [feasible_cy, collapsed_cy],
+        H,
+        W,
+    )
+
+    assert saw_refined
+    assert best is not None
+    assert best[1] == feasible_cy
+    row_edges = f._axis_edges(best[1], best[2], f.nrows, H)
+    assert f._axis_edges_are_valid(row_edges, f.nrows, H)
+
+    row_centers = 571.8 + p * np.arange(6)
+    table = pd.DataFrame({str(BBOX.CENTER_RR): row_centers})
+    assigned = f._add_row_number_info(table, row_edges, (H, W))
+    assert assigned[str(GRID.ROW_NUM)].astype(int).tolist() == list(range(1, 7))
+
+
+def test_reported_sparse_rows_fit_end_to_end_without_duplicate_bins():
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W, p = 3002, 5066, 403.2
+    cx, cy = W / 2.0, 1579.8
+    occupied = [(i, j) for i in range(1, 7) for j in range(12)]
+    x, y = _lattice_points(p, cx, cy, 8, 12, occupied)
+
+    row_edges, col_edges = f._fit_grid_from_centers(x, y, H, W)
+
+    assert _edges_ok(row_edges, col_edges, 8, 12, H, W)
+    row_centers = np.unique(y)
+    table = pd.DataFrame({str(BBOX.CENTER_RR): row_centers})
+    assigned = f._add_row_number_info(table, row_edges, (H, W))
+    assert assigned[str(GRID.ROW_NUM)].astype(int).tolist() == list(range(1, 7))
+
+
+def test_multistart_tied_residual_prefers_nearest_image_center(monkeypatch):
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W, p = 3002, 5066, 300.0
+
+    def fake_icp_refine(self, x, y, cx, cy, p0, p_min, p_max):
+        del self, x, y, p0, p_min, p_max
+        return float(cx), float(cy), p, 1.0
+
+    monkeypatch.setattr(
+        CenteredAutoGridFinder, "_icp_refine", fake_icp_refine
+    )
+    best, _ = f._multi_start_refine(
+        np.array([W / 2.0]),
+        np.array([H / 2.0]),
+        p,
+        250.0,
+        350.0,
+        [W / 2.0],
+        [1400.0, 1600.0],
+        H,
+        W,
+    )
+
+    assert best is not None
+    assert best[1] == 1600.0
+
+
+def test_bounded_solution_reoptimizes_center_for_clamped_pitch():
+    solution = np.array([400.0, 300.0, 500.0])
+    x = np.array([0.0, 1000.0])
+    y = np.array([100.0, 700.0])
+    a = np.array([-1.0, 1.0])
+    b = np.array([-1.0, 1.0])
+
+    bounded = CenteredAutoGridFinder._bounded_solution(
+        solution, x, y, a, b, p_min=200.0, p_max=400.0
+    )
+
+    assert bounded == pytest.approx((500.0, 400.0, 400.0))
 
 
 def test_fit_grid_returns_edges_and_lands_on_lattice():
@@ -178,6 +356,43 @@ def test_zero_and_one_colony_uniform_no_crash():
     for x, y in [(np.array([]), np.array([])), (np.array([2500.0]), np.array([1570.0]))]:
         re, ce = f._fit_grid_from_centers(x, y, H, W)
         assert _edges_ok(re, ce, 8, 12, H, W)
+
+
+def test_zero_span_degenerate_response_uses_strict_centered_fallback():
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W = 3002, 5066
+    x = np.full(8, W / 2.0)
+    y = np.full(8, H / 2.0)
+
+    row_edges, col_edges = f._fit_grid_from_centers(x, y, H, W)
+
+    assert _edges_ok(row_edges, col_edges, 8, 12, H, W)
+
+
+def test_all_refined_candidates_infeasible_warns_and_falls_back(
+    monkeypatch,
+):
+    f = CenteredAutoGridFinder(nrows=8, ncols=12, warn=True)
+    H, W, p = 3002, 5066, 403.2
+    occ = [(i, j) for i in range(1, 7) for j in range(1, 11)]
+    x, y = _lattice_points(p, W / 2.0, H / 2.0, 8, 12, occ)
+
+    def fake_icp_refine(self, x, y, cx, cy, p0, p_min, p_max):
+        del self, x, y, cx, cy, p0, p_min, p_max
+        return W / 2.0, 1983.0, p, 0.1
+
+    monkeypatch.setattr(
+        CenteredAutoGridFinder, "_icp_refine", fake_icp_refine
+    )
+    with pytest.warns(
+        CenteredAutoGridFinderFallbackWarning,
+        match="invalid-geometry",
+    ):
+        row_edges, col_edges = f._fit_grid_from_centers(x, y, H, W)
+
+    assert _edges_ok(row_edges, col_edges, 8, 12, H, W)
+    assert row_edges[1:-1] + row_edges[-2:0:-1] == pytest.approx(H)
+    assert np.mean(np.diff(row_edges[1:-1])) == pytest.approx(p, abs=1.0)
 
 
 def test_degenerate_response_falls_back_without_exception():
@@ -219,3 +434,19 @@ def test_dense_plate_pitch_above_naive_ceiling_is_found():
     re, ce = f._fit_grid_from_centers(x, y, H, W)
     # recovered column pitch ~ 404 (not capped at 394)
     assert np.mean(np.diff(ce[1:-1])) == pytest.approx(p_true, abs=2.0)
+
+
+def test_valid_off_center_fit_beyond_one_pitch_is_preserved():
+    f = CenteredAutoGridFinder(nrows=8, ncols=12)
+    H, W = 3002, 4200
+    p_true = 300.0
+    cx, cy = W / 2.0, H / 2.0 + p_true + 1.0
+    occ = [(i, j) for i in range(8) for j in range(12)]
+    x, y = _lattice_points(p_true, cx, cy, 8, 12, occ)
+
+    row_edges, col_edges = f._fit_grid_from_centers(x, y, H, W)
+
+    assert _edges_ok(row_edges, col_edges, 8, 12, H, W)
+    assert row_edges[0] == pytest.approx(602.0, abs=2.0)
+    assert row_edges[-1] == pytest.approx(H, abs=2.0)
+    assert np.mean(np.diff(col_edges)) == pytest.approx(p_true, abs=2.0)


### PR DESCRIPTION
## Summary

Fix staged-GPU full-mode deliverables, recoverable SLURM finalization, and staged measurement identity regressions.

## Changes

- Publish overlay PNGs during local and SLURM Stage 3 under `deliverables/overlays/<dataset>/<stem>.png`.
- Propagate overlay alpha into SLURM workers and backfill missing overlays from completed HDF files during resume without rerunning GPU inference.
- Keep named staged jobs such as `stage2-round-1` out of numeric chunk metadata, and tolerate already-polluted live-run metadata during finalization.
- Preserve `MetadataImage_ImageName` across v2 HDF reloads and force the authoritative manifest stem before Stage 3 measurement.
- Repair existing UUID-valued per-image parquets from their source stems during finalization, including `$SCRATCH` staging, while safely falling back from corrupt dataset aggregates to retained individual parquets.

## Root causes covered

1. Staged full mode never invoked the normal overlay publication path.
2. Resume round labels shared a mapping that the manifest builder treated as integer chunk indexes.
3. The v2 HDF loader retained an `ImageName=None` constructor placeholder, so Stage 3 measured a fresh internal UUID instead of the original file stem.

## Validation

- Scoped Ruff checks passed on all changed files.
- Full affected overlay, staged worker, HDF round-trip, metadata source, metadata deliverable, CLI aggregation, dashboard, controller, finalizer, and checkpoint modules passed locally.
- Exact reported UUID/stem metadata join passed with simulated SLURM `$SCRATCH` staging.
- Independent reviews completed with no remaining actionable findings.
- A fresh full GitHub Actions matrix will be dispatched for the updated branch head.