### PR TITLE
Remove orientation inspect explanation

### DIFF
--- a/src/phenotypic/measure/_measure_orientation_zones.py
+++ b/src/phenotypic/measure/_measure_orientation_zones.py
@@ -1857,40 +1857,6 @@ class MeasureOrientationZones(MeasureFeatures, PlotImage):
         self._add_zone_ring_traces(fig)
         self._add_mean_axis_traces(fig)
         self._add_metric_hover_trace(fig)
-        fig.add_annotation(
-                text=(
-                    "<b>Field:</b> short blue bars are local fiber axes "
-                    "(tensor normal + 90°); length and opacity encode local "
-                    "coherence C.<br>"
-                    "<b>Signed outward turning:</b> the Spectral overlay shows "
-                    "the full observed directional range in deg/px, centred at "
-                    "zero.<br>Negative is counterclockwise and positive is "
-                    "clockwise as growth moves outward. The inferred inoculum core is "
-                    "excluded from this directional view.<br>"
-                    "<b>Long range:</b> thin concentric circles sample the "
-                    f"{self.radial_ring_width:g} px Sholl-style orientation bands; "
-                    f"matching sectors {self.long_range_lag:g} px apart are compared "
-                    "in degrees.<br>Hover the circles or colony centres for "
-                    "ring and zone-to-zone summaries.<br>"
-                    "<b>Selectors:</b> circles bound the radial zones; toggle mean "
-                    "axes and the green detected-mask boundary.<br>"
-                    "<b>Metrics:</b> hover colony centres for R, turning, and C. "
-                    "R is common parallel alignment, not radial alignment.<br>Turning "
-                    "is the coherence-weighted spatial change in the local axis. "
-                    "Radial tilt compares each detected local axis with its outward "
-                    "spoke; outward turning measures how that tilt changes radially."
-                ),
-                xref="paper",
-                yref="paper",
-                x=0.0,
-                y=-0.19,
-                xanchor="left",
-                yanchor="top",
-                align="left",
-                showarrow=False,
-                font=dict(color=_OI_NAVY, size=11),
-        )
-        fig.update_layout(margin=dict(b=350))
         fig.update_xaxes(range=[-0.5, w - 0.5], constrain="domain")
         fig.update_yaxes(
                 range=[h - 0.5, -0.5],

--- a/tests/unit/measure/test_measure_orientation_zones.py
+++ b/tests/unit/measure/test_measure_orientation_zones.py
@@ -929,9 +929,8 @@ def test_inspect_builds_figure():
     fig = op.inspect(image)
     assert isinstance(fig, go.Figure)
     assert len(fig.data) > 0
-    annotation_text = {str(ann.text) for ann in fig.layout.annotations}
-    object_labels = {str(prop.label) for prop in image.objects.props}
-    assert annotation_text.isdisjoint(object_labels)
+    assert not fig.layout.annotations
+    assert fig.layout.margin.b is None
     assert not any(
         getattr(trace, "mode", None) == "text" for trace in fig.data
     )


### PR DESCRIPTION
## Summary

- remove the long explanatory annotation from `MeasureOrientationZones.inspect()`
- remove the associated 350 px bottom margin so the image is no longer compressed
- assert that the inspect figure contains no annotations or forced bottom margin

## Root cause

The annotation reserved most of the fixed-height Plotly canvas through a 350 px bottom margin. With the image axes constrained to equal pixel scaling, the remaining plot domain became very small and caused the image, colorbar, text, and legend to crowd one another.

## User impact

Orientation-zone inspection now displays the plot, overlays, colorbar, and legend without the overlapping explanatory block.

## Validation

- `uv run ruff check --fix src/phenotypic/measure/_measure_orientation_zones.py tests/unit/measure/test_measure_orientation_zones.py`
- `uv run pytest tests/unit/measure/test_measure_orientation_zones.py -k 'inspect_builds_figure'` (`1 passed, 52 deselected`)
