### PR TITLE
Restore Measurements reference URL

### DIFF
--- a/docs/source/_extensions/measurements_ref.py
+++ b/docs/source/_extensions/measurements_ref.py
@@ -1,13 +1,14 @@
 """Generate the two-page Measurements reference from the public schema.
 
-At ``builder-inited`` time, this extension discovers every public
+At ``config-inited`` time, before Sphinx discovers source files, this extension
+discovers every public
 ``phenotypic.schema.MeasurementInfo`` class and writes two deterministic pages:
 Measurements and Metadata. Each canonical class contributes one linked section
 heading and its measurement table. It also copies packaged measurement images
 into the docs static tree so ``/_static/measurements/...`` references resolve.
 
 The pages are regenerated on every build, so new public schema classes surface
-automatically. Do not edit generated ``measurements_ref/*.rst`` files by hand;
+automatically. Do not edit generated ``measurements_ref/**/index.rst`` files by hand;
 edit the source enums or this extension instead.
 """
 
@@ -87,7 +88,7 @@ def _build_reference_page(
                 ".. toctree::",
                 "   :hidden:",
                 "",
-                "   metadata/index",
+                "   ../metadata/index",
                 "",
             ]
         )
@@ -127,7 +128,7 @@ def _build_pages(srcdir: str) -> None:
         info_cls for info_cls in public_infos if info_cls not in metadata_infos
     )
     _write(
-        output_dir / "index.rst",
+        output_dir / "measurements" / "index.rst",
         _build_reference_page(
             "Measurements", measurement_infos, metadata_child=True
         ),
@@ -138,16 +139,16 @@ def _build_pages(srcdir: str) -> None:
     )
 
 
-def _generate(app):
+def _generate(app, _config):
     _copy_measurement_assets(app.srcdir)
     _build_pages(app.srcdir)
     print(f"Generated {os.path.join(app.srcdir, 'measurements_ref')}")
 
 
 def setup(app):
