### PR TITLE
fix(cli): four silent data-loss defects in the SLURM chunked-run path

### DIFF
--- a/docs/superpowers/plans/2026-08-14-upstream-defect-fixes.md
+++ b/docs/superpowers/plans/2026-08-14-upstream-defect-fixes.md
@@ -1,0 +1,496 @@
+# Upstream Defect Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two confirmed CLI defects — macOS AppleDouble sidecar files counted
+as input images, and SLURM chunked runs silently dropping trailing images from
+`master_measurements`.
+
+**Architecture:** Both are discovery bugs with the same shape: a filter that
+admits something it should not, and an aggregation that reads a stale derived
+artifact instead of the source. Each fix is a small guard plus a regression test
+that reproduces the loss first.
+
+**Tech Stack:** Python 3.12, polars, pytest, `uv` as the sole runner.
+
+**Spec:** None — these originate as defect reports from
+`docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md` §3.3 and
+OQ-10, where both were found while validating that design against a real run at
+`/Volumes/T9/exfab/UCR-033-E-D_LinzerGanoderma/Results/frame00_discriminability`.
+Evidence for each is restated in its task.
+
+## Global Constraints
+
+- `uv` is the sole package manager and runner. Never bare `python` or `pip`.
+- `uv run ruff check --fix <paths you changed>` — **always pass explicit paths**.
+- Tests must be able to fail: reproduce each defect before fixing it, and record
+  the observed failure output in the commit.
+- Vendored reference sources under `docs/superpowers/specs/*/refs/` are read-only.
+- Do not modify the validation run at `/Volumes/T9/...` — it is read-only evidence.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `src/phenotypic/_cli/_cli_directory_scanner.py` | Input image discovery and counting | Modify — exclude dotfiles at 4 scan sites |
+| `tests/unit/cli/test_cli_directory_scanner_dotfiles.py` | Regression for defect 1 | Create |
+| `src/phenotypic/_cli/_cli_checkpoint_handler.py` | SLURM checkpoint/finalize entry points | Modify — flush unchunked parquets before final aggregation |
+| `tests/unit/cli/test_slurm_finalize_flushes_trailing.py` | Regression for defect 2 | Create |
+
+---
+
+## Task 1: Exclude AppleDouble and dotfiles from image discovery
+
+**Evidence.** `Path("._d000436_300_001.tif").suffix == ".tif"`, so the scanner's
+`p.suffix.lower() in valid_exts` filter admits macOS AppleDouble sidecars. On an
+exFAT volume macOS writes one beside every file. Observed on the validation run:
+`.phenotypic/progress/manifest.json` reports `total_images: 60` for 30 images,
+`completed: 30`, `pending: 30`, `is_complete: false` — on a run that finished
+successfully. Anything gating on `is_complete` misreads every such run as
+unfinished, including the GUI runs registry (`gui/shell/_runs_registry.py:631`)
+and the SLURM observer (`gui/run_console/_slurm_observer.py:1245`).
+
+**Files:**
+- Modify: `src/phenotypic/_cli/_cli_directory_scanner.py:78`, `:90`, `:283`, `:294`
+- Test: `tests/unit/cli/test_cli_directory_scanner_dotfiles.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `_is_image_file(p: Path, valid_exts: set[str]) -> bool` — the single
+  predicate all four sites call. Task 2 does not depend on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/cli/test_cli_directory_scanner_dotfiles.py`:
+
+```python
+"""AppleDouble sidecars must never be counted as input images.
+
+macOS writes a `._<name>` sidecar beside every file on exFAT/FAT volumes.
+`Path("._x.tif").suffix` is `".tif"`, so an extension-only filter admits them
+and every count doubles.
+"""
+from pathlib import Path
+
+from phenotypic._cli._cli_directory_scanner import (
+    scan_input_path,
+    count_images_by_dataset,
+)
+
+
+def _make_tree(root: Path) -> None:
+    """Two real images per dataset, each with an AppleDouble sidecar."""
+    for ds in ("plate_a", "plate_b"):
+        d = root / ds
+        d.mkdir(parents=True)
+        for stem in ("img_001", "img_002"):
+            (d / f"{stem}.tif").write_bytes(b"real")
+            (d / f"._{stem}.tif").write_bytes(b"\x00\x05\x16\x07")  # AppleDouble
+
+
+def test_scan_excludes_appledouble_sidecars(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    datasets = scan_input_path(tmp_path)
+    for name, images in datasets.items():
+        names = [p.name for p in images]
+        assert not any(n.startswith("._") for n in names), (
+            f"dataset {name} admitted AppleDouble sidecars: {names}"
+        )
+        assert len(images) == 2, f"dataset {name} has {len(images)} images, want 2"
+
+
+def test_count_excludes_appledouble_sidecars(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    counts = count_images_by_dataset(tmp_path)
+    assert sum(counts.values()) == 4, f"counted {counts}, want 2 per dataset"
+
+
+def test_dotfiles_generally_excluded(tmp_path: Path) -> None:
+    """.DS_Store and any other dotfile with an image extension are not inputs."""
+    d = tmp_path / "plate_a"
+    d.mkdir(parents=True)
+    (d / "img_001.tif").write_bytes(b"real")
+    (d / ".hidden.tif").write_bytes(b"nope")
+    datasets = scan_input_path(tmp_path)
+    images = next(iter(datasets.values()))
+    assert [p.name for p in images] == ["img_001.tif"]
+```
+
+- [ ] **Step 2: Run the test and confirm it fails for the right reason**
+
+```bash
+uv run pytest tests/unit/cli/test_cli_directory_scanner_dotfiles.py -v
+```
+
+Expected: `test_scan_excludes_appledouble_sidecars` and
+`test_count_excludes_appledouble_sidecars` FAIL with 4 images / count 8 rather
+than 2 / 4. If the import names are wrong, correct them from the module's
+actual public functions before proceeding — do not weaken the assertions.
+
+- [ ] **Step 3: Add the shared predicate**
+
+In `src/phenotypic/_cli/_cli_directory_scanner.py`, above the first use:
+
+```python
+def _is_image_file(path: Path, valid_exts: set[str]) -> bool:
+    """True for a real input image.
+
+    Excludes dotfiles: macOS writes an AppleDouble `._<name>` sidecar beside
+    every file on exFAT/FAT volumes, and `Path("._x.tif").suffix` is `".tif"`,
+    so an extension-only filter counts each image twice.
+    """
+    return (
+        path.is_file()
+        and not path.name.startswith(".")
+        and path.suffix.lower() in valid_exts
+    )
+```
+
+- [ ] **Step 4: Route all four scan sites through it**
+
+Replace at `:78`, `:90`, `:283`, `:294` — each currently reads
+`p.is_file() and p.suffix.lower() in valid_exts`:
+
+```python
+        if _is_image_file(p, valid_exts)
+```
+
+Leave `:62` (the single-file case) unchanged: passing a dotfile explicitly is a
+deliberate user act, not directory discovery, and rejecting it there would be a
+separate behaviour change.
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+uv run pytest tests/unit/cli/test_cli_directory_scanner_dotfiles.py -v
+uv run pytest tests/unit/cli -q
+```
+
+Expected: new tests PASS, existing CLI suite unchanged (505 passed, 1 skipped at
+baseline).
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check --fix src/phenotypic/_cli/_cli_directory_scanner.py tests/unit/cli/test_cli_directory_scanner_dotfiles.py
+git add src/phenotypic/_cli/_cli_directory_scanner.py tests/unit/cli/test_cli_directory_scanner_dotfiles.py
+git commit -m "fix(cli): exclude dotfiles from input image discovery
+
+macOS writes an AppleDouble ._<name> sidecar beside every file on
+exFAT/FAT volumes, and Path('._x.tif').suffix is '.tif', so the
+extension-only filter counted every image twice. Observed on a real run:
+manifest.json reported total_images 60 for 30 images, with
+is_complete false on a run that finished."
+```
+
+---
+
+## Task 2: Flush unchunked parquets before final SLURM aggregation
+
+**Evidence.** Three links, each verified in source:
+
+1. `_build_entry_list` (`_cli_slurm_array_scripts.py:51-60`) appends a checkpoint
+   sentinel only after every `checkpoint_interval` images, and emits **no
+   terminal sentinel** — its own docstring says "Terminal work is submitted as a
+   separate dependent lifecycle job."
+2. `_resolve_checkpoint_interval` (`:86-110`) clamps the interval to `[50, 500]`.
+3. `_run_finalize` (`_cli_checkpoint_handler.py:238-272`) calls
+   `aggregate_measurements` directly, with no chunk-write first. That resolves
+   sources via `discover_measurement_sources`
+   (`_measurement_sources.py:104-120`), which **prefers
+   `_dataset_aggregated.parquet` and skips the individual per-image parquets**.
+
+So on a SLURM run whose image count is not a multiple of the interval, the
+trailing `n_images % interval` images (up to 499) are written to disk as
+per-image parquets, never chunked into the aggregate, and then excluded from the
+master because aggregation reads the aggregate alone. The data is on disk; the
+published result silently omits it.
+
+**Fix:** flush before aggregating. `_scan_unchunked_parquets` already tracks
+which per-image parquets have been consumed, so the flush is idempotent and a
+no-op when the image count divides evenly.
+
+**Files:**
+- Modify: `src/phenotypic/_cli/_cli_checkpoint_handler.py` (in `_run_finalize`,
+  immediately before the `aggregate_measurements` call at `:267`)
+- Test: `tests/unit/cli/test_slurm_finalize_flushes_trailing.py`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: no new public symbol. Behaviour change only.
+
+- [ ] **Step 1: Read the two functions you will call**
+
+```bash
+uv run python -c "
+import inspect
+from phenotypic._cli import _cli_chunk_writer as m
+print(inspect.signature(m.aggregate_chunks))
+print(inspect.signature(m._scan_unchunked_parquets))
+"
+```
+
+Record the exact signatures — Step 3's call must match them. If
+`aggregate_chunks` is not the right entry point, use whichever function the
+checkpoint sentinel path invokes (trace from
+`_cli_checkpoint_handler.py`'s `--checkpoint-type checkpoint` branch).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/cli/test_slurm_finalize_flushes_trailing.py`:
+
+```python
+"""Trailing images must reach the master when the count is not a multiple
+of the SLURM checkpoint interval.
+
+Sentinels fire only every `checkpoint_interval` images and there is no
+terminal sentinel, so the last partial group is never chunked. Final
+aggregation prefers `_dataset_aggregated.parquet` over the individual
+per-image parquets, so those rows vanish from the published master.
+"""
+from pathlib import Path
+
+import polars as pl
+
+from phenotypic.sdk_ import dataset_measurements_dir
+from phenotypic._cli._cli_chunk_writer import aggregate_chunks
+
+
+DATASET = "plate_a"
+
+
+def _write_per_image(output_dir: Path, stems: list[str]) -> None:
+    d = dataset_measurements_dir(output_dir, DATASET)
+    d.mkdir(parents=True, exist_ok=True)
+    for i, stem in enumerate(stems):
+        pl.DataFrame(
+            {
+                "MetadataImage_ImageName": [stem],
+                "Object_Label": [1],
+                "Shape_Area": [float(i)],
+            }
+        ).write_parquet(d / f"{stem}.parquet")
+
+
+def test_trailing_images_reach_the_aggregate(tmp_path: Path) -> None:
+    """Chunk only the first 2 of 3 images, then aggregate: all 3 must appear."""
+    stems = ["img_001", "img_002", "img_003"]
+    _write_per_image(tmp_path, stems)
+
+    # Simulate a checkpoint that consumed only the first two images —
+    # the state a run leaves when 3 % interval != 0.
+    aggregate_chunks(tmp_path, [DATASET])  # consumes what exists so far
+
+    # A third image lands after the last checkpoint sentinel.
+    _write_per_image(tmp_path, ["img_004"])
+
+    from phenotypic._cli._cli_output_manager import aggregate_measurements
+
+    aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
+
+    from phenotypic.sdk_ import master_measurements_parquet_path
+
+    master = pl.read_parquet(master_measurements_parquet_path(tmp_path))
+    got = set(master["MetadataImage_ImageName"].to_list())
+    assert got == {"img_001", "img_002", "img_003", "img_004"}, (
+        f"master is missing trailing images: {sorted(got)}"
+    )
+```
+
+- [ ] **Step 3: Run it and record the failure**
+
+```bash
+uv run pytest tests/unit/cli/test_slurm_finalize_flushes_trailing.py -v
+```
+
+Expected: FAIL — `img_004` absent from the master. **Paste the actual assertion
+output into the commit message in Step 6.** If it passes, the defect does not
+reproduce this way: stop, and report what the aggregation actually did rather
+than adjusting the test until it fails.
+
+- [ ] **Step 4: Flush before aggregating**
+
+In `src/phenotypic/_cli/_cli_checkpoint_handler.py`, in `_run_finalize`,
+immediately before the `aggregate_measurements(` call:
+
+```python
+    # Flush any per-image parquets written after the last checkpoint sentinel.
+    # Sentinels fire every `checkpoint_interval` images and there is no terminal
+    # sentinel (_cli_slurm_array_scripts.py:51-60), so a run whose image count is
+    # not a multiple of the interval leaves up to interval-1 images unchunked.
+    # aggregate_measurements prefers _dataset_aggregated.parquet over the
+    # individual parquets, so without this flush those rows never reach the
+    # master. Idempotent: _scan_unchunked_parquets skips already-consumed files.
+    from ._cli_chunk_writer import aggregate_chunks
+
+    aggregate_chunks(output_dir, list(datasets_totals.keys()))
+    _check_epoch()
+```
+
+- [ ] **Step 5: Run the tests**
+
+```bash
+uv run pytest tests/unit/cli/test_slurm_finalize_flushes_trailing.py -v
+uv run pytest tests/unit/cli -q
+```
+
+Expected: new test PASSES, existing CLI suite unchanged.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+uv run ruff check --fix src/phenotypic/_cli/_cli_checkpoint_handler.py tests/unit/cli/test_slurm_finalize_flushes_trailing.py
+git add src/phenotypic/_cli/_cli_checkpoint_handler.py tests/unit/cli/test_slurm_finalize_flushes_trailing.py
+git commit -m "fix(cli): flush unchunked parquets before final SLURM aggregation
+
+Checkpoint sentinels fire every checkpoint_interval images (clamped to
+[50,500]) and there is no terminal sentinel, so a run whose image count
+is not a multiple of the interval leaves up to interval-1 images
+unchunked. Final aggregation resolves sources via
+discover_measurement_sources, which prefers _dataset_aggregated.parquet
+and skips the individual per-image parquets -- so those images were on
+disk but absent from the published master.
+
+Observed failure before the fix:
+<paste the Step 3 assertion output here>"
+```
+
+---
+
+## Task 3: Correct the monitor spec's now-stale typo claims
+
+**Why this is here.** The `MetadatasCondition` schema typo — recorded in the
+monitor spec as a live production defect and tracked as a third chip — was fixed
+upstream by the `origin/main` merge at `86d341b2f`. Verified in this worktree:
+`CONDITION_METADATA.category()` now returns `MetadataCondition`,
+`is_metadata_header("MetadataCondition_Media")` is `True`, and
+`ensure_metadata_prefix` no longer double-prefixes. The spec now asserts three
+things that are false, in a document whose whole value is that its claims were
+checked.
+
+**But the data outlives the fix.** The validated run's mirror still contains
+`Metadata_MetadataCondition_CarbonSource` and its four siblings, written before
+the fix. The monitor must still tolerate that shape, so the spec's test for it
+survives — with a different justification.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md`
+
+- [ ] **Step 1: Find every affected passage**
+
+```bash
+grep -n "MetadatasCondition\|MetadataCondition" docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md
+```
+
+- [ ] **Step 2: Correct the claims**
+
+Three changes, each keeping the evidence and dropping the falsehood:
+
+1. §3.2's warning that a hand-typed `MetadataCondition_Media` "matches nothing"
+   and gets double-prefixed — **now false**. Replace with a note that the typo
+   was fixed at `86d341b2f`, and that the discovery rule (never assume a column
+   name) is what made the design immune either way.
+2. §3.3.0.1's "the typo is present in production data" — **still true of the
+   data, no longer true of the code**. Reword to: data written before the fix
+   carries the double-prefixed columns, which is why the monitor reads column
+   names from the frame rather than constructing them.
+3. §1's "Out of scope: fixing the `MetadatasCondition` typo" and §15's
+   "Explicitly not changed" — remove; there is nothing left to fix.
+
+Keep test 24 (double-prefixed columns are usable) and restate its justification:
+it guards against old runs, not against a live bug.
+
+- [ ] **Step 3: Verify no stale claim survives**
+
+```bash
+uv run python -c "
+import re
+t = open('docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md').read()
+n = re.sub(r'\s+', ' ', t)
+for phrase in ['stray s', 'double-prefix', 'MetadatasCondition']:
+    print(f'{phrase!r}:', n.count(phrase))
+"
+```
+
+Every surviving mention must be historical (describing pre-fix data), not a
+claim about current code.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md
+git commit -m "docs(monitor): the MetadatasCondition typo was fixed upstream
+
+Fixed by the origin/main merge at 86d341b2f. The spec asserted three
+things that are now false. Data written before the fix still carries the
+double-prefixed columns, so the monitor must still tolerate that shape --
+test 24 survives, with staleness rather than a live bug as its reason."
+```
+
+---
+
+## Execution: dependency DAG and clustering
+
+Derived from each task's `Files`/`Interfaces` block (see
+`orchestration-clustering`). Recorded here because it is a version-controlled
+view of the plan, not separate state.
+
+```
+T1 scanner filter   ──┐
+T2 finalize flush   ──┼──  no edges between tasks; no shared files
+T3 spec correction  ──┘
+```
+
+| Task | Files | Shape | Executor | Model / effort |
+|---|---|---|---|---|
+| T2 | `_cli_checkpoint_handler.py` + its test | **Seam** — one risky wiring point between chunk-writing and aggregation, unverifiable without SLURM | subagent | frontier, high |
+| T1 | `_cli_directory_scanner.py` + its test | **Leaf** — one file, four mechanical sites, one trivial predicate | subagent | mid-tier, medium |
+| T3 | the monitor spec | **Leaf** — docs only | orchestrator | — |
+
+**Why T3 is not dispatched.** It is three surgical corrections to a 2200-line
+document whose context the orchestrator already holds. Dispatching would reload
+that context into a fresh agent to save nothing — the "repeated context loads"
+failure the clustering skill names.
+
+**Why sequential, not parallel.** T1 and T2 have zero file overlap and would
+otherwise be parallel-worktree candidates. They share one git index in this
+worktree, and two agents running `git add`/`git commit` concurrently can
+interleave. The wall-clock saving on two small fixes does not justify that risk
+on a defect branch.
+
+**Order:** T2 → gate → T1 → gate → T3 → deep review over the combined diff →
+simplify pass → regression run over `tests/unit/cli`.
+
+**Gates.** After each cluster: read the diff, run its test plus
+`uv run pytest tests/unit/cli -q`, confirm against the 505-passed/1-skipped
+baseline. After all three: a fresh code-review agent over the combined diff at
+frontier tier — never weaker than the implementer.
+
+---
+
+## Self-Review
+
+**Spec coverage.** No spec — the source is two defect reports plus one
+now-obsolete chip. Task 1 covers the AppleDouble miscount with its four scan
+sites. Task 2 covers the trailing-image loss at the finalize path. Task 3 closes
+the documentation debt the upstream fix created. The third chip needs no code.
+
+**Placeholders.** One deliberate: Step 6 of Task 2 says "paste the Step 3
+assertion output here". That is a real instruction with a real artifact, not a
+TBD — the commit must carry the observed failure, per the repo's test-integrity
+rule. Task 2 Step 1 asks the implementer to confirm two signatures before
+calling them, because the flush entry point is the one thing this plan could not
+verify without running a chunked SLURM job.
+
+**Type consistency.** `_is_image_file(path, valid_exts)` is defined in Task 1
+Step 3 and used in Step 4 with the same argument order. Task 2 introduces no new
+symbol. `aggregate_chunks(output_dir, dataset_names)` is used identically in the
+test and the fix, and Step 1 requires confirming that signature first.
+
+**Known risk.** Task 2's test simulates the checkpoint boundary by calling
+`aggregate_chunks` mid-stream rather than running SLURM. If the real loss
+mechanism differs from this simulation, Step 3 will pass instead of failing —
+the plan says to stop and report rather than adjust the test, because a test
+that cannot fail is worse than no test.

--- a/docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md
+++ b/docs/superpowers/specs/2026-08-13-streamlit-run-monitor-design.md
@@ -50,8 +50,6 @@ modified by this work beyond the extractions in Section 4.
 - Deep-zoom / DZI tiling.
 - Comparison across multiple runs in one view.
 - Editing or launching runs.
-- Fixing the `MetadatasCondition` schema typo (Section 3.2) — tracked
-  separately, because it renames a public column in written output.
 
 ---
 
@@ -224,7 +222,7 @@ identity columns. There is no back door: EXIF lands in
 This matters because every control in this dashboard is a CSV metadata column:
 
 - `MetadataGenetic_Strain` — the page selector
-- `MetadatasCondition_Media` — the default grouping
+- `MetadataCondition_Media` — the default grouping
 - `MetadataCulture_Time` — the x axis
 - `MetadataSample_BioReplicate` — the trace identity
 
@@ -246,14 +244,14 @@ image-intrinsic, not anything a user would group by.
 
 Where a schema enum *does* name a column the monitor needs structurally (the
 `point_id` triple, 4.2), derive it from the enum rather than a literal — that
-much of the old rule survives. The media column, for instance, is not
-`MetadataCondition_Media`: `CONDITION_METADATA.category()` returns
-`"MetadatasCondition"` with a stray `s` (`schema/_experimental_tags/_condition.py:20`),
-contradicting its own docstring and every sibling category. It is a pre-existing
-bug, tracked separately. A hand-typed `MetadataCondition_Media` matches nothing,
-and a user CSV column spelled that way is not recognised by `is_metadata_header`,
-so `join_metadata` double-prefixes it to `Metadata_MetadataCondition_Media`.
-Deriving from the enum sidesteps the bug and stays correct after it is fixed.
+much of the old rule survives. The discovery rule earned itself on exactly this: for most of this document's
+life `CONDITION_METADATA.category()` returned `"MetadatasCondition"` — a stray
+`s` no sibling category had — so a hand-typed `MetadataCondition_Media` matched
+nothing and a user CSV column spelled that way was double-prefixed by
+`join_metadata`. **That typo was fixed upstream at `86d341b2f`**; the category
+now returns `MetadataCondition` and `is_metadata_header` recognises it. The
+design needed no change when it was fixed, and would have needed none had it
+never been, which is the property discovery buys.
 
 **Resolution: the user chooses the CSV. The monitor does not infer it.**
 
@@ -573,7 +571,7 @@ why it joins `how="inner"`. Neither was hypothetical.
 ### 3.3.0.1 The schema defaults do not exist in real data
 
 `PlotColonyMetricOverTime` defaults `time` to `MetadataCulture_Time` and
-`groupby` to `[MetadatasCondition_Media]`. **Neither column exists in the
+`groupby` to `[MetadataCondition_Media]`. **Neither column exists in the
 validated run.** Its time axis is `MetadataCulture_AgeHours` (also
 `MetadataAcquisition_Datetime`, `MetadataCulture_StackedDatetime`), and its
 condition is decomposed across carbon source, nitrogen source and pH rather than
@@ -591,21 +589,23 @@ one is passed explicitly to
 to a missing column would fail at `_validate_input_columns`, which is the correct
 loud failure, but only after presenting the user a control that could never work.
 
-**The `MetadatasCondition` typo is present in production data, not just in
-theory.** The run's CSV uses the documented-correct spelling
-(`MetadataCondition_CarbonSource`, …). Because `category()` returns
-`"MetadatasCondition"`, `is_metadata_header` does not recognise those columns, so
-`ensure_metadata_prefix` double-prefixed every one of them:
+**Data written before the upstream fix carries mangled column names.** The
+`MetadatasCondition` typo was fixed at `86d341b2f`, but the validated run
+predates it: its CSV uses the documented-correct spelling
+(`MetadataCondition_CarbonSource`, …), and because `category()` then returned
+`"MetadatasCondition"`, `is_metadata_header` did not recognise those columns and
+`ensure_metadata_prefix` double-prefixed every one:
 
 ```
 CSV:    MetadataCondition_CarbonSource
 mirror: Metadata_MetadataCondition_CarbonSource
 ```
 
-A design reviewer predicted this exact failure from the code alone; the run
-confirms it reaches user data. It is still out of scope to fix here (renaming a
-public column), but the monitor must therefore treat metadata column names as
-**discovered, never assumed** — which the rule above already requires.
+A design reviewer predicted this failure from the code alone before any run
+confirmed it. **The cause is fixed; the data is not** — these columns persist in
+every mirror written before `86d341b2f`, so the monitor must still read column
+names from the frame rather than construct them. That is the same rule as above,
+now earning its keep against history rather than against a live bug.
 
 ### 3.3.1 What the monitor shows, and what it therefore is not
 
@@ -964,9 +964,9 @@ changing a `category()` — must consider this dashboard**, because every one of
 its controls is a metadata column.
 
 This is not defensive boilerplate. 3.3.0.1 records live instances: the
-`MetadatasCondition` category typo, which silently double-prefixes user CSV
-columns and reached production data; and three schema defaults
-(`MetadataCulture_Time`, `MetadatasCondition_Media`,
+`MetadatasCondition` category typo, which silently double-prefixed user CSV
+columns and reached production data before being fixed at `86d341b2f`; and three schema defaults
+(`MetadataCulture_Time`, `MetadataCondition_Media`,
 `MetadataSample_BioReplicate`) that do not exist in a real run, so a plot class
 defaulting to them presents controls that cannot work. Both originate in the
 schema and surface only in a consumer.
@@ -2012,7 +2012,7 @@ that almost nothing needs a browser.
 
 23. **No control relies on a schema default** — with a frame whose columns are
     those of the validated run (no `MetadataCulture_Time`, no
-    `MetadatasCondition_Media`), every control populates from the frame and the
+    `MetadataCondition_Media`), every control populates from the frame and the
     figure builds. Mutation: let `PlotColonyMetricOverTime`'s `time` or `groupby`
     default apply, which must fail at `_validate_input_columns`.
 24. **Double-prefixed metadata columns are usable** — a frame carrying
@@ -2230,13 +2230,13 @@ recorded coupling: `join_metadata` and `prepare_metadata_join_keys` (4.5).
 **New, in `apps/monitor/`:** seven modules, a `pyproject.toml` and a `Dockerfile`
 (Section 5).
 
-**Explicitly not changed:** the `MetadatasCondition` schema typo (3.2);
+**Explicitly not changed:**
 `OutputRoot`, which this design stopped depending on rather than modifying
 (3.5); and CLI completion-marker semantics, which an earlier revision proposed
 changing before 3.1.1 removed the need to detect completion at all.
 
-**Two out-of-scope defects surfaced during review** and are tracked separately:
-the `MetadatasCondition` typo, and a suspected loss of trailing images from
+**Two out-of-scope defects surfaced during review.** The `MetadatasCondition`
+typo has since been fixed upstream (`86d341b2f`). The other — a loss of trailing images from
 `master_measurements.*` on SLURM runs whose image count is not a multiple of the
 checkpoint interval. Neither is caused by this work; both were found by reading
 the data flow closely enough to design against it.

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -248,7 +248,11 @@ def _scan_unchunked_parquets(
         if not meas_dir.is_dir():
             continue
         for meas_file in sorted(meas_dir.glob("*.parquet")):
-            if meas_file.name.startswith("_"):
+            # `_` skips this writer's own `_dataset_aggregated.parquet`.
+            # `.` skips macOS AppleDouble sidecars, which exist beside every
+            # file on an exFAT/FAT volume and are binary, not parquet — the
+            # reader would raise on them.
+            if meas_file.name.startswith(("_", ".")):
                 continue
             rel_key = f"{dataset_dir.name}/{meas_file.name}"
             if rel_key not in chunked_files:

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -19,14 +19,14 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import click
 import polars as pl
 
 from ._cli_file_locking import file_lock
 from ._cli_utils import scan_parquets
-from phenotypic.schema import EXPERIMENT_METADATA, METADATA
+from phenotypic.schema import EXPERIMENT_METADATA, METADATA, OBJECT
 from phenotypic.sdk_ import (
     DIR_CHUNKS,
     CHUNK_STATE_JSON,
@@ -162,10 +162,6 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
         lambda p: chunk_df.write_parquet(p, **PARQUET_WRITE_OPTIONS),
     )
 
-    state[ChunkStateKey.CHUNKED_FILES] = sorted(chunked_files)
-    state[ChunkStateKey.NEXT_CHUNK_ID] = next_chunk_id + 1
-    _write_json(state, state_path)
-
     manifest_path = progress_dir / CHUNK_MANIFEST_JSON
     manifest = _read_json(
         manifest_path,
@@ -208,6 +204,23 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
 
     for ds_name, ds_df in chunk_df.group_by(str(EXPERIMENT_METADATA.DATASET)):
         _update_dataset_parquet(output_dir, str(ds_name[0]), ds_df)
+
+    # Commit the chunk state LAST, once every artifact it describes is durable.
+    # SLURM kills checkpoint tasks routinely -- walltime, preemption, node
+    # failure -- and this state is what tells later checkpoints (and the
+    # finalize-time flush) that a per-image parquet has been consumed. Written
+    # before `_update_dataset_parquet`, a kill in between would mark images
+    # consumed whose rows never reached the aggregate; since final aggregation
+    # prefers the aggregate they would never reach the master, and no flush
+    # could recover them because the state says there is nothing to flush.
+    #
+    # Committing last inverts the failure into a safe one: a kill now leaves
+    # images *unmarked* whose rows may already be in the aggregate, so the next
+    # pass re-chunks them -- harmless, because `_update_dataset_parquet`
+    # deduplicates on the colony key.
+    state[ChunkStateKey.CHUNKED_FILES] = sorted(chunked_files)
+    state[ChunkStateKey.NEXT_CHUNK_ID] = next_chunk_id + 1
+    _write_json(state, state_path)
 
     logger.info(
         "Chunk %s written: %d new files, %d rows (total: %d rows across %d chunks)",
@@ -371,6 +384,15 @@ def _rebuild_combined(chunks_dir: Path) -> pl.DataFrame | None:
 
 
 # ---------------------------------------------------------------------------
+#: Colony primary key -- one row per detected object per image per dataset,
+#: the grain of every per-image measurement parquet.
+_AGGREGATE_KEY: Final[tuple[str, ...]] = (
+    str(EXPERIMENT_METADATA.DATASET),
+    str(METADATA.IMAGE_NAME),
+    str(OBJECT.LABEL),
+)
+
+
 def _update_dataset_parquet(
     output_dir: Path, dataset_name: str, new_df: pl.DataFrame
 ) -> None:
@@ -394,6 +416,17 @@ def _update_dataset_parquet(
             new_df = pl.concat([prev, new_df], how="diagonal_relaxed")
         except Exception:
             logger.warning("Corrupt %s, rebuilding from new data", agg_path)
+
+    # Deduplicate on the colony key, keeping the later row. This makes the
+    # append idempotent, which is what lets `_aggregate_chunks_locked` commit
+    # its chunk state *after* the data: a task killed mid-write can safely
+    # re-chunk images whose rows already landed. It also collapses the
+    # duplicates a `--restart` produces, since `results/` survives a restart
+    # while its images are re-measured and appended over the old rows.
+    key = [c for c in _AGGREGATE_KEY if c in new_df.columns]
+    if key:
+        new_df = new_df.unique(subset=key, keep="last", maintain_order=True)
+
     atomic_write_with_writer(
         agg_path,
         lambda p: new_df.write_parquet(p, **PARQUET_WRITE_OPTIONS),

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -170,15 +170,22 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
     datasets_in_chunk = (
         chunk_df[str(EXPERIMENT_METADATA.DATASET)].unique().to_list()
     )
-    manifest[ChunkManifestKey.CHUNKS].append(
-        {
-            ChunkManifestKey.NAME: chunk_name,
-            ChunkManifestKey.ROWS: chunk_df.height,
-            ChunkManifestKey.DATASETS: sorted(
-                str(d) for d in datasets_in_chunk
-            ),
-        }
-    )
+    entry = {
+        ChunkManifestKey.NAME: chunk_name,
+        ChunkManifestKey.ROWS: chunk_df.height,
+        ChunkManifestKey.DATASETS: sorted(str(d) for d in datasets_in_chunk),
+    }
+    # Replace any entry for this chunk name rather than appending. Chunk state
+    # (including `next_chunk_id`) is committed last, so a killed task's retry
+    # regenerates the *same* chunk name — and an append would record it twice
+    # and double `total_rows`, which the dashboard reports as run progress.
+    existing = manifest[ChunkManifestKey.CHUNKS]
+    for index, chunk_entry in enumerate(existing):
+        if chunk_entry.get(ChunkManifestKey.NAME) == chunk_name:
+            existing[index] = entry
+            break
+    else:
+        existing.append(entry)
     manifest[ChunkManifestKey.TOTAL_ROWS] = sum(
         c[ChunkManifestKey.ROWS] for c in manifest[ChunkManifestKey.CHUNKS]
     )
@@ -188,6 +195,12 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
         chunk_df, analysis_full_parquet_path(progress_dir)
     )
     if combined is not None:
+        # Same idempotency requirement as the aggregate below: chunk state is
+        # committed last, so a killed task re-chunks images whose rows already
+        # reached these files. `_incremental_combined` is a bare concat, so
+        # without this the retry doubles every colony in the rolling master —
+        # the very artifact this module exists to publish mid-run.
+        combined = _dedupe_on_colony_key(combined, context="rolling master")
         atomic_write_with_writer(
             analysis_full_parquet_path(progress_dir),
             lambda p: combined.write_parquet(p, **PARQUET_WRITE_OPTIONS),
@@ -393,6 +406,43 @@ _AGGREGATE_KEY: Final[tuple[str, ...]] = (
 )
 
 
+def _dedupe_on_colony_key(
+    df: pl.DataFrame, *, context: str
+) -> pl.DataFrame:
+    """Collapse repeated colonies, keeping the later row.
+
+    This is what makes every retry-exposed write in this module idempotent, so
+    :func:`_aggregate_chunks_locked` can commit its chunk state *after* the
+    data: a task killed mid-write re-chunks images whose rows already landed,
+    and the second copy collapses into the first. It also absorbs the
+    duplicates a ``--restart`` produces, since ``results/`` survives a restart
+    while its images are re-measured and appended over the old rows.
+
+    **The full key is required.** An earlier revision filtered
+    :data:`_AGGREGATE_KEY` down to whichever columns happened to be present,
+    which looks defensive and is the opposite: without ``Object_Label`` the key
+    degrades to ``(dataset, image)`` and ``unique`` keeps exactly **one row per
+    image**, silently deleting every other colony in it. Nothing guarantees
+    that column — ``_read_and_concat`` only guarantees the dataset and image
+    columns — so a partial key is refused rather than applied. Skipping leaves
+    duplicate rows, which is recoverable and visible; dropping colonies is
+    neither.
+    """
+    missing = [c for c in _AGGREGATE_KEY if c not in df.columns]
+    if missing:
+        logger.warning(
+            "Skipping dedup of %s: frame lacks colony-key column(s) %s. "
+            "Repeated rows may survive; this is preferred to collapsing on a "
+            "partial key, which would drop real colonies.",
+            context,
+            missing,
+        )
+        return df
+    return df.unique(
+        subset=list(_AGGREGATE_KEY), keep="last", maintain_order=True
+    )
+
+
 def _update_dataset_parquet(
     output_dir: Path, dataset_name: str, new_df: pl.DataFrame
 ) -> None:
@@ -417,15 +467,7 @@ def _update_dataset_parquet(
         except Exception:
             logger.warning("Corrupt %s, rebuilding from new data", agg_path)
 
-    # Deduplicate on the colony key, keeping the later row. This makes the
-    # append idempotent, which is what lets `_aggregate_chunks_locked` commit
-    # its chunk state *after* the data: a task killed mid-write can safely
-    # re-chunk images whose rows already landed. It also collapses the
-    # duplicates a `--restart` produces, since `results/` survives a restart
-    # while its images are re-measured and appended over the old rows.
-    key = [c for c in _AGGREGATE_KEY if c in new_df.columns]
-    if key:
-        new_df = new_df.unique(subset=key, keep="last", maintain_order=True)
+    new_df = _dedupe_on_colony_key(new_df, context=f"aggregate for {dataset_name}")
 
     atomic_write_with_writer(
         agg_path,

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
 
 import click
 import polars as pl
@@ -145,7 +146,18 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
         logger.info("No new measurement files to chunk")
         return
 
-    chunk_df = _read_and_concat(new_files)
+    read = _read_and_concat(new_files)
+    if read.unreadable:
+        # ERROR and by name: these are user measurements. They are deliberately
+        # left out of `chunked_files` below, so the next checkpoint -- or the
+        # finalize-time flush -- retries them.
+        logger.error(
+            "Could not read %d per-image parquet(s); leaving them unchunked "
+            "for a later retry: %s",
+            len(read.unreadable),
+            ", ".join(read.unreadable),
+        )
+    chunk_df = read.frame
     if chunk_df is None:
         return
 
@@ -231,6 +243,10 @@ def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:
     # images *unmarked* whose rows may already be in the aggregate, so the next
     # pass re-chunks them -- harmless, because `_update_dataset_parquet`
     # deduplicates on the colony key.
+    #
+    # Only files that actually produced rows are recorded. `_scan_unchunked_
+    # parquets` deliberately does not mark on discovery.
+    chunked_files.update(_chunk_state_key(path) for path in read.consumed)
     state[ChunkStateKey.CHUNKED_FILES] = sorted(chunked_files)
     state[ChunkStateKey.NEXT_CHUNK_ID] = next_chunk_id + 1
     _write_json(state, state_path)
@@ -257,8 +273,12 @@ def _scan_unchunked_parquets(
 
     Args:
         results_dir: The ``results/`` directory containing dataset subdirs.
-        chunked_files: Set of relative keys already chunked (mutated in place
-            to include newly discovered files).
+        chunked_files: Relative keys already chunked. **Read only** — a file is
+            recorded as consumed by the caller once it has actually been read,
+            not on discovery. Marking here instead would consume a file the
+            reader then failed on, and since final aggregation prefers the
+            aggregate, a transient NFS/GPFS read error would silently drop
+            that image from the master for good.
 
     Returns:
         Sorted list of new measurement file paths.
@@ -280,12 +300,15 @@ def _scan_unchunked_parquets(
             # reader would raise on them.
             if meas_file.name.startswith(("_", ".")):
                 continue
-            rel_key = f"{dataset_dir.name}/{meas_file.name}"
-            if rel_key not in chunked_files:
+            if _chunk_state_key(meas_file) not in chunked_files:
                 new_files.append(meas_file)
-                chunked_files.add(rel_key)
 
     return new_files
+
+
+def _chunk_state_key(parquet_path: Path) -> str:
+    """The ``<dataset>/<file>.parquet`` key chunk state records."""
+    return f"{parquet_path.parent.parent.name}/{parquet_path.name}"
 
 
 def _attach_image_identity(
@@ -315,19 +338,53 @@ def _attach_image_identity(
     return df.with_columns(exprs)
 
 
-def _read_and_concat(parquet_files: list[Path]) -> pl.DataFrame | None:
-    """Read per-image Parquet files, ensure ``Metadata_Dataset``, and concat.
+class _ConcatResult(NamedTuple):
+    """What :func:`_read_and_concat` actually managed to read.
+
+    Attributes:
+        frame: The concatenated measurements, or ``None`` if nothing read.
+        consumed: The paths that contributed rows. **Only these may be
+            recorded in chunk state** — marking a file consumed that was never
+            read is what makes a read error permanent.
+        unreadable: ``"<name> (<reason>)"`` per file that could not be read.
+            Reported rather than skipped in silence, which is how a short
+            master goes unnoticed.
+    """
+
+    frame: pl.DataFrame | None
+    consumed: list[Path]
+    unreadable: list[str]
+
+
+def _read_and_concat(parquet_files: list[Path]) -> _ConcatResult:
+    """Read per-image Parquet files, normalize identity, and concat.
+
+    Each frame is normalized *before* concatenation: ``Metadata_ImageName`` is
+    set from the file stem, ``Metadata_FileSuffix`` is added when absent, and
+    ``Metadata_Dataset`` is injected from the directory when absent (a
+    ``--no-dataset-column`` run omits it).
+
+    Two of those three are colony-key columns, which is why every reader of
+    these files must go through here. Concatenating them raw and then
+    deduplicating on the colony key collapses unrelated colonies: without
+    ``Metadata_ImageName`` normalization every image shares one key value, so
+    ``unique`` keeps one row per ``Object_Label`` across the whole dataset.
 
     Args:
         parquet_files: Paths to per-image Parquet files.
 
     Returns:
-        Concatenated DataFrame, or ``None`` if no files could be read.
+        A :class:`_ConcatResult`; ``frame`` is ``None`` when no file read.
     """
     lazy_frames = scan_parquets(parquet_files)
-    if not lazy_frames:
-        return None
+    # `scan_parquets` omits what it could not scan rather than raising.
+    unreadable = [
+        f"{path.name} (could not be scanned)"
+        for path in parquet_files
+        if path not in lazy_frames
+    ]
     frames: list[pl.DataFrame] = []
+    consumed: list[Path] = []
     for pq_path, lf in lazy_frames.items():
         try:
             df = lf.collect()
@@ -341,11 +398,14 @@ def _read_and_concat(parquet_files: list[Path]) -> pl.DataFrame | None:
                     ),
                 )
             frames.append(df)
+            consumed.append(pq_path)
         except Exception as exc:
-            logger.warning("Failed to read %s: %s", pq_path, exc)
+            unreadable.append(f"{pq_path.name} ({exc})")
     if not frames:
-        return None
-    return pl.concat(frames, how="diagonal_relaxed")
+        return _ConcatResult(None, consumed, unreadable)
+    return _ConcatResult(
+        pl.concat(frames, how="diagonal_relaxed"), consumed, unreadable
+    )
 
 
 def _incremental_combined(
@@ -461,8 +521,22 @@ def _quarantine_corrupt_aggregate(agg_path: Path) -> Path | None:
             try:
                 agg_path.replace(candidate)
             except OSError as exc:
-                logger.error("Could not preserve %s: %s", agg_path, exc)
-                return None
+                # A rename within one directory cannot cross devices, but some
+                # network/FUSE mounts refuse rename-over regardless. Copy
+                # instead; the caller overwrites `agg_path` either way, so a
+                # copy preserves the same evidence.
+                try:
+                    shutil.copy2(agg_path, candidate)
+                except OSError as copy_exc:
+                    logger.error(
+                        "Could not preserve %s (rename: %s; copy: %s). The "
+                        "rebuilt aggregate will overwrite it and the "
+                        "unreadable bytes will be lost.",
+                        agg_path,
+                        exc,
+                        copy_exc,
+                    )
+                    return None
             return candidate
     logger.error(
         "Too many quarantined copies beside %s; leaving it in place", agg_path
@@ -476,21 +550,34 @@ def _rebuild_dataset_aggregate(
     """Re-derive an unreadable aggregate from the per-image parquets.
 
     The aggregate is a *cache* of ``results/<ds>/measurements/*.parquet``, so
-    the source of truth for rebuilding it sits in the same directory. Nothing
-    deletes those files. Two staged-GPU paths relocate some of them —
-    ``reconcile_stage3_publications`` (Stage 3 never completed) and
-    ``quarantine_unchanged_restart_parquets`` (stale epoch) — but both move
-    exactly the images slated for reprocessing, whose rows the aggregate
-    should not be carrying either. So the rebuild reflects what the directory
-    currently holds, which is the aggregate's contract.
+    the source of truth for rebuilding it sits in the same directory, and the
+    rebuild goes through :func:`_read_and_concat` — the same reader that built
+    the aggregate originally. Reading those files raw would *not* reproduce
+    it: the identity normalization lives in that reader, and two of the three
+    columns it fixes up are colony-key columns, so a raw re-read followed by
+    :func:`_dedupe_on_colony_key` collapses unrelated colonies rather than
+    restoring them.
+
+    Nothing deletes the per-image parquets. Two staged-GPU paths relocate some
+    of them — ``reconcile_stage3_publications`` (Stage 3 never completed) and
+    ``quarantine_unchanged_restart_parquets`` (stale epoch) — but neither can
+    co-occur with chunking: both are staged-GPU-only, and the staged
+    strategies never write the ``chunk_state.json`` that gates every entry
+    into this module. The two path sets being disjoint is what makes the
+    rebuild sound. Note that it is *not* sound in general — a healthy
+    aggregate is append-only and never drops a row when a per-image parquet
+    goes away, so do not read this as "the aggregate tracks the directory".
 
     An earlier revision logged "rebuilding from new data" here and then wrote
     only the incoming chunk, destroying every previously aggregated colony
     while chunk state still listed their sources as consumed. Nothing could
     recover them, and final aggregation publishes the master from this file.
 
-    Returns the rebuilt frame, or ``None`` when there is nothing to rebuild
-    from, in which case the caller writes the incoming chunk alone.
+    Returns the rebuilt frame, or ``None`` when nothing could be rebuilt, in
+    which case the caller writes the incoming chunk alone. That branch is
+    unreachable from the chunk path — the sources include the very files that
+    produced the incoming chunk, which were read moments earlier — so it is a
+    guard, not a designed behaviour.
     """
     logger.error(
         "Cannot read %s (%s); rebuilding it from the per-image parquets",
@@ -514,31 +601,24 @@ def _rebuild_dataset_aggregate(
         )
         return None
 
-    frames: list[pl.DataFrame] = []
-    unreadable: list[str] = []
-    for path in sources:
-        try:
-            frames.append(pl.read_parquet(path))
-        except Exception as exc:  # noqa: BLE001 - report and continue
-            unreadable.append(f"{path.name} ({exc})")
-    if unreadable:
+    rebuilt = _read_and_concat(sources)
+    if rebuilt.unreadable:
         logger.error(
-            "Rebuild of %s skipped %d unreadable per-image parquet(s): %s",
+            "Rebuild of %s could not read %d per-image parquet(s): %s",
             agg_path,
-            len(unreadable),
-            ", ".join(unreadable),
+            len(rebuilt.unreadable),
+            ", ".join(rebuilt.unreadable),
         )
-    if not frames:
+    if rebuilt.frame is None:
         return None
 
-    rebuilt = pl.concat(frames, how="diagonal_relaxed")
     logger.info(
-        "Rebuilt %s from %d per-image parquet(s): %d rows",
+        "Rebuilt %s from %d per-image parquet(s): %d rows before dedup",
         agg_path,
-        len(frames),
-        rebuilt.height,
+        len(rebuilt.consumed),
+        rebuilt.frame.height,
     )
-    return rebuilt
+    return rebuilt.frame
 
 
 def _update_dataset_parquet(

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -36,6 +36,7 @@ from phenotypic.sdk_ import (
     DIR_MEASUREMENTS,
     ChunkStateKey,
     ChunkManifestKey,
+    chunk_state_path,
     PARQUET_WRITE_OPTIONS,
     atomic_write_json,
     atomic_write_with_writer,
@@ -50,19 +51,23 @@ from phenotypic.sdk_ import (
 logger = logging.getLogger(__name__)
 
 
-@click.command()
-@click.option(
-    "--output-dir",
-    type=click.Path(exists=True, path_type=Path),
-    required=True,
-)
-def aggregate_chunks(output_dir: Path) -> None:
-    """Aggregate unchunked per-image measurement files into a dashboard chunk.
+def flush_unchunked_measurements(output_dir: Path) -> None:
+    """Chunk any per-image measurement files not yet consumed.
 
-    The entire read-scan-write cycle is serialised via an exclusive
-    file lock on ``progress/.chunk_lock`` so that concurrent checkpoint
-    tasks (SLURM may schedule multiple sentinels near-simultaneously)
-    do not race on the shared state files or duplicate data.
+    The plain-function form of :func:`aggregate_chunks`, so in-process callers
+    can flush without going through click. The SLURM finalize path
+    (``_cli_checkpoint_handler._run_finalize``) uses it: checkpoint sentinels
+    fire only every ``checkpoint_interval`` images and no terminal sentinel is
+    emitted, so a run whose image count is not a multiple of the interval
+    leaves its last partial group unchunked.
+
+    Idempotent — :func:`_scan_unchunked_parquets` skips files already recorded
+    in the chunk state, so a run that divides evenly flushes nothing.
+
+    The entire read-scan-write cycle is serialised via an exclusive file lock
+    on ``progress/.chunk_lock`` so that concurrent checkpoint tasks (SLURM may
+    schedule multiple sentinels near-simultaneously) do not race on the shared
+    state files or duplicate data.
     """
     progress_dir = progress_dir_helper(output_dir)
     progress_dir.mkdir(parents=True, exist_ok=True)
@@ -73,6 +78,48 @@ def aggregate_chunks(output_dir: Path) -> None:
     with open(lock_path, "r") as lock_fh:
         with file_lock(lock_fh, shared=False, timeout=120.0):
             _aggregate_chunks_locked(output_dir, progress_dir)
+
+
+def flush_trailing_measurements_if_chunked(output_dir: Path) -> None:
+    """Flush trailing per-image parquets, but only for runs that were chunked.
+
+    Guards :func:`flush_unchunked_measurements` on the presence of chunk state,
+    which is what distinguishes the two aggregation regimes:
+
+    * A **chunked** run (SLURM) publishes its master from
+      ``_dataset_aggregated.parquet``, because
+      ``discover_measurement_sources`` prefers the aggregate and skips the
+      individual per-image parquets. Any image not yet chunked is therefore
+      invisible to aggregation — and checkpoint sentinels fire only every
+      ``checkpoint_interval`` images with no terminal sentinel, so the last
+      partial group is always in that state. Flushing first is what makes the
+      master complete.
+    * An **unchunked** run (local, staged-local) has no aggregate, so
+      aggregation already reads every per-image parquet directly. Flushing
+      would only manufacture chunk artifacts the run never had, so it is
+      skipped.
+
+    Without the guard this would change local runs' output layout to fix a bug
+    they do not have.
+    """
+    if not chunk_state_path(output_dir).is_file():
+        return
+    flush_unchunked_measurements(output_dir)
+
+
+@click.command()
+@click.option(
+    "--output-dir",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+)
+def aggregate_chunks(output_dir: Path) -> None:
+    """Aggregate unchunked per-image measurement files into a dashboard chunk.
+
+    The checkpoint-sentinel entry point. See
+    :func:`flush_unchunked_measurements` for the behaviour and its locking.
+    """
+    flush_unchunked_measurements(output_dir)
 
 
 def _aggregate_chunks_locked(output_dir: Path, progress_dir: Path) -> None:

--- a/src/phenotypic/_cli/_cli_chunk_writer.py
+++ b/src/phenotypic/_cli/_cli_chunk_writer.py
@@ -443,6 +443,104 @@ def _dedupe_on_colony_key(
     )
 
 
+def _quarantine_corrupt_aggregate(agg_path: Path) -> Path | None:
+    """Move an unreadable aggregate aside, returning where it went.
+
+    Preserves the bytes for diagnosis instead of overwriting them: a file that
+    cannot be read is evidence, and this is the only place that would notice.
+    The quarantined name keeps the ``_`` prefix so neither
+    :func:`_scan_unchunked_parquets` nor ``discover_measurement_sources`` can
+    re-ingest it as a per-image measurement source. Numbered rather than fixed
+    so a second corruption cannot clobber the first.
+    """
+    for index in range(1, 1000):
+        candidate = agg_path.with_name(
+            f"{agg_path.stem}.corrupt{index}{agg_path.suffix}"
+        )
+        if not candidate.exists():
+            try:
+                agg_path.replace(candidate)
+            except OSError as exc:
+                logger.error("Could not preserve %s: %s", agg_path, exc)
+                return None
+            return candidate
+    logger.error(
+        "Too many quarantined copies beside %s; leaving it in place", agg_path
+    )
+    return None
+
+
+def _rebuild_dataset_aggregate(
+    agg_path: Path, read_error: Exception
+) -> pl.DataFrame | None:
+    """Re-derive an unreadable aggregate from the per-image parquets.
+
+    The aggregate is a *cache* of ``results/<ds>/measurements/*.parquet``, so
+    the source of truth for rebuilding it sits in the same directory. Nothing
+    deletes those files. Two staged-GPU paths relocate some of them —
+    ``reconcile_stage3_publications`` (Stage 3 never completed) and
+    ``quarantine_unchanged_restart_parquets`` (stale epoch) — but both move
+    exactly the images slated for reprocessing, whose rows the aggregate
+    should not be carrying either. So the rebuild reflects what the directory
+    currently holds, which is the aggregate's contract.
+
+    An earlier revision logged "rebuilding from new data" here and then wrote
+    only the incoming chunk, destroying every previously aggregated colony
+    while chunk state still listed their sources as consumed. Nothing could
+    recover them, and final aggregation publishes the master from this file.
+
+    Returns the rebuilt frame, or ``None`` when there is nothing to rebuild
+    from, in which case the caller writes the incoming chunk alone.
+    """
+    logger.error(
+        "Cannot read %s (%s); rebuilding it from the per-image parquets",
+        agg_path,
+        read_error,
+    )
+    quarantined = _quarantine_corrupt_aggregate(agg_path)
+    if quarantined is not None:
+        logger.error("Preserved the unreadable file at %s", quarantined)
+
+    sources = [
+        path
+        for path in sorted(agg_path.parent.glob("*.parquet"))
+        if not path.name.startswith(("_", "."))
+    ]
+    if not sources:
+        logger.error(
+            "No per-image parquets under %s to rebuild from; the aggregate "
+            "will contain only the incoming chunk",
+            agg_path.parent,
+        )
+        return None
+
+    frames: list[pl.DataFrame] = []
+    unreadable: list[str] = []
+    for path in sources:
+        try:
+            frames.append(pl.read_parquet(path))
+        except Exception as exc:  # noqa: BLE001 - report and continue
+            unreadable.append(f"{path.name} ({exc})")
+    if unreadable:
+        logger.error(
+            "Rebuild of %s skipped %d unreadable per-image parquet(s): %s",
+            agg_path,
+            len(unreadable),
+            ", ".join(unreadable),
+        )
+    if not frames:
+        return None
+
+    rebuilt = pl.concat(frames, how="diagonal_relaxed")
+    logger.info(
+        "Rebuilt %s from %d per-image parquet(s): %d rows",
+        agg_path,
+        len(frames),
+        rebuilt.height,
+    )
+    return rebuilt
+
+
 def _update_dataset_parquet(
     output_dir: Path, dataset_name: str, new_df: pl.DataFrame
 ) -> None:
@@ -464,8 +562,10 @@ def _update_dataset_parquet(
         try:
             prev = pl.read_parquet(agg_path)
             new_df = pl.concat([prev, new_df], how="diagonal_relaxed")
-        except Exception:
-            logger.warning("Corrupt %s, rebuilding from new data", agg_path)
+        except Exception as exc:
+            rebuilt = _rebuild_dataset_aggregate(agg_path, exc)
+            if rebuilt is not None:
+                new_df = pl.concat([rebuilt, new_df], how="diagonal_relaxed")
 
     new_df = _dedupe_on_colony_key(new_df, context=f"aggregate for {dataset_name}")
 

--- a/src/phenotypic/_cli/_cli_directory_scanner.py
+++ b/src/phenotypic/_cli/_cli_directory_scanner.py
@@ -15,6 +15,24 @@ from phenotypic.sdk_ import default_output_dir_name, DIR_RESULTS, DIR_HDF
 from ._cli_types import Dataset
 
 
+def _is_image_file(path: Path, valid_exts: set[str]) -> bool:
+    """True if ``path`` is a real input image.
+
+    Dotfiles are excluded, which an extension-only test does not do. macOS
+    writes an AppleDouble ``._<name>`` sidecar beside every file on exFAT/FAT
+    volumes — the usual format for an external drive — and
+    ``Path("._x.tif").suffix`` is ``".tif"``, so each image would be counted
+    twice. Observed on a real run: ``manifest.json`` reported
+    ``total_images: 60`` for 30 images and ``is_complete: false`` on a run that
+    had finished, which anything gating on completion reads as still running.
+    """
+    return (
+        path.is_file()
+        and not path.name.startswith(".")
+        and path.suffix.lower() in valid_exts
+    )
+
+
 def generate_timestamped_output_dir() -> Path:
     """
     Generate timestamped output directory name.
@@ -75,7 +93,7 @@ def scan_directory_structure(input_path: Path) -> Dict[str, List[Path]]:
     # Collect images directly in root directory
     root_images = [
         p for p in input_path.iterdir()
-        if p.is_file() and p.suffix.lower() in valid_exts
+        if _is_image_file(p, valid_exts)
     ]
 
     # Scan one level of subdirectories
@@ -87,7 +105,7 @@ def scan_directory_structure(input_path: Path) -> Dict[str, List[Path]]:
         # Collect images in this subdirectory
         sub_images = [
             p for p in subdir.iterdir()
-            if p.is_file() and p.suffix.lower() in valid_exts
+            if _is_image_file(p, valid_exts)
         ]
 
         if sub_images:
@@ -280,7 +298,7 @@ def get_input_structure_summary(input_path: Path) -> Dict[str, Any]:
     # Count root images
     root_count = sum(
             1 for p in input_path.iterdir()
-            if p.is_file() and p.suffix.lower() in valid_exts
+            if _is_image_file(p, valid_exts)
     )
 
     # Count subdirectory images
@@ -291,7 +309,7 @@ def get_input_structure_summary(input_path: Path) -> Dict[str, Any]:
 
         sub_count = sum(
                 1 for p in subdir.iterdir()
-                if p.is_file() and p.suffix.lower() in valid_exts
+                if _is_image_file(p, valid_exts)
         )
 
         if sub_count > 0:

--- a/src/phenotypic/_cli/_cli_directory_scanner.py
+++ b/src/phenotypic/_cli/_cli_directory_scanner.py
@@ -210,7 +210,13 @@ def scan_hdf_outputs(output_dir: Path) -> List[Dataset]:
             if not hdf_dir.is_dir():
                 continue
 
-            hdf_files = sorted(hdf_dir.glob("*.h5"))
+            # Skip dotfiles: on an exFAT/FAT volume macOS leaves an
+            # AppleDouble `._<name>.h5` beside every HDF, and it is binary
+            # junk, not an HDF — `--mode measure` on such a tree would try to
+            # load it.
+            hdf_files = sorted(
+                p for p in hdf_dir.glob("*.h5") if not p.name.startswith(".")
+            )
             if not hdf_files:
                 continue
 

--- a/src/phenotypic/_cli/_cli_output_manager.py
+++ b/src/phenotypic/_cli/_cli_output_manager.py
@@ -1259,6 +1259,16 @@ def aggregate_measurements(
         pipeline has any :class:`PostMeasurement` op configured. Split
         and analysis failures never change the return value.
     """
+    # Chunked (SLURM) runs publish from `_dataset_aggregated.parquet`, which
+    # `discover_measurement_sources` prefers over the individual per-image
+    # parquets. Checkpoint sentinels fire only every `checkpoint_interval`
+    # images and no terminal sentinel is emitted, so the last partial group is
+    # never chunked and would be silently absent from the master. Flush it
+    # first. No-op for unchunked runs and for evenly-divided ones.
+    from ._cli_chunk_writer import flush_trailing_measurements_if_chunked
+
+    flush_trailing_measurements_if_chunked(output_dir)
+
     path_to_dataset = measurement_sources_by_path(
         discover_measurement_sources(output_dir, dataset_names)
     )

--- a/src/phenotypic/_cli/_cli_recompile_slurm_scripts.py
+++ b/src/phenotypic/_cli/_cli_recompile_slurm_scripts.py
@@ -55,6 +55,20 @@ def build_recompile_tasks(
     """
     output_dir = Path(output_dir)
     shard_size = max(1, int(shard_size))
+
+    # Flush trailing per-image parquets before resolving shards. This path
+    # never reaches `aggregate_measurements` — the recompile worker
+    # concatenates the shards itself — so without the flush,
+    # `discover_measurement_sources` returns `_dataset_aggregated.parquet`
+    # alone and any image left unchunked by the last checkpoint sentinel is
+    # dropped from the rebuilt master. That would silently defeat the very
+    # command a user runs to recover from a short master, and would make
+    # `--mode recompile` disagree with `--mode recompile --slurm` on the same
+    # directory. No-op for unchunked runs and evenly-divided ones.
+    from ._cli_chunk_writer import flush_trailing_measurements_if_chunked
+
+    flush_trailing_measurements_if_chunked(output_dir)
+
     tasks: list[dict[str, Any]] = []
     shard_id = 0
 

--- a/src/phenotypic/_cli/_measurement_sources.py
+++ b/src/phenotypic/_cli/_measurement_sources.py
@@ -94,7 +94,11 @@ def discover_measurement_sources(
         individual_paths = [
             path
             for path in sorted(meas_dir.glob("*.parquet"))
-            if not path.name.startswith("_")
+            # `_` skips `_dataset_aggregated.parquet`; `.` skips macOS
+            # AppleDouble sidecars, which are binary and would force
+            # `aggregate_parquet_files` off its fast multi-path read onto the
+            # per-file fallback for the whole dataset.
+            if not path.name.startswith(("_", "."))
         ]
         aggregated = meas_dir / DATASET_AGGREGATED_PARQUET
         aggregate_needs_recovery = (

--- a/tests/unit/cli/test_chunk_writer_crash_safety.py
+++ b/tests/unit/cli/test_chunk_writer_crash_safety.py
@@ -27,6 +27,7 @@ from phenotypic.sdk_ import (
     CHUNK_MANIFEST_JSON,
     DATASET_AGGREGATED_PARQUET,
     ChunkManifestKey,
+    chunk_state_path,
     dataset_measurements_dir,
     master_measurements_parquet_path,
     progress_dir,
@@ -35,28 +36,56 @@ from phenotypic.sdk_ import (
 DATASET = "plate_a"
 
 
-def _write_per_image(output_dir: Path, stems: list[str]) -> None:
-    meas_dir = dataset_measurements_dir(output_dir, DATASET)
+def _write_per_image(
+    output_dir: Path,
+    stems: list[str],
+    *,
+    dataset: str = DATASET,
+    colonies: int = 1,
+    dataset_column: bool = True,
+    name_column: str | None = "stem",
+) -> None:
+    """Write per-image parquets in a chosen on-disk shape.
+
+    The shape matters. Per-image parquets do not all carry the colony-key
+    columns: ``--no-dataset-column`` omits ``Metadata_Dataset``, and
+    ``Metadata_ImageName`` can be absent or hold a UUID (``Image.name`` falls
+    back to ``str(self.uuid)``). The chunk writer's reader normalizes all
+    three, so a test helper that only ever writes the already-normalized
+    shape cannot see a reader that skips normalization.
+
+    Args:
+        dataset_column: Emit ``Metadata_Dataset``.
+        name_column: ``"stem"`` writes the file stem, ``"uuid"`` writes a
+            per-image UUID-shaped value, ``None`` omits the column.
+    """
+    meas_dir = dataset_measurements_dir(output_dir, dataset)
     meas_dir.mkdir(parents=True, exist_ok=True)
     for i, stem in enumerate(stems):
-        pl.DataFrame(
-            {
-                str(EXPERIMENT_METADATA.DATASET): [DATASET],
-                str(METADATA.IMAGE_NAME): [stem],
-                str(OBJECT.LABEL): [1],
-                "Shape_Area": [float(i + 1)],
-            }
-        ).write_parquet(meas_dir / f"{stem}.parquet")
+        columns: dict[str, list[object]] = {}
+        if dataset_column:
+            columns[str(EXPERIMENT_METADATA.DATASET)] = [dataset] * colonies
+        if name_column == "stem":
+            columns[str(METADATA.IMAGE_NAME)] = [stem] * colonies
+        elif name_column == "uuid":
+            columns[str(METADATA.IMAGE_NAME)] = [
+                f"3f2b7c1a-0000-4000-8000-{i:012d}"
+            ] * colonies
+        columns[str(OBJECT.LABEL)] = list(range(1, colonies + 1))
+        columns["Shape_Area"] = [float(i + 1)] * colonies
+        pl.DataFrame(columns).write_parquet(meas_dir / f"{stem}.parquet")
 
 
-def _aggregate_image_names(output_dir: Path) -> list[str]:
-    agg = (
-        dataset_measurements_dir(output_dir, DATASET)
-        / DATASET_AGGREGATED_PARQUET
-    )
-    if not agg.is_file():
+def _aggregate(output_dir: Path, dataset: str = DATASET) -> pl.DataFrame | None:
+    agg = dataset_measurements_dir(output_dir, dataset) / DATASET_AGGREGATED_PARQUET
+    return pl.read_parquet(agg) if agg.is_file() else None
+
+
+def _aggregate_image_names(output_dir: Path, dataset: str = DATASET) -> list[str]:
+    agg = _aggregate(output_dir, dataset)
+    if agg is None:
         return []
-    return pl.read_parquet(agg)[str(METADATA.IMAGE_NAME)].to_list()
+    return agg[str(METADATA.IMAGE_NAME)].to_list()
 
 
 def test_kill_before_aggregate_write_does_not_lose_images(
@@ -159,7 +188,18 @@ def test_dedup_is_skipped_when_the_colony_key_is_incomplete(
     )
 
 
-def test_corrupt_aggregate_is_rebuilt_not_discarded(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "dataset_column, name_column",
+    [
+        pytest.param(True, "stem", id="normalized"),
+        pytest.param(False, "stem", id="no-dataset-column"),
+        pytest.param(True, None, id="no-image-name"),
+        pytest.param(True, "uuid", id="uuid-image-name"),
+    ],
+)
+def test_corrupt_aggregate_is_rebuilt_not_discarded(
+    tmp_path: Path, dataset_column: bool, name_column: str | None
+) -> None:
     """An unreadable aggregate must be rebuilt from its source, not replaced.
 
     The aggregate is a cache of ``results/<ds>/measurements/*.parquet``. When it
@@ -167,10 +207,26 @@ def test_corrupt_aggregate_is_rebuilt_not_discarded(tmp_path: Path) -> None:
     aggregated colony — and chunk state still lists those sources as consumed,
     so no later flush recovers them. Since final aggregation publishes the
     master from this file, those colonies never reach the user.
+
+    Parametrized over the on-disk shapes because the rebuild must go through
+    the same identity normalization that built the aggregate. Reading the
+    per-image parquets raw looks equivalent and is not: two of the three
+    columns the reader fixes up are colony-key columns, so a raw re-read
+    followed by dedup collapses unrelated colonies instead of restoring them
+    — silently, since the rebuild's own row count is taken before the dedup.
     """
-    _write_per_image(tmp_path, ["img_001", "img_002"])
+    _write_per_image(
+        tmp_path,
+        ["img_001", "img_002"],
+        colonies=2,
+        dataset_column=dataset_column,
+        name_column=name_column,
+    )
     flush_unchunked_measurements(tmp_path)
-    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"]
+    assert sorted(set(_aggregate_image_names(tmp_path))) == [
+        "img_001",
+        "img_002",
+    ]
 
     agg_path = (
         dataset_measurements_dir(tmp_path, DATASET) / DATASET_AGGREGATED_PARQUET
@@ -178,14 +234,29 @@ def test_corrupt_aggregate_is_rebuilt_not_discarded(tmp_path: Path) -> None:
     agg_path.write_bytes(b"not a parquet file at all")
 
     # A later checkpoint brings one new image.
-    _write_per_image(tmp_path, ["img_003"])
+    _write_per_image(
+        tmp_path,
+        ["img_003"],
+        colonies=2,
+        dataset_column=dataset_column,
+        name_column=name_column,
+    )
     flush_unchunked_measurements(tmp_path)
 
-    assert sorted(_aggregate_image_names(tmp_path)) == [
+    rebuilt = _aggregate(tmp_path)
+    assert rebuilt is not None
+    assert sorted(set(_aggregate_image_names(tmp_path))) == [
         "img_001",
         "img_002",
         "img_003",
     ], "prior colonies were discarded instead of rebuilt from the per-image parquets"
+    assert rebuilt.height == 6, (
+        f"expected 3 images x 2 colonies, got {rebuilt.height} rows — the "
+        f"rebuild dropped or duplicated colonies"
+    )
+    assert (
+        rebuilt[str(EXPERIMENT_METADATA.DATASET)].null_count() == 0
+    ), "rebuild left Metadata_Dataset null, breaking dedup across the boundary"
 
 
 def test_corrupt_aggregate_is_preserved_for_diagnosis(tmp_path: Path) -> None:
@@ -199,13 +270,117 @@ def test_corrupt_aggregate_is_preserved_for_diagnosis(tmp_path: Path) -> None:
     _write_per_image(tmp_path, ["img_002"])
     flush_unchunked_measurements(tmp_path)
 
-    preserved = list(meas_dir.glob("*corrupt*"))
-    assert preserved, f"corrupt aggregate was overwritten: {list(meas_dir.iterdir())}"
-    assert preserved[0].read_bytes() == b"corrupt bytes"
-    # Must not be re-ingested as a measurement source on a later pass.
-    assert preserved[0].name.startswith("_"), (
-        f"{preserved[0].name} would be globbed as a per-image parquet"
+    # Assert the exact name, not a glob match: it pins the numbering the
+    # docstring promises, and the `_` prefix is what keeps the file out of
+    # `_scan_unchunked_parquets` and `discover_measurement_sources`.
+    preserved = meas_dir / "_dataset_aggregated.corrupt1.parquet"
+    assert preserved.is_file(), (
+        f"corrupt aggregate was overwritten: {sorted(p.name for p in meas_dir.iterdir())}"
     )
+    assert preserved.read_bytes() == b"corrupt bytes"
+
+
+def test_quarantine_falls_back_to_copy_when_rename_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mount that refuses rename-over must not cost us the evidence.
+
+    The caller overwrites the aggregate either way, so if the rename fails and
+    nothing else happens, the unreadable bytes are gone — on exactly the
+    network filesystems (GPFS, NFS, FUSE) whose torn writes produce them.
+    """
+    _write_per_image(tmp_path, ["img_001"])
+    flush_unchunked_measurements(tmp_path)
+
+    meas_dir = dataset_measurements_dir(tmp_path, DATASET)
+    (meas_dir / DATASET_AGGREGATED_PARQUET).write_bytes(b"corrupt bytes")
+
+    real_replace = Path.replace
+
+    def refuse_quarantine_rename(self: Path, target: object) -> Path:
+        if "corrupt" in Path(str(target)).name:
+            raise OSError("simulated rename-over refusal")
+        return real_replace(self, target)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "replace", refuse_quarantine_rename)
+
+    _write_per_image(tmp_path, ["img_002"])
+    flush_unchunked_measurements(tmp_path)
+    monkeypatch.undo()
+
+    preserved = meas_dir / "_dataset_aggregated.corrupt1.parquet"
+    assert preserved.is_file(), "rename failed and the bytes were not copied aside"
+    assert preserved.read_bytes() == b"corrupt bytes"
+    # The rebuild must still have happened.
+    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"]
+
+
+def test_corrupt_aggregate_recovery_is_scoped_to_one_dataset(
+    tmp_path: Path,
+) -> None:
+    """Corruption in one plate must not disturb another's aggregate."""
+    other = "plate_b"
+    _write_per_image(tmp_path, ["img_001"])
+    _write_per_image(tmp_path, ["img_001"], dataset=other)
+    flush_unchunked_measurements(tmp_path)
+
+    before = _aggregate(tmp_path, other)
+    assert before is not None
+
+    (
+        dataset_measurements_dir(tmp_path, DATASET) / DATASET_AGGREGATED_PARQUET
+    ).write_bytes(b"corrupt bytes")
+    _write_per_image(tmp_path, ["img_002"])
+    _write_per_image(tmp_path, ["img_002"], dataset=other)
+    flush_unchunked_measurements(tmp_path)
+
+    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"]
+    assert sorted(_aggregate_image_names(tmp_path, other)) == [
+        "img_001",
+        "img_002",
+    ]
+    # The quarantine landed in the corrupt dataset's directory only.
+    assert (
+        dataset_measurements_dir(tmp_path, DATASET)
+        / "_dataset_aggregated.corrupt1.parquet"
+    ).is_file()
+    assert not list(
+        dataset_measurements_dir(tmp_path, other).glob("*corrupt*")
+    )
+
+
+def test_unreadable_per_image_parquet_is_retried_not_consumed(
+    tmp_path: Path,
+) -> None:
+    """A file that could not be read must not be recorded as chunked.
+
+    The scanner used to mark every file it *discovered* as consumed, before
+    anything read it, and the reader skipped unreadable files with a bare
+    warning. A torn or momentarily unavailable per-image parquet was therefore
+    marked consumed forever: no later flush retries it, and since final
+    aggregation prefers the aggregate, that image never reaches the master.
+    """
+    _write_per_image(tmp_path, ["img_001", "img_002"])
+    torn = dataset_measurements_dir(tmp_path, DATASET) / "img_003.parquet"
+    torn.write_bytes(b"a torn write, mid-copy")
+
+    flush_unchunked_measurements(tmp_path)
+    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"]
+
+    state = json.loads(chunk_state_path(tmp_path).read_text())
+    assert f"{DATASET}/img_003.parquet" not in state["chunked_files"], (
+        "an unread file was recorded as chunked, so no flush will retry it"
+    )
+
+    # The write completes (or the transient read error clears).
+    _write_per_image(tmp_path, ["img_003"])
+    flush_unchunked_measurements(tmp_path)
+
+    assert sorted(_aggregate_image_names(tmp_path)) == [
+        "img_001",
+        "img_002",
+        "img_003",
+    ], "the recovered image never reached the aggregate"
 
 
 def test_reprocessing_the_same_images_does_not_duplicate(

--- a/tests/unit/cli/test_chunk_writer_crash_safety.py
+++ b/tests/unit/cli/test_chunk_writer_crash_safety.py
@@ -11,6 +11,7 @@ because the state says there is nothing to flush.
 SLURM kills checkpoint tasks routinely: walltime, preemption, node failure.
 """
 
+import json
 from pathlib import Path
 
 import polars as pl
@@ -23,8 +24,12 @@ from phenotypic._cli._cli_chunk_writer import (
 )
 from phenotypic.schema import EXPERIMENT_METADATA, METADATA, OBJECT
 from phenotypic.sdk_ import (
+    CHUNK_MANIFEST_JSON,
     DATASET_AGGREGATED_PARQUET,
+    ChunkManifestKey,
     dataset_measurements_dir,
+    master_measurements_parquet_path,
+    progress_dir,
 )
 
 DATASET = "plate_a"
@@ -77,6 +82,80 @@ def test_kill_before_aggregate_write_does_not_lose_images(
 
     assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"], (
         "images consumed by the killed task never reached the aggregate"
+    )
+
+
+def test_retry_after_kill_does_not_duplicate_any_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retried checkpoint must not double-count in *any* retry-exposed file.
+
+    Committing chunk state last means a killed task re-chunks images whose rows
+    may already have landed. Three artifacts are written before that commit —
+    the rolling master, ``analysis_full.parquet``, and the chunk manifest — and
+    each must absorb the repeat. An earlier revision deduplicated only the
+    dataset aggregate, so a kill in the aggregate loop left every colony
+    doubled in the master the module exists to publish mid-run.
+
+    The kill is simulated at the *latest* possible point, after the master and
+    manifest writes, which is the window that duplicates.
+    """
+    _write_per_image(tmp_path, ["img_001", "img_002"])
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated kill after the master and manifest writes")
+
+    monkeypatch.setattr(chunk_writer, "_update_dataset_parquet", _boom)
+    with pytest.raises(OSError):
+        flush_unchunked_measurements(tmp_path)
+    monkeypatch.undo()
+
+    flush_unchunked_measurements(tmp_path)
+
+    expected = {"img_001", "img_002"}
+    assert set(_aggregate_image_names(tmp_path)) == expected
+    assert len(_aggregate_image_names(tmp_path)) == 2, "aggregate duplicated"
+
+    master = pl.read_parquet(master_measurements_parquet_path(tmp_path))
+    assert master.height == 2, (
+        f"rolling master duplicated after retry: {master.height} rows"
+    )
+
+    manifest = json.loads(
+        (progress_dir(tmp_path) / CHUNK_MANIFEST_JSON).read_text()
+    )
+    names = [c[ChunkManifestKey.NAME] for c in manifest[ChunkManifestKey.CHUNKS]]
+    assert len(names) == len(set(names)), f"manifest repeated a chunk: {names}"
+    assert manifest[ChunkManifestKey.TOTAL_ROWS] == 2, (
+        f"manifest total_rows double-counted: {manifest}"
+    )
+
+
+def test_dedup_is_skipped_when_the_colony_key_is_incomplete(
+    tmp_path: Path,
+) -> None:
+    """A frame without ``Object_Label`` must keep every row.
+
+    Nothing guarantees that column. Filtering the key down to whichever columns
+    are present would leave ``(dataset, image)``, and ``unique`` on that keeps
+    one row per image — silently deleting every other colony. Duplicates are
+    recoverable; deleted colonies are not.
+    """
+    meas_dir = dataset_measurements_dir(tmp_path, DATASET)
+    meas_dir.mkdir(parents=True, exist_ok=True)
+    frame = pl.DataFrame(
+        {
+            str(EXPERIMENT_METADATA.DATASET): [DATASET, DATASET, DATASET],
+            str(METADATA.IMAGE_NAME): ["img_001", "img_001", "img_001"],
+            "Shape_Area": [1.0, 2.0, 3.0],
+        }
+    )
+
+    _update_dataset_parquet(tmp_path, DATASET, frame)
+
+    agg = pl.read_parquet(meas_dir / DATASET_AGGREGATED_PARQUET)
+    assert agg.height == 3, (
+        f"rows dropped by dedup on a partial key: {agg.height} of 3 survived"
     )
 
 

--- a/tests/unit/cli/test_chunk_writer_crash_safety.py
+++ b/tests/unit/cli/test_chunk_writer_crash_safety.py
@@ -1,0 +1,126 @@
+"""The chunk writer must not lose images when a checkpoint task is killed.
+
+``_aggregate_chunks_locked`` consumes per-image parquets and records them in
+``chunk_state.json`` so later checkpoints skip them. If that state is committed
+*before* the data it describes reaches ``_dataset_aggregated.parquet``, a task
+killed in between leaves those images permanently marked as consumed while
+their rows are absent from the aggregate — and since final aggregation prefers
+the aggregate, they never reach the master. No later flush can recover them,
+because the state says there is nothing to flush.
+
+SLURM kills checkpoint tasks routinely: walltime, preemption, node failure.
+"""
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from phenotypic._cli import _cli_chunk_writer as chunk_writer
+from phenotypic._cli._cli_chunk_writer import (
+    _update_dataset_parquet,
+    flush_unchunked_measurements,
+)
+from phenotypic.schema import EXPERIMENT_METADATA, METADATA, OBJECT
+from phenotypic.sdk_ import (
+    DATASET_AGGREGATED_PARQUET,
+    dataset_measurements_dir,
+)
+
+DATASET = "plate_a"
+
+
+def _write_per_image(output_dir: Path, stems: list[str]) -> None:
+    meas_dir = dataset_measurements_dir(output_dir, DATASET)
+    meas_dir.mkdir(parents=True, exist_ok=True)
+    for i, stem in enumerate(stems):
+        pl.DataFrame(
+            {
+                str(EXPERIMENT_METADATA.DATASET): [DATASET],
+                str(METADATA.IMAGE_NAME): [stem],
+                str(OBJECT.LABEL): [1],
+                "Shape_Area": [float(i + 1)],
+            }
+        ).write_parquet(meas_dir / f"{stem}.parquet")
+
+
+def _aggregate_image_names(output_dir: Path) -> list[str]:
+    agg = (
+        dataset_measurements_dir(output_dir, DATASET)
+        / DATASET_AGGREGATED_PARQUET
+    )
+    if not agg.is_file():
+        return []
+    return pl.read_parquet(agg)[str(METADATA.IMAGE_NAME)].to_list()
+
+
+def test_kill_before_aggregate_write_does_not_lose_images(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A task killed before the aggregate lands must leave work recoverable.
+
+    Simulates the kill by making the aggregate write raise, then retries the
+    flush cleanly — as the next checkpoint sentinel or the finalize-time flush
+    would. The images must reach the aggregate on that retry.
+    """
+    _write_per_image(tmp_path, ["img_001", "img_002"])
+
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise OSError("simulated task kill before the aggregate write")
+
+    monkeypatch.setattr(chunk_writer, "_update_dataset_parquet", _boom)
+    with pytest.raises(OSError):
+        flush_unchunked_measurements(tmp_path)
+
+    monkeypatch.undo()
+    flush_unchunked_measurements(tmp_path)
+
+    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"], (
+        "images consumed by the killed task never reached the aggregate"
+    )
+
+
+def test_reprocessing_the_same_images_does_not_duplicate(
+    tmp_path: Path,
+) -> None:
+    """Appending the same colony twice must not double it.
+
+    Committing chunk state after the data means a killed task can re-chunk
+    images whose rows already landed. That is only safe if the append is
+    idempotent on the colony key.
+    """
+    _write_per_image(tmp_path, ["img_001"])
+    frame = pl.read_parquet(
+        dataset_measurements_dir(tmp_path, DATASET) / "img_001.parquet"
+    )
+
+    _update_dataset_parquet(tmp_path, DATASET, frame)
+    _update_dataset_parquet(tmp_path, DATASET, frame)
+
+    assert _aggregate_image_names(tmp_path) == ["img_001"], (
+        "re-appending the same colony duplicated it in the aggregate"
+    )
+
+
+def test_reappend_keeps_the_newer_measurement(tmp_path: Path) -> None:
+    """When a colony is re-measured, the later value wins.
+
+    This is the `--restart` shape: the aggregate survives, the images are
+    re-measured, and the new rows are appended over the old.
+    """
+    _write_per_image(tmp_path, ["img_001"])
+    meas = dataset_measurements_dir(tmp_path, DATASET) / "img_001.parquet"
+    first = pl.read_parquet(meas)
+    _update_dataset_parquet(tmp_path, DATASET, first)
+
+    second = first.with_columns(pl.lit(99.0).alias("Shape_Area"))
+    _update_dataset_parquet(tmp_path, DATASET, second)
+
+    agg = pl.read_parquet(
+        dataset_measurements_dir(tmp_path, DATASET)
+        / DATASET_AGGREGATED_PARQUET
+    )
+    assert agg.height == 1, f"expected one row, got {agg.height}"
+    assert agg["Shape_Area"].to_list() == [99.0], (
+        "the older measurement won; the later one should"
+    )

--- a/tests/unit/cli/test_chunk_writer_crash_safety.py
+++ b/tests/unit/cli/test_chunk_writer_crash_safety.py
@@ -159,6 +159,55 @@ def test_dedup_is_skipped_when_the_colony_key_is_incomplete(
     )
 
 
+def test_corrupt_aggregate_is_rebuilt_not_discarded(tmp_path: Path) -> None:
+    """An unreadable aggregate must be rebuilt from its source, not replaced.
+
+    The aggregate is a cache of ``results/<ds>/measurements/*.parquet``. When it
+    cannot be read, writing only the incoming chunk destroys every previously
+    aggregated colony — and chunk state still lists those sources as consumed,
+    so no later flush recovers them. Since final aggregation publishes the
+    master from this file, those colonies never reach the user.
+    """
+    _write_per_image(tmp_path, ["img_001", "img_002"])
+    flush_unchunked_measurements(tmp_path)
+    assert sorted(_aggregate_image_names(tmp_path)) == ["img_001", "img_002"]
+
+    agg_path = (
+        dataset_measurements_dir(tmp_path, DATASET) / DATASET_AGGREGATED_PARQUET
+    )
+    agg_path.write_bytes(b"not a parquet file at all")
+
+    # A later checkpoint brings one new image.
+    _write_per_image(tmp_path, ["img_003"])
+    flush_unchunked_measurements(tmp_path)
+
+    assert sorted(_aggregate_image_names(tmp_path)) == [
+        "img_001",
+        "img_002",
+        "img_003",
+    ], "prior colonies were discarded instead of rebuilt from the per-image parquets"
+
+
+def test_corrupt_aggregate_is_preserved_for_diagnosis(tmp_path: Path) -> None:
+    """The unreadable bytes must survive, not be overwritten in place."""
+    _write_per_image(tmp_path, ["img_001"])
+    flush_unchunked_measurements(tmp_path)
+
+    meas_dir = dataset_measurements_dir(tmp_path, DATASET)
+    (meas_dir / DATASET_AGGREGATED_PARQUET).write_bytes(b"corrupt bytes")
+
+    _write_per_image(tmp_path, ["img_002"])
+    flush_unchunked_measurements(tmp_path)
+
+    preserved = list(meas_dir.glob("*corrupt*"))
+    assert preserved, f"corrupt aggregate was overwritten: {list(meas_dir.iterdir())}"
+    assert preserved[0].read_bytes() == b"corrupt bytes"
+    # Must not be re-ingested as a measurement source on a later pass.
+    assert preserved[0].name.startswith("_"), (
+        f"{preserved[0].name} would be globbed as a per-image parquet"
+    )
+
+
 def test_reprocessing_the_same_images_does_not_duplicate(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/cli/test_cli_directory_scanner_dotfiles.py
+++ b/tests/unit/cli/test_cli_directory_scanner_dotfiles.py
@@ -1,0 +1,93 @@
+"""AppleDouble sidecars must never be counted as input images.
+
+macOS writes a ``._<name>`` sidecar beside every file on exFAT/FAT volumes —
+the normal way an external drive is formatted. ``Path("._x.tif").suffix`` is
+``".tif"``, so a filter that tests the extension alone admits every sidecar and
+each image is counted twice.
+
+Observed on a real run: ``.phenotypic/progress/manifest.json`` reported
+``total_images: 60`` for 30 images, with ``is_complete: false`` on a run that
+had finished. Anything gating on completion — the GUI runs registry, the SLURM
+observer — reads such a run as unfinished forever.
+"""
+
+from pathlib import Path
+
+import polars as pl
+
+from phenotypic._cli._cli_chunk_writer import _scan_unchunked_parquets
+from phenotypic._cli._cli_directory_scanner import (
+    get_input_structure_summary,
+    scan_directory_structure,
+)
+from phenotypic.sdk_ import dataset_measurements_dir
+
+APPLEDOUBLE = b"\x00\x05\x16\x07\x00\x02\x00\x00"
+
+
+def _make_tree(root: Path) -> None:
+    """Two real images per dataset, each shadowed by an AppleDouble sidecar."""
+    for ds in ("plate_a", "plate_b"):
+        d = root / ds
+        d.mkdir(parents=True)
+        for stem in ("img_001", "img_002"):
+            (d / f"{stem}.tif").write_bytes(b"real")
+            (d / f"._{stem}.tif").write_bytes(APPLEDOUBLE)
+
+
+def test_scan_excludes_appledouble_sidecars(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    datasets = scan_directory_structure(tmp_path)
+    assert datasets, "no datasets discovered"
+    for name, images in datasets.items():
+        names = [p.name for p in images]
+        assert not any(n.startswith("._") for n in names), (
+            f"dataset {name} admitted AppleDouble sidecars: {names}"
+        )
+        assert len(images) == 2, f"dataset {name} has {len(images)}, want 2"
+
+
+def test_count_excludes_appledouble_sidecars(tmp_path: Path) -> None:
+    _make_tree(tmp_path)
+    summary = get_input_structure_summary(tmp_path)
+    assert summary["total_images"] == 4, (
+        f"summary counted {summary}, want 2 per dataset"
+    )
+    assert summary["datasets"] == {"plate_a": 2, "plate_b": 2}, summary
+
+
+def test_root_level_images_exclude_sidecars(tmp_path: Path) -> None:
+    """The flat-directory case takes a different code path than subdirs."""
+    (tmp_path / "img_001.tif").write_bytes(b"real")
+    (tmp_path / "._img_001.tif").write_bytes(APPLEDOUBLE)
+    datasets = scan_directory_structure(tmp_path)
+    all_names = [p.name for images in datasets.values() for p in images]
+    assert all_names == ["img_001.tif"], all_names
+
+
+def test_dotfiles_generally_excluded(tmp_path: Path) -> None:
+    """Any dotfile with an image extension is not an input, not just ._ ones."""
+    d = tmp_path / "plate_a"
+    d.mkdir(parents=True)
+    (d / "img_001.tif").write_bytes(b"real")
+    (d / ".hidden.tif").write_bytes(b"nope")
+    datasets = scan_directory_structure(tmp_path)
+    images = next(iter(datasets.values()))
+    assert [p.name for p in images] == ["img_001.tif"]
+
+
+def test_chunk_scan_excludes_appledouble_parquets(tmp_path: Path) -> None:
+    """The chunk writer has the same filter, and the same gap.
+
+    ``_scan_unchunked_parquets`` skips ``_``-prefixed names (to avoid its own
+    ``_dataset_aggregated.parquet``) but not ``.``-prefixed ones, so on an
+    exFAT volume it would hand a binary AppleDouble file to the parquet reader.
+    """
+    meas = dataset_measurements_dir(tmp_path, "plate_a")
+    meas.mkdir(parents=True)
+    pl.DataFrame({"a": [1]}).write_parquet(meas / "img_001.parquet")
+    (meas / "._img_001.parquet").write_bytes(APPLEDOUBLE)
+
+    found = _scan_unchunked_parquets(tmp_path / "results", set())
+    names = [p.name for p in found]
+    assert names == ["img_001.parquet"], names

--- a/tests/unit/cli/test_slurm_finalize_flushes_trailing.py
+++ b/tests/unit/cli/test_slurm_finalize_flushes_trailing.py
@@ -1,0 +1,108 @@
+"""Trailing images must reach the master when the image count is not a
+multiple of the SLURM checkpoint interval.
+
+Checkpoint sentinels are emitted only after every ``checkpoint_interval``
+images and there is no terminal sentinel
+(``_cli_slurm_array_scripts._build_entry_list``), so the last partial group is
+never chunked. Final aggregation resolves its sources via
+``discover_measurement_sources``, which prefers
+``_dataset_aggregated.parquet`` over the individual per-image parquets — so
+those trailing rows exist on disk and are absent from the published master.
+"""
+
+from pathlib import Path
+
+import polars as pl
+
+from phenotypic._cli._cli_chunk_writer import flush_unchunked_measurements
+from phenotypic._cli._cli_output_manager import aggregate_measurements
+from phenotypic.schema import EXPERIMENT_METADATA, METADATA, OBJECT
+from phenotypic.sdk_ import (
+    DATASET_AGGREGATED_PARQUET,
+    chunk_state_path,
+    dataset_measurements_dir,
+    master_measurements_parquet_path,
+)
+
+DATASET = "plate_a"
+
+
+def _write_per_image(output_dir: Path, stems: list[str]) -> None:
+    """Write one per-image measurement parquet per stem, as a worker would."""
+    meas_dir = dataset_measurements_dir(output_dir, DATASET)
+    meas_dir.mkdir(parents=True, exist_ok=True)
+    for i, stem in enumerate(stems):
+        pl.DataFrame(
+            {
+                str(EXPERIMENT_METADATA.DATASET): [DATASET],
+                str(METADATA.IMAGE_NAME): [stem],
+                str(OBJECT.LABEL): [1],
+                "Shape_Area": [float(i + 1)],
+            }
+        ).write_parquet(meas_dir / f"{stem}.parquet")
+
+
+def _master_image_names(output_dir: Path) -> set[str]:
+    master = pl.read_parquet(master_measurements_parquet_path(output_dir))
+    return set(master[str(METADATA.IMAGE_NAME)].to_list())
+
+
+def test_trailing_images_reach_the_master(tmp_path: Path) -> None:
+    """Images written after the last checkpoint sentinel must not be dropped.
+
+    Reproduces the SLURM shape: a checkpoint consumes the images seen so far,
+    then the remaining ``n % interval`` images land with no further sentinel,
+    and the dependent finalizer aggregates.
+    """
+    chunked = ["img_001", "img_002", "img_003"]
+    _write_per_image(tmp_path, chunked)
+
+    # A checkpoint sentinel fires: everything so far is chunked into
+    # _dataset_aggregated.parquet.
+    flush_unchunked_measurements(tmp_path)
+
+    # The trailing image lands. No further sentinel is emitted, because
+    # _build_entry_list appends one only every `checkpoint_interval` images.
+    _write_per_image(tmp_path, ["img_004"])
+
+    # The dependent finalizer runs.
+    aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
+
+    got = _master_image_names(tmp_path)
+    assert got == {"img_001", "img_002", "img_003", "img_004"}, (
+        f"master is missing trailing images: got {sorted(got)}"
+    )
+
+
+def test_no_trailing_images_is_unaffected(tmp_path: Path) -> None:
+    """The evenly-divisible case must keep working — the flush is a no-op."""
+    stems = ["img_001", "img_002"]
+    _write_per_image(tmp_path, stems)
+    flush_unchunked_measurements(tmp_path)
+
+    aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
+
+    assert _master_image_names(tmp_path) == set(stems)
+
+
+def test_unchunked_run_is_not_chunked_by_aggregation(tmp_path: Path) -> None:
+    """A local run has no chunk state, and aggregation must not create one.
+
+    Local and staged-local runs are never chunked: aggregation reads their
+    per-image parquets directly, so they do not have this defect. Flushing them
+    would manufacture ``progress/chunks/`` and ``_dataset_aggregated.parquet``
+    artifacts they never had — fixing nothing and changing their output layout.
+    """
+    stems = ["img_001", "img_002", "img_003"]
+    _write_per_image(tmp_path, stems)
+
+    aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
+
+    assert _master_image_names(tmp_path) == set(stems)
+    assert not chunk_state_path(tmp_path).is_file(), (
+        "aggregation created chunk state for an unchunked run"
+    )
+    assert not (
+        dataset_measurements_dir(tmp_path, DATASET)
+        / DATASET_AGGREGATED_PARQUET
+    ).is_file(), "aggregation created an aggregate for an unchunked run"

--- a/tests/unit/cli/test_slurm_finalize_flushes_trailing.py
+++ b/tests/unit/cli/test_slurm_finalize_flushes_trailing.py
@@ -16,6 +16,8 @@ import polars as pl
 
 from phenotypic._cli._cli_chunk_writer import flush_unchunked_measurements
 from phenotypic._cli._cli_output_manager import aggregate_measurements
+from phenotypic._cli._cli_recompile_slurm_scripts import build_recompile_tasks
+from phenotypic._cli._measurement_sources import discover_measurement_sources
 from phenotypic.schema import EXPERIMENT_METADATA, METADATA, OBJECT
 from phenotypic.sdk_ import (
     DATASET_AGGREGATED_PARQUET,
@@ -65,6 +67,15 @@ def test_trailing_images_reach_the_master(tmp_path: Path) -> None:
     # _build_entry_list appends one only every `checkpoint_interval` images.
     _write_per_image(tmp_path, ["img_004"])
 
+    # Pin the mechanism: source discovery returns the aggregate alone, so the
+    # trailing image is invisible to aggregation. Without this the test would
+    # also pass if a future change made discovery fall back to the individual
+    # parquets — which would hide a regression in the flush.
+    sources = discover_measurement_sources(tmp_path, [DATASET])
+    assert [p.path.name for p in sources] == [DATASET_AGGREGATED_PARQUET], (
+        f"expected discovery to prefer the aggregate, got {sources}"
+    )
+
     # The dependent finalizer runs.
     aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
 
@@ -83,6 +94,52 @@ def test_no_trailing_images_is_unaffected(tmp_path: Path) -> None:
     aggregate_measurements(output_dir=tmp_path, dataset_names=[DATASET])
 
     assert _master_image_names(tmp_path) == set(stems)
+
+
+def test_slurm_recompile_shards_include_trailing_images(tmp_path: Path) -> None:
+    """The SLURM recompile path must see the trailing images too.
+
+    ``build_recompile_tasks`` resolves shards at submit time and never reaches
+    ``aggregate_measurements`` — the worker concatenates the shards itself. So
+    the flush has to happen here as well, or the command a user runs *to
+    recover from a short master* rebuilds the same short master, and
+    ``--mode recompile`` and ``--mode recompile --slurm`` disagree on one
+    directory.
+    """
+    _write_per_image(tmp_path, ["img_001", "img_002", "img_003"])
+    flush_unchunked_measurements(tmp_path)
+    _write_per_image(tmp_path, ["img_004"])
+
+    tasks = build_recompile_tasks(
+        output_dir=tmp_path,
+        dataset_names=[DATASET],
+        include_dataset_column=True,
+        overlay_alpha=0.5,
+        shard_size=100,
+    )
+
+    sharded = [
+        Path(f).name
+        for t in tasks
+        for f in t.get("files", [])
+    ]
+    assert sharded, f"no measurement shards emitted: {tasks}"
+
+    # Every image must be reachable from the shards — either because the
+    # aggregate now contains it (post-flush) or because it is listed directly.
+    rows = pl.concat(
+        [
+            pl.read_parquet(dataset_measurements_dir(tmp_path, DATASET) / name)
+            for name in sharded
+        ],
+        how="diagonal_relaxed",
+    )
+    assert set(rows[str(METADATA.IMAGE_NAME)].to_list()) == {
+        "img_001",
+        "img_002",
+        "img_003",
+        "img_004",
+    }, f"recompile shards omit trailing images: {sharded}"
 
 
 def test_unchunked_run_is_not_chunked_by_aggregation(tmp_path: Path) -> None:


### PR DESCRIPTION
Four data-loss defects in the SLURM chunked-run path, found while validating a real completed run at `Results/frame00_discriminability`. Each one silently drops user measurements from `deliverables/master_measurements.*` — no error, no short-count warning, just fewer colonies than were measured.

The first two are the defects the branch set out to fix. The last two were found by review *of those fixes*, and each undermines the premise of the one before it, which is why they are here rather than filed.

## 1. Trailing images never reach the master (`68714de4b`, `f6dae85ba`)

Checkpoint sentinels fire every `checkpoint_interval` images and there is no terminal sentinel, so the images processed after the last checkpoint stay unchunked. `discover_measurement_sources` prefers `_dataset_aggregated.parquet` and skips the individual per-image parquets, so those trailing images never reach the master. Final aggregation now flushes them first, guarded on chunk state so non-chunked runs are untouched.

The follow-up commit covers the second caller: `build_recompile_tasks` resolves recompile shards at submit time and never touches `aggregate_measurements`, so `--mode recompile --slurm` rebuilt the same short master — the command a user runs *to recover* from a short master. The flush is deliberately not sited inside `discover_measurement_sources`: a function named "discover" that writes chunk files and rewrites the master is a surprising side effect, and read-only callers are plausible.

## 2. macOS AppleDouble sidecars counted as images (`b0f502cd3`, `f6dae85ba`)

`Path("._x.tif").suffix` is `".tif"`, so on any tree that has lived on an exFAT/FAT volume every image was discovered twice and the sidecar was then handed to the reader as an image. Discovery now excludes dotfiles at four sites, plus `scan_hdf_outputs` (which would load a sidecar as an HDF under `--mode measure`) and `_measurement_sources` (where the missing `.` filter silently disabled the fast multi-path read for the whole dataset).

## 3. Chunk state was committed before the data it described (`af7df99cb`, `b52dc0240`)

`_aggregate_chunks_locked` recorded consumed per-image parquets in `chunk_state.json` *before* writing the aggregate. A checkpoint task killed in between — walltime, preemption, node failure, all routine on SLURM — permanently marked those images consumed while their rows were absent. No later flush could recover them: the state said there was nothing to flush. This undermines the idempotency claim fix 1 rests on.

The state commit moves last, and the append is made idempotent on the colony key `(Metadata_Dataset, Metadata_ImageName, Object_Label)` — the second is what makes the first safe, since committing last inverts the failure into re-chunking images whose rows may already have landed.

Review then found that only one of the **three** retry-exposed writes had been made idempotent. The rolling master and `analysis_full.parquet` come from a bare concat, so a kill in the aggregate loop doubled every colony in the artifact this module exists to publish mid-run, compounding on each later chunk; and `chunk_manifest.json` double-counted `total_rows`, which the dashboard reports as run progress.

It also found the dedup silently degrading into row deletion: the key was filtered to whichever columns happened to be present, which looks defensive and is the opposite — without `Object_Label` the key becomes `(dataset, image)` and `unique` keeps **one row per image**. The full key is now required, and a frame missing it is logged and left alone.

## 4. A corrupt aggregate destroyed everything before it (`7f78326d3`, `397057a8c`)

`_update_dataset_parquet` caught a failed read of `_dataset_aggregated.parquet`, logged `"Corrupt %s, rebuilding from new data"`, and then wrote only the incoming chunk. That is not a rebuild but a silent truncation to the last checkpoint's worth of images, and the log said the opposite of what the code did. It is unrecoverable by design: chunk state still lists the earlier sources as consumed, and final aggregation publishes the master from this file. One torn write drops every colony measured before it.

It now rebuilds from `results/<ds>/measurements/*.parquet`, moves the unreadable bytes aside to `_dataset_aggregated.corruptN.parquet` rather than overwriting them (a file that cannot be read is evidence, and this is the only code that would notice), and logs at ERROR.

Review of *that* fix found it incomplete in the same shape again:

- **The rebuild reproduced the concat but not the normalization.** The aggregate's real producer, `_read_and_concat`, sets `Metadata_ImageName` from the file stem, adds `Metadata_FileSuffix`, and injects `Metadata_Dataset` when absent. Two of those three are colony-key columns, so the raw re-read fed a differently-shaped frame into the dedup: under `--no-dataset-column` colonies duplicated, and with a missing or UUID-shaped `Metadata_ImageName` (`Image.name` falls back to `str(self.uuid)`) every historical image shared one key and `unique` kept one row per `Object_Label` across the whole dataset. The row count was logged *before* the dedup, so the operator was told it worked.
- **A second loss site one frame earlier.** `_scan_unchunked_parquets` marked every file consumed on *discovery*, before anything read it, and the reader skipped unreadable files with a bare warning — so a torn or momentarily unavailable per-image parquet was consumed permanently. Files are now recorded only after they produce rows; unreadable ones are named at ERROR and retried.
- **The quarantine's own failure path destroyed the evidence it exists to preserve.** It now falls back to copying the bytes aside.

## Verification

Every fix is mutation-tested against the test that guards it — reintroducing the bug must fail the test, per the project's test-integrity rule. Notably, restoring the raw re-read fails the three non-normalized shapes and *passes* the normalized one, which was exactly the original test's blind spot: its helper only ever wrote per-image parquets already in post-normalization shape.

- `uv run pytest tests/unit/cli tests/unit/schema -q` → 527 passed, 1 skipped
- `uv run pytest tests/integration/cli -q` → 51 passed, 1 deselected
- `uv run mypy src/phenotypic/_cli_chunk_writer.py` clean; the 5 remaining errors in `_cli` are in `_cli_validation.py` and `_cli_file_locking.py`, untouched here and pre-existing
- `ruff check` clean on all changed paths

## Known gaps, deliberately left

- **`_rebuild_dataset_aggregate` with no per-image parquets** writes the incoming chunk alone — the original bug in miniature. Left as a documented guard because it is unreachable from the chunk path: `sources` necessarily includes the very files that produced the incoming chunk, read moments earlier. The belt-and-braces alternative is to refuse to write, since an absent aggregate falls back to the per-image parquets at discovery while a truncated one gets *preferred*.
- **`_measurement_sources.py:153`** separates aggregate from per-image rows with `filename_stem != _DATASET_AGGREGATED_STEM`, and the extension strip leaves `_dataset_aggregated.corrupt1`, which is `!=`. Unreachable today because the `("_", ".")` prefix filter catches it first, but it is the trap for anyone who removes that filter. A `startswith` would close it.

Also included: the implementation plan under `docs/superpowers/plans/`, and a small correction to the Streamlit run-monitor design spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
