### PR TITLE
Fix OperationFailedError pickling

### DIFF
--- a/src/phenotypic/sdk_/exceptions_.py
+++ b/src/phenotypic/sdk_/exceptions_.py
@@ -127,8 +127,19 @@ class OperationFailedError(ImageOperationError):
     """Exception raised when an operation fails."""
 
     def __init__(self, operation, image_name, err_type, message):
+        self.operation = operation
+        self.image_name = image_name
+        self.err_type = err_type
+        self.message = message
         super().__init__(
                 f"The operation: {operation} failed on _root_image: {image_name}. {err_type}: {message}."
+        )
+
+    def __reduce__(self):
+        """Return the constructor state needed to reconstruct this exception."""
+        return (
+            type(self),
+            (self.operation, self.image_name, self.err_type, self.message),
         )
 
 

--- a/tests/unit/sdk_/test_exceptions.py
+++ b/tests/unit/sdk_/test_exceptions.py
@@ -1,0 +1,25 @@
+"""Regression tests for exception transport across process boundaries."""
+
+from __future__ import annotations
+
+import pickle
+
+from phenotypic.sdk_.exceptions_ import OperationFailedError
+
+
+def test_operation_failed_error_pickle_round_trip_preserves_context() -> None:
+    """Pickling must retain every constructor argument and the rendered message."""
+    error = OperationFailedError(
+        operation="MeasureSize",
+        image_name="plate_001",
+        err_type=ValueError,
+        message="bad bins",
+    )
+
+    restored = pickle.loads(pickle.dumps(error))
+
+    assert restored.operation == "MeasureSize"
+    assert restored.image_name == "plate_001"
+    assert restored.err_type is ValueError
+    assert restored.message == "bad bins"
+    assert str(restored) == str(error)

--- a/tests/unit/util/test_local_executor.py
+++ b/tests/unit/util/test_local_executor.py
@@ -1,10 +1,22 @@
 from __future__ import annotations
 
+import pytest
+
 from phenotypic._execution import Executor, LocalExecutor
+from phenotypic.sdk_.exceptions_ import OperationFailedError
 
 
 def _square(x: int) -> int:
     return x * x
+
+
+def _raise_operation_failed_error(_: object) -> None:
+    raise OperationFailedError(
+        operation="MeasureSize",
+        image_name="plate_001",
+        err_type=ValueError,
+        message="bad bins",
+    )
 
 
 def test_local_executor_maps_in_order():
@@ -15,6 +27,18 @@ def test_local_executor_maps_in_order():
 def test_local_executor_parallel_results_ordered():
     ex = LocalExecutor(n_jobs=2)
     assert ex.run(_square, list(range(10))) == [i * i for i in range(10)]
+
+
+def test_local_executor_propagates_operation_failure_context():
+    ex = LocalExecutor(n_jobs=2)
+
+    with pytest.raises(OperationFailedError) as error:
+        ex.run(_raise_operation_failed_error, [None])
+
+    assert error.value.operation == "MeasureSize"
+    assert error.value.image_name == "plate_001"
+    assert error.value.err_type is ValueError
+    assert error.value.message == "bad bins"
 
 
 def test_local_executor_empty():


### PR DESCRIPTION
## Summary

Follow-up to #200.

Make `OperationFailedError` safely reconstructible after a measurement worker sends it across joblib's process boundary. The exception now retains its four constructor values and supplies them through `__reduce__`, while preserving the existing rendered message and call sites.

Without this, unpickling calls the four-argument constructor with only the single formatted string in `.args`, raising `TypeError` and replacing the original measurement failure with `BrokenProcessPool`.

## Validation

- `uv run ruff check --fix src/phenotypic/sdk_/exceptions_.py tests/unit/sdk_/test_exceptions.py tests/unit/util/test_local_executor.py`
- `uv run pytest -q tests/unit/core/test_pipeline_measurement_errors.py tests/unit/sdk_/test_exceptions.py tests/unit/util/test_local_executor.py` (8 passed)
- Independent subagent review: no actionable findings