-    app.connect("builder-inited", _generate)
+    app.connect("config-inited", _generate)
     return {
-        "version": "0.3",
+        "version": "0.4",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/docs/source/_templates/navbar-nav.html
+++ b/docs/source/_templates/navbar-nav.html
@@ -79,7 +79,7 @@
       </button>
       <ul id="pst-nav-measurements" class="dropdown-menu">
         <li>
-          <a class="nav-link dropdown-item nav-internal{% if _pn == 'measurements_ref/index' or _pn.startswith('measurements_ref/measurements/') %} current active{% endif %}"
+          <a class="nav-link dropdown-item nav-internal{% if _pn.startswith('measurements_ref/measurements/') %} current active{% endif %}"
              href="{{ pathto('measurements_ref/measurements/index') }}">
             Measurements
           </a>

--- a/docs/source/explanation/measurement_classification_system.md
+++ b/docs/source/explanation/measurement_classification_system.md
@@ -57,5 +57,5 @@ A model fit on a primary phenotype is classified by its transformation:
 
 See also: [Measurement metrics and their biological meaning](measurement_metrics_biological_meaning.md)
 for per-metric detail, and the
-[measurement reference](../measurements_ref/index) for the Use/Tier badge on
+[measurement reference](../measurements_ref/measurements/index) for the Use/Tier badge on
 every column.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -68,7 +68,7 @@ started.
 
       +++
 
-      .. button-ref:: measurements_ref/index
+      .. button-ref:: measurements_ref/measurements/index
          :ref-type: doc
          :click-parent:
          :color: secondary
@@ -124,7 +124,7 @@ started.
    how_to/index
    explanation/index
    extending/index
-   measurements_ref/index
+   measurements_ref/measurements/index
    api_reference/index
    contrib_guide/index
    downloads

--- a/tests/unit/docs/test_measurements_ref_extension.py
+++ b/tests/unit/docs/test_measurements_ref_extension.py
@@ -73,7 +73,29 @@ def test_build_pages_creates_exactly_two_reference_pages(
         path.relative_to(docs_root).as_posix()
         for path in docs_root.rglob("*.rst")
     )
-    assert pages == ["index.rst", "metadata/index.rst"]
+    assert pages == ["measurements/index.rst", "metadata/index.rst"]
+
+
+def test_setup_generates_pages_before_sphinx_source_discovery(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    extension = _load_extension(monkeypatch)
+    callbacks: dict[str, Any] = {}
+
+    class FakeApp:
+        srcdir = str(tmp_path)
+
+        def connect(self, event: str, callback: Any) -> None:
+            callbacks[event] = callback
+
+    extension.setup(FakeApp())
+
+    assert set(callbacks) == {"config-inited"}
+    callbacks["config-inited"](FakeApp(), object())
+    docs_root = tmp_path / "measurements_ref"
+    assert (docs_root / "measurements" / "index.rst").is_file()
+    assert (docs_root / "metadata" / "index.rst").is_file()
 
 
 def test_measurements_page_has_metadata_as_its_only_toctree_child(
@@ -81,10 +103,10 @@ def test_measurements_page_has_metadata_as_its_only_toctree_child(
     monkeypatch: MonkeyPatch,
 ) -> None:
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
     metadata_page = (docs_root / "metadata" / "index.rst").read_text()
 
-    assert ".. toctree::\n   :hidden:\n\n   metadata/index" in measurements_page
+    assert ".. toctree::\n   :hidden:\n\n   ../metadata/index" in measurements_page
     assert ".. toctree::" not in metadata_page
 
 
@@ -93,7 +115,7 @@ def test_every_canonical_public_class_appears_once_on_the_correct_page(
     monkeypatch: MonkeyPatch,
 ) -> None:
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
     metadata_page = (docs_root / "metadata" / "index.rst").read_text()
     combined = measurements_page + metadata_page
 
@@ -120,7 +142,7 @@ def test_class_order_follows_schema_export_order(
     monkeypatch: MonkeyPatch,
 ) -> None:
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
     metadata_page = (docs_root / "metadata" / "index.rst").read_text()
 
     public_classes = _canonical_public_classes()
@@ -176,7 +198,7 @@ def test_future_classes_are_discovered_and_partitioned_automatically(
     )
 
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
     metadata_page = (docs_root / "metadata" / "index.rst").read_text()
 
     assert _class_heading("FUTURE_MEASUREMENT") in measurements_page
@@ -190,7 +212,7 @@ def test_compatibility_alias_is_deduplicated_to_canonical_class(
     monkeypatch: MonkeyPatch,
 ) -> None:
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
 
     assert measurements_page.count(
         _class_heading("ORIENTATION_ZONE_DIAGNOSTIC")
@@ -221,7 +243,7 @@ def test_generated_tables_escape_rst_markup(
     monkeypatch: MonkeyPatch,
 ) -> None:
     docs_root = _build_reference_tree(tmp_path, monkeypatch)
-    measurements_page = (docs_root / "index.rst").read_text()
+    measurements_page = (docs_root / "measurements" / "index.rst").read_text()
     metadata_page = (docs_root / "metadata" / "index.rst").read_text()
 
     assert ":mod:" not in metadata_page


### PR DESCRIPTION
## Summary

- Restore the published Measurements page at `/measurements_ref/measurements/index.html`.
- Keep the consolidated reference limited to the Measurements and Metadata pages.
- Update authored navigation and documentation links to the restored Measurements path.
- Generate the pages during `config-inited` so clean Sphinx builds discover them.

## Root cause

PR #204 moved the Measurements document to `/measurements_ref/index.html`, removing the existing public URL. The extension also generated its RST files during `builder-inited`, after Sphinx source discovery, which allowed clean builds to omit the generated pages.

## Impact

The existing Measurements URL works again, Metadata remains its only TOCTREE child, and automatically discovered `MeasurementInfo` class sections continue to link to their API reference pages and appear in the right-hand page contents.

## Validation

- `uv run pytest tests/unit/docs/test_measurements_ref_extension.py -q` (`10 passed`)
- `uv run ruff check --fix docs/source/_extensions/measurements_ref.py tests/unit/docs/test_measurements_ref_extension.py`
- Clean `uv run sphinx-build -E -n -b html docs/source <temporary-output>` completed successfully
- Inspected generated Measurements and Metadata HTML navigation, class links, and right-hand page contents
- Independent code review reported no actionable findings

Follow-up to #204.
